### PR TITLE
Fixed typos in source code, and removed unused button styles

### DIFF
--- a/PlayCover/View/MainView.swift
+++ b/PlayCover/View/MainView.swift
@@ -137,12 +137,12 @@ struct MainView: View {
                     }.padding()
                 }
                 .background(.regularMaterial)
-                .overlay(GeometryReader { geomatry in
+                .overlay(GeometryReader { geometry in
                     Text("")
-                        .onChange(of: geomatry.size.height) { v in bottomHeight = v }
+                        .onChange(of: geometry.size.height) { v in bottomHeight = v }
                         .onAppear {
-                            print("Bottom height: \(geomatry.size.height)")
-                            bottomHeight = geomatry.size.height
+                            print("Bottom height: \(geometry.size.height)")
+                            bottomHeight = geometry.size.height
                         }
                 })
             }

--- a/PlayCover/View/Style.swift
+++ b/PlayCover/View/Style.swift
@@ -6,18 +6,6 @@
 import Foundation
 import SwiftUI
 
-struct GetButton: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .padding(.horizontal, 16)
-            .padding(.vertical, 6)
-            .background(Colr.get)
-            .foregroundColor(.white)
-            .textCase(.uppercase)
-            .clipShape(Capsule())
-    }
-}
-
 struct UpdateButton: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
@@ -25,38 +13,6 @@ struct UpdateButton: ButtonStyle {
             .padding(.vertical, 16)
             .background(Colr.success)
             .foregroundColor(.white)
-            .clipShape(Capsule())
-    }
-}
-
-struct XcodeButton: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .padding(.horizontal, 24)
-            .padding(.vertical, 16)
-            .background(Color.blue)
-            .foregroundColor(.white)
-            .clipShape(Capsule())
-    }
-}
-
-struct PlayPassButton: ButtonStyle {
-    @Environment(\.colorScheme) var colorScheme
-    
-    func bgColor(_ pressed : Bool) -> Color {
-        return colorScheme == .dark ? Colr.blackWhite(pressed) : Colr.blackWhite(!pressed)
-    }
-    
-    func textColor(_ pressed : Bool) -> Color {
-        return colorScheme == .dark ? Colr.blackWhite(!pressed) : Colr.blackWhite(pressed)
-    }
-    
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .padding(.horizontal, 14)
-            .padding(.vertical, 14)
-            .background(configuration.isPressed ? bgColor(false) : bgColor(true))
-            .foregroundColor(configuration.isPressed ? textColor(false) : textColor(true))
             .clipShape(Capsule())
     }
 }


### PR DESCRIPTION
- Fixed a typo where a variable was named 'geomatry' instead of 'geometry'
- Removed unused GetButton, XcodeButton, and PlayPassButton styles