### PR TITLE
[May be breaking] Adding option to disable display timeout per-app

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -180,6 +180,18 @@ class AppSettings {
         }
     }
 
+    private static let disableTimeout = "pc.disableTimeout"
+    var disableTimeout: Bool {
+        get {
+            dictionary[AppSettings.disableTimeout] as? Bool ?? false
+        }
+        set {
+            var dict = dictionary
+            dict[AppSettings.disableTimeout] = newValue
+            dictionary = dict
+        }
+    }
+
     private var allPrefs: [String: Any] {
         get {
             do {
@@ -220,6 +232,7 @@ class AppSettings {
     func reset() {
         adaptiveDisplay = info.isGame
         keymapping = info.isGame
+        disableTimeout = false
         layout = []
     }
 

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -5,8 +5,7 @@
 
 import Foundation
 import Cocoa
-import IOKit
-import IOKit.pwr_mgt // swiftlint:disable duplicate_imports
+import IOKit.pwr_mgt
 
 class PlayApp: PhysicialApp {
 

--- a/PlayCover/View/AppSettingsView.swift
+++ b/PlayCover/View/AppSettingsView.swift
@@ -18,6 +18,7 @@ struct AppSettingsView: View {
     @State var bypass: Bool
     @State var selectedRefreshRate: Int
     @State var sensivity: Float
+    @State var disableTimeout: Bool
 
     @State var resetedAlert: Bool = false
     @State var selectedWindowSize: Int
@@ -70,6 +71,13 @@ struct AppSettingsView: View {
             }
             Divider().padding(.leading, 36).padding(.trailing, 36)
             VStack(alignment: .leading, spacing: 0) {
+                Toggle(isOn: $disableTimeout) {
+                    Text("Disable Display Sleep")
+                }
+                .padding()
+                .help("Prevent display from turning off while this app is running")
+                Spacer()
+                Divider().padding(.leading, 36).padding(.trailing, 36)
                 Spacer()
                 Picker(selection: $selectedRefreshRate, label: Text("Screen refresh rate"), content: {
                     Text("60 Hz").tag(0)
@@ -126,7 +134,7 @@ struct AppSettingsView: View {
                     } else {
                         settings.refreshRate = 60
                     }
-
+                    settings.disableTimeout = disableTimeout
                     presentationMode.wrappedValue.dismiss()
 
                 }.buttonStyle(GrowingButton()).padding().frame(height: 80)

--- a/PlayCover/View/PlayAppView.swift
+++ b/PlayCover/View/PlayAppView.swift
@@ -72,6 +72,12 @@ struct PlayAppView: View {
                     Image(systemName: "folder")
                 })
                 Button(action: {
+                    app.settings.disableTimeout.toggle()
+                }, label: {
+                    Text(app.settings.disableTimeout ? "Enable Display Sleep" : "Disable Display Sleep")
+                    Image(systemName: "display")
+                })
+                Button(action: {
                     app.openAppCache()
                 }, label: {
                     Text("Open app cache")

--- a/PlayCover/View/PlayAppView.swift
+++ b/PlayCover/View/PlayAppView.swift
@@ -72,12 +72,6 @@ struct PlayAppView: View {
                     Image(systemName: "folder")
                 })
                 Button(action: {
-                    app.settings.disableTimeout.toggle()
-                }, label: {
-                    Text(app.settings.disableTimeout ? "Enable Display Sleep" : "Disable Display Sleep")
-                    Image(systemName: "display")
-                })
-                Button(action: {
                     app.openAppCache()
                 }, label: {
                     Text("Open app cache")
@@ -150,6 +144,7 @@ struct PlayAppView: View {
                                 bypass: app.settings.bypass,
                                 selectedRefreshRate: app.settings.refreshRate == 60 ? 0 : 1,
                                 sensivity: app.settings.sensivity,
+                                disableTimeout: app.settings.disableTimeout,
                                 selectedWindowSize: app.settings.gameWindowSizeHeight == 1080
                                 ? 0
                                 : app.settings.gameWindowSizeHeight == 1440 ? 1 : 2,


### PR DESCRIPTION
This feature was suggested in issue #85 

This gives the user an option to completely disable display sleep when a specific app is running. However, because of this, we had to change to using `NSWorkspace.shared.openApplication` to give PlayCover a handler to the running app and enable/disable display sleep accordingly, so this PR is may have unintended issues.