### PR TITLE
Move the app links checkbox into the View menu

### DIFF
--- a/PlayCover/View/AppsView.swift
+++ b/PlayCover/View/AppsView.swift
@@ -14,8 +14,6 @@ struct AppsView : View {
     @EnvironmentObject var vm : AppsVM
     
     @State private var gridLayout = [GridItem(.adaptive(minimum: 150, maximum: 150), spacing: 10)]
-    
-    @State private var showAppLinks = UserDefaults.standard.bool(forKey: "ShowLinks")
 
 	@State private var alertTitle = ""
 
@@ -30,14 +28,6 @@ struct AppsView : View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
-                Toggle(isOn: $showAppLinks) {
-                    Text("Show app links")
-                }.onChange(of: showAppLinks) { value in
-                    UserDefaults.standard.set(showAppLinks, forKey: "ShowLinks")
-                    vm.fetchApps()
-                }.padding(.leading, 30)
-                    .help("Untick this option to show installed apps only")
-                Spacer()
                 SearchView().padding(.leading, 20).padding(.trailing, 10).padding(.vertical, 8)
                 ExportView().environmentObject(InstallVM.shared)
                 Button(NSLocalizedString("Download more apps", comment: "")) {

--- a/PlayCover/View/MenuBarView.swift
+++ b/PlayCover/View/MenuBarView.swift
@@ -38,3 +38,31 @@ struct PlayCoverHelpMenuView: Commands {
         }
     }
 }
+
+struct PlayCoverViewMenuView: Commands {
+    @State private var isToggle : Bool = AppsVM.shared.showAppLinks
+    
+    var body: some Commands {
+        CommandGroup(before: .sidebar)
+        {
+            ShowAppLinksCommand() // Can you already tell that I love Swift? /s
+            Divider()
+        }
+    }
+}
+
+struct ShowAppLinksCommand: View{
+    // Must be its own struct because SwiftUI does not update Command when ObservedState changes
+    @ObservedObject var apps = AppsVM.shared
+    
+    var body: some View {
+        Toggle(isOn: $apps.showAppLinks)
+        {
+            Text("Show app links")
+        }.onChange(of: apps.showAppLinks){ value in
+            UserDefaults.standard.set(value, forKey: "ShowLinks")
+            apps.fetchApps()
+        }
+        .keyboardShortcut("A", modifiers: [.command, .option])
+    }
+}

--- a/PlayCover/View/MenuBarView.swift
+++ b/PlayCover/View/MenuBarView.swift
@@ -40,19 +40,16 @@ struct PlayCoverHelpMenuView: Commands {
 }
 
 struct PlayCoverViewMenuView: Commands {
-    @State private var isToggle : Bool = AppsVM.shared.showAppLinks
-    
     var body: some Commands {
         CommandGroup(before: .sidebar)
         {
-            ShowAppLinksCommand() // Can you already tell that I love Swift? /s
+            ShowAppLinksCommand()
             Divider()
         }
     }
 }
 
 struct ShowAppLinksCommand: View{
-    // Must be its own struct because SwiftUI does not update Command when ObservedState changes
     @ObservedObject var apps = AppsVM.shared
     
     var body: some View {

--- a/PlayCover/View/PlayCoverApp.swift
+++ b/PlayCover/View/PlayCoverApp.swift
@@ -65,6 +65,7 @@ struct PlayCoverApp: App {
             .commands {
                 PlayCoverMenuView(showToast: $showToast)
                 PlayCoverHelpMenuView()
+                PlayCoverViewMenuView()
             }
     }
     

--- a/PlayCover/ViewModel/AppsVM.swift
+++ b/PlayCover/ViewModel/AppsVM.swift
@@ -18,6 +18,7 @@ class AppsVM : ObservableObject {
     
     @Published var apps : [BaseApp] = []
     @Published var updatingApps : Bool = false
+    @Published var showAppLinks = UserDefaults.standard.bool(forKey: "ShowLinks")
     
     func fetchApps(){
         DispatchQueue.global(qos: .background).async {


### PR DESCRIPTION
Moved the app links checkbox into the View Menu and removed the checkbox on the main window to free up space for the search bar
![viewmenu](https://user-images.githubusercontent.com/23693150/179912307-0ec12b2e-68b1-440e-99b9-2f27a46ade7c.gif)

