### PR TITLE
Add 2022 M2 Macbook Air to Notched macs.

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -6,7 +6,7 @@
 import Foundation
 import AppKit
 
-let notchModels = [ "MacBookPro18,3", "MacBookPro18,4", "MacBookPro18,1", "MacBookPro18,2"]
+let notchModels = [ "MacBookPro18,3", "MacBookPro18,4", "MacBookPro18,1", "MacBookPro18,2", "Mac14,2"]
 
 extension NSScreen {
     


### PR DESCRIPTION
Adds M2 MBA to the notched Macbooks detection, identifier Mac14,2.