### PR TITLE
feat: Menu bar related changes

### DIFF
--- a/PlayCover/View/MainView.swift
+++ b/PlayCover/View/MainView.swift
@@ -68,7 +68,7 @@ struct MainView: View {
     @State var noticesExpanded = false
     @State var bottomHeight: CGFloat = 0
     
-    @State private var showToast = false
+    @Binding var showToast: Bool
     
     var body: some View {
         if apps.updatingApps { ProgressView() }
@@ -162,8 +162,9 @@ struct MainView: View {
 }
 
 struct Previews_MainView_Previews: PreviewProvider {
+    @State static var showToast = false
 	static var previews: some View {
-		MainView()
+		MainView(showToast: $showToast)
 			.padding()
 			.environmentObject(UpdateService.shared)
 			.environmentObject(InstallVM.shared)

--- a/PlayCover/View/MenuBarView.swift
+++ b/PlayCover/View/MenuBarView.swift
@@ -1,0 +1,40 @@
+//
+//  MenuBarView.swift
+//  PlayCover
+//
+
+import SwiftUI
+
+struct PlayCoverMenuView: Commands{
+    @Binding var showToast: Bool
+    
+    var body: some Commands {
+        CommandGroup(after: .systemServices) {
+            Button("Copy log") {
+                Log.shared.logdata.copyToClipBoard()
+                showToast.toggle()
+            }
+            .keyboardShortcut("L", modifiers: [.command, .option])
+        }
+    }
+}
+
+struct PlayCoverHelpMenuView: Commands {
+    var body: some Commands{
+        CommandGroup(replacing: .help) {
+            Button("Documentation") {
+                NSWorkspace.shared.open(URL(string:"https://github.com/PlayCover/PlayCover/wiki")!)
+            }
+            Divider()
+            Button("Website") {
+                NSWorkspace.shared.open(URL(string: "https://playcover.io")!)
+            }
+            Button("GitHub") {
+                NSWorkspace.shared.open(URL(string:"https://github.com/PlayCover/PlayCover/")!)
+            }
+            Button("Discord") {
+                NSWorkspace.shared.open(URL(string: "https://discord.gg/PlayCover")!)
+            }
+        }
+    }
+}

--- a/PlayCover/View/PlayCoverApp.swift
+++ b/PlayCover/View/PlayCoverApp.swift
@@ -38,10 +38,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 @main
 struct PlayCoverApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @State var showToast = false
     
     var body: some Scene {
         WindowGroup {
-            MainView()
+            MainView(showToast: $showToast)
                 .padding()
                 .environmentObject(UpdateService.shared)
                 .environmentObject(InstallVM.shared)
@@ -61,27 +62,8 @@ struct PlayCoverApp: App {
             }
         }.handlesExternalEvents(matching: Set(arrayLiteral: "{same path of URL?}")) // create new window if doesn't exist
             .commands {
-                CommandGroup(after: .help) {
-                    Divider()
-                    Button("Website") {
-                        NSWorkspace.shared.open(URL(string: "https://playcover.io")!)
-
-                    }
-                    Button("GitHub") {
-                        NSWorkspace.shared.open(URL(string:"https://github.com/PlayCover/PlayCover/")!)
-                    }
-                    Button("Documentation") {
-                        NSWorkspace.shared.open(URL(string:"https://github.com/PlayCover/PlayCover/wiki")!)
-                    }
-                    Button("Discord") {
-                        NSWorkspace.shared.open(URL(string: "https://discord.gg/PlayCover")!)
-                    }
-                }
-                CommandGroup(after: .systemServices) {
-                    Button("Copy log") {
-                        Log.shared.logdata.copyToClipBoard()
-                    }
-                }
+                PlayCoverMenuView(showToast: $showToast)
+                PlayCoverHelpMenuView()
             }
     }
     


### PR DESCRIPTION
Menu bar:
- Separated the menu bar view into a file
- Introduced a state into MainView (Reenables toast when logs are copied)
- Added a keyboard shortcut for Copy Log
- Changed Help Menu
<img width="689" alt="image" src="https://user-images.githubusercontent.com/23693150/179707655-dfd291e7-3a6e-4598-8117-c3bf45d80813.png">