### PR TITLE
fixed: Change the update url to fit new update file format

### DIFF
--- a/PlayCover/Services/UpdateService.swift
+++ b/PlayCover/Services/UpdateService.swift
@@ -39,7 +39,7 @@ class UpdateService : ObservableObject {
     
     static let shared = UpdateService()
     
-    static let baseUrl = "https://github.com/PlayCover/PlayCover/releases/download/$/PlayCover.$.zip"
+    static let baseUrl = "https://github.com/PlayCover/PlayCover/releases/download/$/PlayCover_$.dmg"
     
     @Published var updateLink : String = ""
     


### PR DESCRIPTION
Addresses issue #36 where PlayCover was pointing to the wrong update file