### PR TITLE
fix: disable tabs in PlayCover

### DIFF
--- a/PlayCover/View/PlayCoverApp.swift
+++ b/PlayCover/View/PlayCoverApp.swift
@@ -50,6 +50,7 @@ struct PlayCoverApp: App {
                 .environmentObject(AppIntegrity())
                 .frame(minWidth: 720, minHeight: 650)
                 .onAppear {
+                    NSWindow.allowsAutomaticWindowTabbing = false
                     UserDefaults.standard.register(defaults: ["ShowLinks" : true])
                     SoundDeviceService.shared.prepareSoundDevice()
                     UpdateService.shared.checkUpdate()


### PR DESCRIPTION
Tabs in macOS are normally automatically enabled (accessible by pressing Shift + Command + \\)
Since this function is practically useless for PlayCover, we should disable it