### PR TITLE
Implement Discord Activity(Rich Presence)

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		AA818CB5287ABEC3000BEE9D /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = AA818CB4287ABEC3000BEE9D /* Yams */; };
 		ABED59832887A32F004D782B /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABED59822887A32F004D782B /* MenuBarView.swift */; };
 		B1084E1F28AA80F400E399FA /* AppSettingsVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1084E1E28AA80F400E399FA /* AppSettingsVM.swift */; };
+		B1419FB628BA82EE000CB69F /* DiscordActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1419FB528BA82EE000CB69F /* DiscordActivity.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -165,6 +166,7 @@
 		ABED59822887A32F004D782B /* MenuBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		ABF0BA1A285F9ED200FC5259 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B1084E1E28AA80F400E399FA /* AppSettingsVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsVM.swift; sourceTree = "<group>"; };
+		B1419FB528BA82EE000CB69F /* DiscordActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscordActivity.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -235,6 +237,7 @@
 				923421F6275F40300030CD7D /* AppContainer.swift */,
 				92ECD8AD274E787200DB7AC6 /* AppInfo.swift */,
 				9286D295273A7E4200958DD3 /* AppSettings.swift */,
+				B1419FB528BA82EE000CB69F /* DiscordActivity.swift */,
 				AA71964A287A0EA800623C15 /* PlayRules.swift */,
 				6E7CA16428B4D02900216CD8 /* ITunesResponse.swift */,
 				6E7CA16628B4EEAE00216CD8 /* Keymapping.swift */,
@@ -623,6 +626,7 @@
 				6E5C68BA289865C8008EC11B /* MainView.swift in Sources */,
 				92ECD8AA274E76FD00DB7AC6 /* TempAllocator.swift in Sources */,
 				28361D6028927CAC00B35EDB /* SaveGenshinUserData.swift in Sources */,
+				B1419FB628BA82EE000CB69F /* DiscordActivity.swift in Sources */,
 				53F4D29E26C43C040020167C /* UserIntentFlow.swift in Sources */,
 				6E66B0BF289DE6240099B907 /* StoreVM.swift in Sources */,
 				AA71964B287A0EA800623C15 /* PlayRules.swift in Sources */,

--- a/PlayCover/AppInstaller/Utils/Entitlements.swift
+++ b/PlayCover/AppInstaller/Utils/Entitlements.swift
@@ -52,6 +52,7 @@ class Entitlements {
         base["com.apple.security.print"] = true
     }
 
+    // swiftlint:disable cyclomatic_complexity
     static func composeEntitlements(_ app: PlayApp) throws -> [String: Any] {
         var base = [String: Any]()
 		let bundleID = app.info.bundleIdentifier
@@ -81,6 +82,10 @@ class Entitlements {
 				rules.bypass = bundleRules.bypass
 			}
 		}
+
+        if app.settings.settings.discordActivity.enable {
+             rules.allow?.append("(allow network* ipc-posix*)")
+         }
 
         sandboxProfile.append(contentsOf: PlayRules.buildRules(rules: rules.allow ?? [], bundleID: bundleID))
 

--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -21,6 +21,7 @@ struct AppSettingsData: Codable {
     var aspectRatio: Int = 1
     var notch: Bool = NSScreen.hasNotch()
     var bypass: Bool = false
+    var discordActivity = DiscordActivity()
     var version: String = "2.0.0"
 }
 

--- a/PlayCover/Model/DiscordActivity.swift
+++ b/PlayCover/Model/DiscordActivity.swift
@@ -1,0 +1,16 @@
+//
+//  DiscordActivity.swift
+//  PlayCover
+//
+//  Created by 이승윤 on 2022/07/16.
+//
+
+import Foundation
+
+class DiscordActivity: Codable {
+    var enable = true
+    var applicationID = ""
+    var details = ""
+    var state = ""
+    var image = ""
+}

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+// swiftlint:disable file_length
 struct AppSettingsView: View {
     @Environment(\.dismiss) var dismiss
 
@@ -41,6 +42,10 @@ struct AppSettingsView: View {
                 JBBypassView(settings: $viewModel.settings)
                     .tabItem {
                         Text("settings.tab.jbBypass")
+                    }
+                EtcView(settings: $viewModel.settings)
+                    .tabItem {
+                        Text("settings.tab.etc")
                     }
                 InfoView(info: viewModel.app.info)
                     .tabItem {
@@ -291,6 +296,62 @@ struct JBBypassView: View {
                 HStack {
                     Toggle("settings.toggle.jbBypass", isOn: $settings.settings.bypass)
                         .help("settings.toggle.jbBypass.help")
+                    Spacer()
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+struct EtcView: View {
+    @Binding var settings: AppSettings
+    @State var showPopover = false
+
+    var body: some View {
+        ScrollView {
+            VStack {
+                HStack {
+                    Toggle("settings.toggle.discord", isOn: $settings.settings.discordActivity.enable)
+                    Button("settings.button.discord") { showPopover = true }
+                        .popover(isPresented: $showPopover, arrowEdge: .bottom) {
+                            VStack {
+                                HStack {
+                                    Text("settings.text.applicationID")
+                                        .frame(width: 90)
+                                    TextField("", text: $settings.settings.discordActivity.applicationID)
+                                        .frame(minWidth: 200, maxWidth: 200)
+                                }.padding([.horizontal, .top])
+                                HStack {
+                                    Text("settings.text.details")
+                                        .frame(width: 90)
+                                        .help("settings.text.details.help")
+                                    TextField("", text: $settings.settings.discordActivity.details)
+                                        .frame(minWidth: 200, maxWidth: 200)
+                                }.padding(.horizontal)
+                                HStack {
+                                    Text("settings.text.state")
+                                        .frame(width: 90)
+                                        .help("settings.text.state.help")
+                                    TextField("", text: $settings.settings.discordActivity.state)
+                                        .frame(minWidth: 200, maxWidth: 200)
+                                }.padding(.horizontal)
+                                HStack {
+                                    Text("settings.text.image")
+                                        .help("settings.text.image.help")
+                                        .frame(width: 90)
+                                    TextField("", text: $settings.settings.discordActivity.image)
+                                        .frame(minWidth: 200, maxWidth: 200)
+                                }.padding(.horizontal)
+                                HStack {
+                                    Button("settings.button.clearActivity") {
+                                        settings.settings.discordActivity = DiscordActivity()
+                                        showPopover = false
+                                    }
+                                    Button("button.OK") { showPopover = false }
+                                }.padding(.bottom)
+                            }
+                        }
                     Spacer()
                 }
             }

--- a/PlayCover/de.lproj/Localizable.strings
+++ b/PlayCover/de.lproj/Localizable.strings
@@ -194,6 +194,12 @@
 "preferences.toggle.automaticUpdates" = "Automatically check for updates";
 
 /* (No Comment) */
+"settings.button.discord" = "Custom Discord activity";
+
+/* (No Comment) */
+"settings.button.clearActivity" = "Clear custom activity";
+
+/* (No Comment) */
 "search.search" = "Search...";
 
 /* (No Comment) */
@@ -215,10 +221,34 @@
 "settings.slider.mouseSensitivity" = "Mouse sensitivity: ";
 
 /* (No Comment) */
+"settings.tab.etc" = "Etc";
+
+/* (No Comment) */
+"settings.text.applicationID" = "Application ID";
+
+/* (No Comment) */
 "settings.text.customHeight" = "Height";
 
 /* (No Comment) */
 "settings.text.customWidth" = "Width";
+
+/* (No Comment) */
+"settings.text.details" = "Details";
+
+/* (No Comment) */
+"settings.text.details.help" = "First row below title";
+
+/* (No Comment) */
+"settings.text.image" = "Image";
+
+/* (No Comment) */
+"settings.text.image.help" = "Link to image or Dev portal asset name";
+
+/* (No Comment) */
+"settings.text.state" = "State";
+
+/* (No Comment) */
+"settings.text.state.help" = "Second row below title";
 
 /* (No Comment) */
 "settings.toggle.adaptiveDisplay" = "Adaptive display";
@@ -237,6 +267,9 @@
 
 /* (No Comment) */
 "settings.toggle.disableDisplaySleep.info" = "Prevent display from turning off while this app is running";
+
+/* (No Comment) */
+"settings.toggle.discord" = "Enable Discord activity";
 
 /* (No Comment) */
 "settings.toggle.gaming" = "Gaming Mode";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -137,3 +137,15 @@
 "xcode.install.failed.subtext" = "Please install Xcode Command Line tools from Terminal with the command `xcode-select --install`, and restart PlayCover";
 "xcode.install.progress" = "Installing Xcode Command Line Tools";
 "xcode.install.progress.subtext" = "May take around 5-10 minutes depending on internet speed";
+
+"settings.tab.etc" = "Etc";
+"settings.button.discord" = "Custom Discord activity";
+"settings.button.clearActivity" = "Clear custom activity";
+"settings.text.applicationID" = "Application ID";
+"settings.text.details" = "Details";
+"settings.text.details.help" = "First row below title";
+"settings.text.image" = "Image";
+"settings.text.image.help" = "Link to image or Dev portal asset name";
+"settings.text.state" = "State";
+"settings.text.state.help" = "Second row below title";
+"settings.toggle.discord" = "Enable Discord activity";

--- a/PlayCover/es.lproj/Localizable.strings
+++ b/PlayCover/es.lproj/Localizable.strings
@@ -197,6 +197,13 @@
 "search.search" = "Search...";
 
 /* (No Comment) */
+"settings.button.discord" = "Custom Discord activity";
+
+/* (No Comment) */
+"settings.button.clearActivity" = "Clear custom activity";
+
+
+/* (No Comment) */
 "settings.picker.displayRefreshRate" = "Screen refresh rate";
 
 /* (No Comment) */
@@ -215,10 +222,34 @@
 "settings.slider.mouseSensitivity" = "Mouse sensitivity: ";
 
 /* (No Comment) */
+"settings.tab.etc" = "Etc";
+
+/* (No Comment) */
+"settings.text.applicationID" = "Application ID";
+
+/* (No Comment) */
 "settings.text.customHeight" = "Height";
 
 /* (No Comment) */
 "settings.text.customWidth" = "Width";
+
+/* (No Comment) */
+"settings.text.details" = "Details";
+
+/* (No Comment) */
+"settings.text.details.help" = "First row below title";
+
+/* (No Comment) */
+"settings.text.image" = "Image";
+
+/* (No Comment) */
+"settings.text.image.help" = "Link to image or Dev portal asset name";
+
+/* (No Comment) */
+"settings.text.state" = "State";
+
+/* (No Comment) */
+"settings.text.state.help" = "Second row below title";
 
 /* (No Comment) */
 "settings.toggle.adaptiveDisplay" = "Adaptive display";
@@ -237,6 +268,9 @@
 
 /* (No Comment) */
 "settings.toggle.disableDisplaySleep.info" = "Prevent display from turning off while this app is running";
+
+/* (No Comment) */
+"settings.toggle.discord" = "Enable Discord activity";
 
 /* (No Comment) */
 "settings.toggle.gaming" = "Gaming Mode";

--- a/PlayCover/fr.lproj/Localizable.strings
+++ b/PlayCover/fr.lproj/Localizable.strings
@@ -197,6 +197,12 @@
 "search.search" = "Recherche en cours...";
 
 /* (No Comment) */
+"settings.button.discord" = "Custom Discord activity";
+
+/* (No Comment) */
+"settings.button.clearActivity" = "Clear custom activity";
+
+/* (No Comment) */
 "settings.picker.displayRefreshRate" = "Taux de rafraîchissement de l'écran";
 
 /* (No Comment) */
@@ -215,10 +221,34 @@
 "settings.slider.mouseSensitivity" = "Sensibilité de la souris : ";
 
 /* (No Comment) */
+"settings.tab.etc" = "Etc";
+
+/* (No Comment) */
+"settings.text.applicationID" = "Application ID";
+
+/* (No Comment) */
 "settings.text.customHeight" = "Hauteur";
 
 /* (No Comment) */
 "settings.text.customWidth" = "Largeur";
+
+/* (No Comment) */
+"settings.text.details" = "Details";
+
+/* (No Comment) */
+"settings.text.details.help" = "First row below title";
+
+/* (No Comment) */
+"settings.text.image" = "Image";
+
+/* (No Comment) */
+"settings.text.image.help" = "Link to image or Dev portal asset name";
+
+/* (No Comment) */
+"settings.text.state" = "State";
+
+/* (No Comment) */
+"settings.text.state.help" = "Second row below title";
 
 /* (No Comment) */
 "settings.toggle.adaptiveDisplay" = "Affichage adaptatif";
@@ -237,6 +267,9 @@
 
 /* (No Comment) */
 "settings.toggle.disableDisplaySleep.info" = "Empêcher l'affichage de s'éteindre pendant que cette application est ouvert";
+
+/* (No Comment) */
+"settings.toggle.discord" = "Enable Discord activity";
 
 /* (No Comment) */
 "settings.toggle.gaming" = "Mode de mappage de clavier amélioré";

--- a/PlayCover/id.lproj/Localizable.strings
+++ b/PlayCover/id.lproj/Localizable.strings
@@ -197,6 +197,12 @@
 "search.search" = "Search...";
 
 /* (No Comment) */
+"settings.button.discord" = "Custom Discord activity";
+
+/* (No Comment) */
+"settings.button.clearActivity" = "Clear custom activity";
+
+/* (No Comment) */
 "settings.picker.displayRefreshRate" = "Screen refresh rate";
 
 /* (No Comment) */
@@ -215,10 +221,34 @@
 "settings.slider.mouseSensitivity" = "Mouse sensitivity: ";
 
 /* (No Comment) */
+"settings.tab.etc" = "Etc";
+
+/* (No Comment) */
+"settings.text.applicationID" = "Application ID";
+
+/* (No Comment) */
 "settings.text.customHeight" = "Height";
 
 /* (No Comment) */
 "settings.text.customWidth" = "Width";
+
+/* (No Comment) */
+"settings.text.details" = "Details";
+
+/* (No Comment) */
+"settings.text.details.help" = "First row below title";
+
+/* (No Comment) */
+"settings.text.image" = "Image";
+
+/* (No Comment) */
+"settings.text.image.help" = "Link to image or Dev portal asset name";
+
+/* (No Comment) */
+"settings.text.state" = "State";
+
+/* (No Comment) */
+"settings.text.state.help" = "Second row below title";
 
 /* (No Comment) */
 "settings.toggle.adaptiveDisplay" = "Adaptive display";
@@ -237,6 +267,9 @@
 
 /* (No Comment) */
 "settings.toggle.disableDisplaySleep.info" = "Prevent display from turning off while this app is running";
+
+/* (No Comment) */
+"settings.toggle.discord" = "Enable Discord activity";
 
 /* (No Comment) */
 "settings.toggle.gaming" = "Gaming Mode";

--- a/PlayCover/it.lproj/Localizable.strings
+++ b/PlayCover/it.lproj/Localizable.strings
@@ -197,6 +197,12 @@
 "search.search" = "Search...";
 
 /* (No Comment) */
+"settings.button.discord" = "Custom Discord activity";
+
+/* (No Comment) */
+"settings.button.clearActivity" = "Clear custom activity";
+
+/* (No Comment) */
 "settings.picker.displayRefreshRate" = "Screen refresh rate";
 
 /* (No Comment) */
@@ -215,10 +221,34 @@
 "settings.slider.mouseSensitivity" = "Mouse sensitivity: ";
 
 /* (No Comment) */
+"settings.tab.etc" = "Etc";
+
+/* (No Comment) */
+"settings.text.applicationID" = "Application ID";
+
+/* (No Comment) */
 "settings.text.customHeight" = "Height";
 
 /* (No Comment) */
 "settings.text.customWidth" = "Width";
+
+/* (No Comment) */
+"settings.text.details" = "Details";
+
+/* (No Comment) */
+"settings.text.details.help" = "First row below title";
+
+/* (No Comment) */
+"settings.text.image" = "Image";
+
+/* (No Comment) */
+"settings.text.image.help" = "Link to image or Dev portal asset name";
+
+/* (No Comment) */
+"settings.text.state" = "State";
+
+/* (No Comment) */
+"settings.text.state.help" = "Second row below title";
 
 /* (No Comment) */
 "settings.toggle.adaptiveDisplay" = "Adaptive display";
@@ -237,6 +267,9 @@
 
 /* (No Comment) */
 "settings.toggle.disableDisplaySleep.info" = "Prevent display from turning off while this app is running";
+
+/* (No Comment) */
+"settings.toggle.discord" = "Enable Discord activity";
 
 /* (No Comment) */
 "settings.toggle.gaming" = "Gaming Mode";

--- a/PlayCover/ja.lproj/Localizable.strings
+++ b/PlayCover/ja.lproj/Localizable.strings
@@ -197,6 +197,12 @@
 "search.search" = "検索...";
 
 /* (No Comment) */
+"settings.button.discord" = "Custom Discord activity";
+
+/* (No Comment) */
+"settings.button.clearActivity" = "Clear custom activity";
+
+/* (No Comment) */
 "settings.picker.displayRefreshRate" = "画面のリフレッシュレート";
 
 /* (No Comment) */
@@ -215,10 +221,34 @@
 "settings.slider.mouseSensitivity" = "マウス感度: ";
 
 /* (No Comment) */
+"settings.tab.etc" = "Etc";
+
+/* (No Comment) */
+"settings.text.applicationID" = "Application ID";
+
+/* (No Comment) */
 "settings.text.customHeight" = "Height";
 
 /* (No Comment) */
 "settings.text.customWidth" = "Width";
+
+/* (No Comment) */
+"settings.text.details" = "Details";
+
+/* (No Comment) */
+"settings.text.details.help" = "First row below title";
+
+/* (No Comment) */
+"settings.text.image" = "Image";
+
+/* (No Comment) */
+"settings.text.image.help" = "Link to image or Dev portal asset name";
+
+/* (No Comment) */
+"settings.text.state" = "State";
+
+/* (No Comment) */
+"settings.text.state.help" = "Second row below title";
 
 /* (No Comment) */
 "settings.toggle.adaptiveDisplay" = "ディスプレイに合わせる";
@@ -237,6 +267,9 @@
 
 /* (No Comment) */
 "settings.toggle.disableDisplaySleep.info" = "このアプリの実行中にディスプレイがオフにならないようにする";
+
+/* (No Comment) */
+"settings.toggle.discord" = "Enable Discord activity";
 
 /* (No Comment) */
 "settings.toggle.gaming" = "ゲームモードを有効にする";

--- a/PlayCover/ko.lproj/Localizable.strings
+++ b/PlayCover/ko.lproj/Localizable.strings
@@ -197,6 +197,12 @@
 "search.search" = "검색...";
 
 /* (No Comment) */
+"settings.button.discord" = "Custom Discord activity";
+
+/* (No Comment) */
+"settings.button.clearActivity" = "Clear custom activity";
+
+/* (No Comment) */
 "settings.picker.displayRefreshRate" = "화면 주사율";
 
 /* (No Comment) */
@@ -215,10 +221,34 @@
 "settings.slider.mouseSensitivity" = "마우스 감도: ";
 
 /* (No Comment) */
+"settings.tab.etc" = "Etc";
+
+/* (No Comment) */
+"settings.text.applicationID" = "Application ID";
+
+/* (No Comment) */
 "settings.text.customHeight" = "높이";
 
 /* (No Comment) */
 "settings.text.customWidth" = "너비";
+
+/* (No Comment) */
+"settings.text.details" = "Details";
+
+/* (No Comment) */
+"settings.text.details.help" = "First row below title";
+
+/* (No Comment) */
+"settings.text.image" = "Image";
+
+/* (No Comment) */
+"settings.text.image.help" = "Link to image or Dev portal asset name";
+
+/* (No Comment) */
+"settings.text.state" = "State";
+
+/* (No Comment) */
+"settings.text.state.help" = "Second row below title";
 
 /* (No Comment) */
 "settings.toggle.adaptiveDisplay" = "적응형 화면";
@@ -237,6 +267,9 @@
 
 /* (No Comment) */
 "settings.toggle.disableDisplaySleep.info" = "앱이 실행되는 동안 화면이 꺼지는 것을 방지합니다";
+
+/* (No Comment) */
+"settings.toggle.discord" = "Enable Discord activity";
 
 /* (No Comment) */
 "settings.toggle.gaming" = "게이밍 모드";

--- a/PlayCover/ru.lproj/Localizable.strings
+++ b/PlayCover/ru.lproj/Localizable.strings
@@ -197,6 +197,12 @@
 "search.search" = "Search...";
 
 /* (No Comment) */
+"settings.button.discord" = "Custom Discord activity";
+
+/* (No Comment) */
+"settings.button.clearActivity" = "Clear custom activity";
+
+/* (No Comment) */
 "settings.picker.displayRefreshRate" = "Screen refresh rate";
 
 /* (No Comment) */
@@ -215,10 +221,34 @@
 "settings.slider.mouseSensitivity" = "Mouse sensitivity: ";
 
 /* (No Comment) */
+"settings.tab.etc" = "Etc";
+
+/* (No Comment) */
+"settings.text.applicationID" = "Application ID";
+
+/* (No Comment) */
 "settings.text.customHeight" = "Height";
 
 /* (No Comment) */
 "settings.text.customWidth" = "Width";
+
+/* (No Comment) */
+"settings.text.details" = "Details";
+
+/* (No Comment) */
+"settings.text.details.help" = "First row below title";
+
+/* (No Comment) */
+"settings.text.image" = "Image";
+
+/* (No Comment) */
+"settings.text.image.help" = "Link to image or Dev portal asset name";
+
+/* (No Comment) */
+"settings.text.state" = "State";
+
+/* (No Comment) */
+"settings.text.state.help" = "Second row below title";
 
 /* (No Comment) */
 "settings.toggle.adaptiveDisplay" = "Adaptive display";
@@ -237,6 +267,9 @@
 
 /* (No Comment) */
 "settings.toggle.disableDisplaySleep.info" = "Prevent display from turning off while this app is running";
+
+/* (No Comment) */
+"settings.toggle.discord" = "Enable Discord activity";
 
 /* (No Comment) */
 "settings.toggle.gaming" = "Gaming Mode";

--- a/PlayCover/vi.lproj/Localizable.strings
+++ b/PlayCover/vi.lproj/Localizable.strings
@@ -122,3 +122,15 @@
 "xcode.install.progress" = "Đang cài đặt Command Line Tools for Xcode";
 "xcode.install.progress.subtext" = "Có thể tốn tầm 5-10 phút tùy thuộc vào nhà cung cấp dịch vụ internet của bạn";
 "debug.crash" = "[DEBUG] Crash app";
+
+"settings.tab.etc" = "Etc";
+"settings.button.discord" = "Custom Discord activity";
+"settings.button.clearActivity" = "Clear custom activity";
+"settings.text.applicationID" = "Application ID";
+"settings.text.details" = "Details";
+"settings.text.details.help" = "First row below title";
+"settings.text.image" = "Image";
+"settings.text.image.help" = "Link to image or Dev portal asset name";
+"settings.text.state" = "State";
+"settings.text.state.help" = "Second row below title";
+"settings.toggle.discord" = "Enable Discord activity";

--- a/PlayCover/zh-Hans.lproj/Localizable.strings
+++ b/PlayCover/zh-Hans.lproj/Localizable.strings
@@ -197,6 +197,12 @@
 "search.search" = "搜索...";
 
 /* (No Comment) */
+"settings.button.discord" = "Custom Discord activity";
+
+/* (No Comment) */
+"settings.button.clearActivity" = "Clear custom activity";
+
+/* (No Comment) */
 "settings.picker.displayRefreshRate" = "屏幕刷新率";
 
 /* (No Comment) */
@@ -215,10 +221,34 @@
 "settings.slider.mouseSensitivity" = "鼠标灵敏度: ";
 
 /* (No Comment) */
+"settings.tab.etc" = "Etc";
+
+/* (No Comment) */
+"settings.text.applicationID" = "Application ID";
+
+/* (No Comment) */
 "settings.text.customHeight" = "高度";
 
 /* (No Comment) */
 "settings.text.customWidth" = "宽度";
+
+/* (No Comment) */
+"settings.text.details" = "Details";
+
+/* (No Comment) */
+"settings.text.details.help" = "First row below title";
+
+/* (No Comment) */
+"settings.text.image" = "Image";
+
+/* (No Comment) */
+"settings.text.image.help" = "Link to image or Dev portal asset name";
+
+/* (No Comment) */
+"settings.text.state" = "State";
+
+/* (No Comment) */
+"settings.text.state.help" = "Second row below title";
 
 /* (No Comment) */
 "settings.toggle.adaptiveDisplay" = "适配显示器";
@@ -237,6 +267,9 @@
 
 /* (No Comment) */
 "settings.toggle.disableDisplaySleep.info" = "防止显示器在此应用运行时息屏";
+
+/* (No Comment) */
+"settings.toggle.discord" = "Enable Discord activity";
 
 /* (No Comment) */
 "settings.toggle.customSize" = "启用自定义窗口大小";


### PR DESCRIPTION
This PR implement discord activity(also known as Rich Presence) feature.
When you open app from PlayCover, https://github.com/PlayCover/PlayTools/pull/2 will connect to discord client via IPC and update activity.

Default activity looks like below.
|<img width="201" alt="image" src="https://user-images.githubusercontent.com/18005062/179347083-a2a1ed2a-0e77-4526-9a8f-cb427391ae64.png">|<img width="292" alt="Default Activity" src="https://user-images.githubusercontent.com/18005062/179347038-11f0be03-730e-4cbf-8eaa-b4385c87da66.png">|
|---|---|

Because discord does not allow us to change name of application, It will display name as `PlayCover` and show application name(from bundle) in detail field.

**But** user can set specific application name by creating their own application in [Discord Developer Portal](https://discord.com/developers/applications). Also user can change details, state string and image shown at left side.

By setting custom activity like below, user can deliver discord activity as their wish.
<img width="750" alt="image" src="https://user-images.githubusercontent.com/18005062/187042802-187ad178-7449-4c2a-b187-74f2745030d1.png">|<img width="233" alt="스크린샷 2022-07-16 오후 5 44 56" src="https://user-images.githubusercontent.com/18005062/179347739-4e6a5b30-d03f-4dfe-a497-bdca074c23cf.png"><img width="164" alt="image" src="https://user-images.githubusercontent.com/18005062/179347789-f27dc91a-76dd-49ad-ab78-dde6550a0f6c.png">|<img width="318" alt="스크린샷 2022-07-16 오후 5 45 15" src="https://user-images.githubusercontent.com/18005062/179347744-ac19e725-5e82-4fad-9ee4-deb84785b42a.png">|
|---|---|---|


