### PR TITLE
fix: Update account switcher UI

### DIFF
--- a/PlayCover/PlayCoverError.swift
+++ b/PlayCover/PlayCoverError.swift
@@ -9,6 +9,7 @@ enum PlayCoverError: Error {
     case appEncrypted
     case appCorrupted
     case appProhibited
+    case noGenshinAccount
 }
 
 extension PlayCoverError: LocalizedError {
@@ -30,6 +31,9 @@ extension PlayCoverError: LocalizedError {
         case .appProhibited:
             return NSLocalizedString("You may receive a ban! There have been reports of" +
                                      " bans when playing this game using PlayCover.", comment: "")
+        case .noGenshinAccount:
+            return NSLocalizedString("We couldn't find a Genshin account! Are you signed into an account in-app?",
+                                     comment: "")
     }
     }
 }

--- a/PlayCover/Utils/DeleteStoredGenshinUserData.swift
+++ b/PlayCover/Utils/DeleteStoredGenshinUserData.swift
@@ -13,6 +13,6 @@ func deleteStoredAccount(folderName: String) {
     do {
         try fileManager.removeItem(atPath: folderPath)
     } catch {
-        print("Error revoming stored folder: \(error)")
+        Log.shared.error("Error revoming stored folder: \(error)")
     }
 }

--- a/PlayCover/Utils/SaveGenshinUserData.swift
+++ b/PlayCover/Utils/SaveGenshinUserData.swift
@@ -4,77 +4,83 @@
 //
 //  Created by José Elias Moreno villegas on 20/07/22.
 //
-// swiftlint:disable all
+// swiftlint:disable identifier_name
 
 import Foundation
 import SwiftUI
 
-func storeUserData( folderName: String, accountRegion: String ){
+func storeUserData( folderName: String, accountRegion: String ) {
         let MIHOYO_ACCOUNT_INFO_PLIST_2_Encryption = "MIHOYO_ACCOUNT_INFO_PLIST_2_Encryption"
         let MIHOYO_KIBANA_REPORT_ARRAY_KEY_Encryption = "MIHOYO_KIBANA_REPORT_ARRAY_KEY_Encryption"
         let MIHOYO_LAST_ACCOUNT_MODEL_Encryption = "MIHOYO_LAST_ACCOUNT_MODEL_Encryption"
 
-        //get Path URL and create a folder with the content of uidInfo.txt
+        // get Path URL and create a folder with the content of uidInfo.txt
         let gameDataPath = NSHomeDirectory() + "/Library/Containers/com.miHoYo.GenshinImpact/Data/Documents/"
-        
-        //Path to the folder where the data will be stored check if exists and if not create it
+
+        // Path to the folder where the data will be stored check if exists and if not create it
         let store = NSHomeDirectory() + "/Library/Containers/io.playcover.PlayCover/storage/"
         let storePath = NSHomeDirectory() + "/Library/Containers/io.playcover.PlayCover/storage/" + folderName + "/"
 
         // Data to move from GameDataPath to StorePath
-        let MIHOYO_ACCOUNT_INFO_PLIST_2_Encryption_URL = URL(fileURLWithPath: gameDataPath + MIHOYO_ACCOUNT_INFO_PLIST_2_Encryption)
-        let MIHOYO_KIBANA_REPORT_ARRAY_KEY_Encryption_URL = URL(fileURLWithPath: gameDataPath + MIHOYO_KIBANA_REPORT_ARRAY_KEY_Encryption)
-        let MIHOYO_LAST_ACCOUNT_MODEL_Encryption_URL = URL(fileURLWithPath: gameDataPath + MIHOYO_LAST_ACCOUNT_MODEL_Encryption)
+        let MIHOYO_ACCOUNT_INFO_PLIST_2_Encryption_URL =
+            URL(fileURLWithPath: gameDataPath + MIHOYO_ACCOUNT_INFO_PLIST_2_Encryption)
+        let MIHOYO_KIBANA_REPORT_ARRAY_KEY_Encryption_URL =
+            URL(fileURLWithPath: gameDataPath + MIHOYO_KIBANA_REPORT_ARRAY_KEY_Encryption)
+        let MIHOYO_LAST_ACCOUNT_MODEL_Encryption_URL =
+            URL(fileURLWithPath: gameDataPath + MIHOYO_LAST_ACCOUNT_MODEL_Encryption)
 
         // create folder using StorePath
         let fileManager = FileManager.default
-    
+
         if !fileManager.fileExists(atPath: store) {
             do {
                 try fileManager.createDirectory(atPath: store, withIntermediateDirectories: false, attributes: nil)
                 try fileManager.createDirectory(atPath: storePath, withIntermediateDirectories: false, attributes: nil)
             } catch {
-                print("Error creating store directory: \(error)")
+                Log.shared.error("Error creating store directory: \(error)")
             }
         } else {
             do {
                 try fileManager.createDirectory(atPath: storePath, withIntermediateDirectories: false, attributes: nil)
             } catch {
-                print("Error creating game directory: \(error)")
+                Log.shared.error("Error creating game directory: \(error)")
             }
         }
-    
+
         // move data from GameDataPath to StorePath
         do {
             try fileManager.copyItem(at: MIHOYO_ACCOUNT_INFO_PLIST_2_Encryption_URL,
                                      to: URL(fileURLWithPath: storePath + MIHOYO_ACCOUNT_INFO_PLIST_2_Encryption))
-            
+
             try fileManager.copyItem(at: MIHOYO_KIBANA_REPORT_ARRAY_KEY_Encryption_URL,
                                      to: URL(fileURLWithPath: storePath + MIHOYO_KIBANA_REPORT_ARRAY_KEY_Encryption))
-            
+
             try fileManager.copyItem(at: MIHOYO_LAST_ACCOUNT_MODEL_Encryption_URL,
                                      to: URL(fileURLWithPath: storePath + MIHOYO_LAST_ACCOUNT_MODEL_Encryption))
             fileManager.createFile(atPath: storePath + "region.txt", contents: nil, attributes: nil)
-            try accountRegion.write(to: URL(fileURLWithPath:storePath + "region.txt"), atomically: false, encoding: .utf8)
-            
+            try accountRegion.write(to: URL(fileURLWithPath: storePath + "region.txt"),
+                                    atomically: false, encoding: .utf8)
+
         } catch {
-            print("Error moving file: \(error)")
+            Log.shared.error("Error moving file: \(error)")
         }
 
 }
 
-func checkCurrentRegion (selectedRegion:String) -> Bool {
+func checkCurrentRegion (selectedRegion: String) throws -> Bool {
     let regionName = selectedRegion == "America" ? "os_usa" : "os_euro"
     // plist path
-    let url = URL(fileURLWithPath: NSHomeDirectory() + "/Library/Containers/com.miHoYo.GenshinImpact/Data/Library/Preferences/com.miHoYo.GenshinImpact.plist")
+    let url = URL(fileURLWithPath: NSHomeDirectory() + "/Library/Containers/com.miHoYo.GenshinImpact/" +
+                  "Data/Library/Preferences/com.miHoYo.GenshinImpact.plist")
 
     // read plist file
-    // swiftlint:disable:next force_try
-    let data = try! Data(contentsOf: url)
-    // swiftlint:disable:next all
-    let plist = try! PropertyListSerialization.propertyList(from: data, options: [], format: nil) as! [String: Any]
-    // swiftlint:disable:next force_cast
-    let value = plist["GENERAL_DATA"] as! String
+    let data = try Data(contentsOf: url)
+
+    guard let plist = try PropertyListSerialization
+        .propertyList(from: data, options: [], format: nil)
+            as? [String: Any] else { throw PlayCoverError.noGenshinAccount }
+
+    guard let value = plist["GENERAL_DATA"] as? String else { throw PlayCoverError.noGenshinAccount }
 
     // Check if selected region is in the region of the plist
     // "The current account is set to a different server, enter the game"

--- a/PlayCover/Utils/Shell.swift
+++ b/PlayCover/Utils/Shell.swift
@@ -98,8 +98,8 @@ class Shell: ObservableObject {
         shell("cp -R /Applications/\(bundleName.esc).app/Wrapper/\(name.esc).app \(temp.esc)/ipafile/Payload/")
     }
     static func removeTwitterSessionCookie () {
-        // swiftlint:disable:next line_length
-        shell("rm -rf /Users/\(NSUserName())/Library/Containers/com.miHoYo.GenshinImpact/Data/Library/Cookies/Cookies.binarycookies")
+        shell("rm -rf /Users/\(NSUserName())/Library/Containers/com.miHoYo.GenshinImpact/" +
+              "Data/Library/Cookies/Cookies.binarycookies")
 
     }
 

--- a/PlayCover/View/ChangeGenshinAccountView.swift
+++ b/PlayCover/View/ChangeGenshinAccountView.swift
@@ -10,8 +10,7 @@ struct ChangeGenshinAccountView: View {
     @Environment(\.presentationMode) var presentationMode
     @State var folderName: String = ""
     @State var accountList: [String] = getAccountList()
-    // swiftlint:disable multiple_closures_with_trailing_closure
-    // swiftlint:disable opening_brace
+    @State var restoreAlert: Bool = false
     var body: some View {
         VStack(alignment: .center, spacing: 16) {
             Spacer()
@@ -21,28 +20,34 @@ struct ChangeGenshinAccountView: View {
                 if account != ".DS_Store"{
                     Button(action: {
                         self.folderName = account
-                        restoreUserData(folderName: account)
-                        self.presentationMode.wrappedValue.dismiss()
-                    })
-                    {
+                        self.restoreAlert = true
+                    }, label: {
                         HStack {
                             Image(systemName: "person.fill")
                             Text(account)
                         }.frame(minWidth: 300, alignment: .center)
-                    }.controlSize(.large).buttonStyle(GrowingButton()).font(.title3)
+                    }).controlSize(.large).buttonStyle(.automatic).font(.title3)
+                        .foregroundColor(.accentColor)
                         .frame(width: 300, alignment: .center)
+                        .alert("Really Restore Account?", isPresented: $restoreAlert, actions: {
+                            Button("Restore Account") {
+                                restoreUserData(folderName: account)
+                                self.presentationMode.wrappedValue.dismiss()
+                            }
+                            Button("Cancel", role: .cancel) {}
+                        }, message: {
+                            Text("This will override your currently signed-in account.")
+                        })
                 }
             }.frame(width: 450)
-            Spacer()
             Button(action: {
                 presentationMode.wrappedValue.dismiss()
-            })
-            {
-                Text("Exit").frame(minWidth: 300, alignment: .center)
-            }.buttonStyle(CancelButtonPink())
+            }, label: {
+                Text("Exit").frame(alignment: .center)
+            }).buttonStyle(.automatic)
                 .frame(height: 50)
-            Spacer()
         }
+        .frame(minWidth: 300)
     }
 }
 

--- a/PlayCover/View/DeleteGenshinStoredAccountView.swift
+++ b/PlayCover/View/DeleteGenshinStoredAccountView.swift
@@ -10,7 +10,7 @@ struct DeleteGenshinStoredAccountView: View {
     @Environment(\.presentationMode) var presentationMode
     @State var folderName: String = ""
     @State var accountList: [String] = getAccountList()
-    // swiftlint:disable multiple_closures_with_trailing_closure
+    @State var deleteAlert: Bool = false
     var body: some View {
         VStack(alignment: .center, spacing: 16) {
             Spacer()
@@ -20,25 +20,33 @@ struct DeleteGenshinStoredAccountView: View {
                 if account != ".DS_Store"{
                     Button(action: {
                         self.folderName = account
-                        deleteStoredAccount(folderName: account)
-                        self.presentationMode.wrappedValue.dismiss()
-                    }) {
+                        self.deleteAlert = true
+                    }, label: {
                         HStack {
                             Image(systemName: "person.fill")
                             Text(account)
                         }.frame(minWidth: 300, alignment: .center)
-                    }.controlSize(.large).buttonStyle(GrowingButton()).font(.title3)
+                    }).controlSize(.large).buttonStyle(.automatic).font(.title3)
+                        .foregroundColor(.accentColor)
                         .frame(width: 300, alignment: .center)
+                        .alert("Really Delete Account?", isPresented: $deleteAlert) {
+                            Button("Delete \"\(folderName)\" Account", role: .destructive) {
+                                deleteStoredAccount(folderName: account)
+                                self.presentationMode.wrappedValue.dismiss()
+                            }.foregroundColor(.red)
+                            Button("Cancel", role: .cancel) {}
+                                .keyboardShortcut(.defaultAction)
+                        }
                 }
             }.frame(width: 450)
-            Spacer()
             Button(action: {
                 presentationMode.wrappedValue.dismiss()
-            }) {
-                Text("Exit").frame(minWidth: 300, alignment: .center)
-            }.buttonStyle(CancelButtonPink()).frame(height: 50)
+            }, label: {
+                Text("Exit").frame(alignment: .center)
+            }).buttonStyle(.automatic).frame(height: 50)
             Spacer()
         }
+        .frame(minWidth: 300)
     }
 }
 

--- a/PlayCover/View/PlayAppView.swift
+++ b/PlayCover/View/PlayAppView.swift
@@ -115,25 +115,22 @@ struct PlayAppView: View {
                     Divider().padding(.leading, 36).padding(.trailing, 36)
                     Button(action: {
                         showStoreGenshinAccount.toggle()
-                        // swiftlint:disable:next multiple_closures_with_trailing_closure
-                    }) {
+                    }, label: {
                         Text("Store current account")
                         Image(systemName: "folder.badge.person.crop")
-                    }
+                    })
                     Button(action: {
                         showChangeGenshinAccount.toggle()
-                        // swiftlint:disable:next multiple_closures_with_trailing_closure
-                    }) {
+                    }, label: {
                         Text("Restore an account")
                         Image(systemName: "folder.badge.gearshape")
-                    }
+                    })
                     Button(action: {
                         showDeleteGenshinAccount.toggle()
-                        // swiftlint:disable:next multiple_closures_with_trailing_closure
-                    }) {
+                    }, label: {
                         Text("Delete an account")
                         Image(systemName: "folder.badge.minus")
-                    }
+                    })
                     Divider().padding(.leading, 36).padding(.trailing, 36)
                 }
             }

--- a/PlayCover/View/StoreGenshinAccountView.swift
+++ b/PlayCover/View/StoreGenshinAccountView.swift
@@ -4,8 +4,6 @@
 //
 //  Created by José Elias Moreno villegas on 21/07/22.
 //
-// swiftlint:disable line_length
-// swiftlint:disable multiple_closures_with_trailing_closure
 import SwiftUI
 import AlertToast
 
@@ -24,9 +22,9 @@ struct StoreGenshinAccountView: View {
                        label: Text("Select account region")
                     .font(.headline).lineLimit(1).fixedSize(),
                        content: {
-                            Text("America").tag("America").frame(minWidth: 150, maxWidth: 150, minHeight: 350)
-                            Text("Europe").tag("Europe").frame(minWidth: 150, maxWidth: 150, minHeight: 350)
-                }).pickerStyle(SegmentedPickerStyle())
+                            Text("America").tag("America")
+                            Text("Europe").tag("Europe")
+                }).pickerStyle(.radioGroup)
                 Spacer()
             }
             HStack {
@@ -37,28 +35,41 @@ struct StoreGenshinAccountView: View {
             Spacer()
             Button(action: {
                 if !folderName.isEmpty && !selectedRegion.isEmpty {
-                    if checkCurrentRegion(selectedRegion: selectedRegion) {
-                        regionIsNotValid = false
-                        if selectedRegion == "America" {
-                            storeUserData(folderName: $folderName.wrappedValue.lowercased(),
-                                          accountRegion: "os_usa")
+                    do {
+                        if try checkCurrentRegion(selectedRegion: selectedRegion) {
+                            regionIsNotValid = false
+                            if selectedRegion == "America" {
+                                storeUserData(folderName: $folderName.wrappedValue.lowercased(),
+                                              accountRegion: "os_usa")
+                            } else {
+                                storeUserData(folderName: $folderName.wrappedValue.lowercased(),
+                                              accountRegion: "os_euro")
+                            }
+                            presentationMode.wrappedValue.dismiss()
                         } else {
-                            storeUserData(folderName: $folderName.wrappedValue.lowercased(),
-                                          accountRegion: "os_euro")
+                            regionIsNotValid = true
                         }
-                        presentationMode.wrappedValue.dismiss()
-                    } else {
-                        regionIsNotValid = true
+                    } catch {
+                        Log.shared.error("An error occoured while trying to store your account: "
+                                         + error.localizedDescription)
                     }
-                } else { presentationMode.wrappedValue.dismiss()
-                }
-            }) {
+                } else { presentationMode.wrappedValue.dismiss() }
+            }, label: {
                 Text("Store!").frame(minWidth: 300, alignment: .center)
-                }.controlSize(.large).buttonStyle(GrowingButton()).font(.title3)
+            }).controlSize(.large).buttonStyle(.automatic).font(.title3)
+                .keyboardShortcut(.defaultAction)
+                .disabled(selectedRegion == "" || folderName == "")
 
-            Spacer()
+            Button(action: {
+                presentationMode.wrappedValue.dismiss()
+            }, label: {
+                Text("Exit").frame(alignment: .center)
+            })
+            .keyboardShortcut(.cancelAction)
         }.padding()
-                .alert(NSLocalizedString("The current account is set to a different Region. Launch the game, Change the region, and pass through the gates to save. Then try again",
+                .alert(NSLocalizedString("The current account is set to a different Region. " +
+                                         "Launch the game, Change the region, and pass through the gates to save. " +
+                                         "Then try again",
                                          comment: ""), isPresented: $regionIsNotValid) {
                     Button("Close",
                            role: .cancel) {
@@ -66,7 +77,6 @@ struct StoreGenshinAccountView: View {
                         presentationMode.wrappedValue.dismiss()
                     }
                 }
-            Spacer()
         }
     }
 


### PR DESCRIPTION
- require all fields to be filled out before the store button becomes available
- add "Exit" button to store account sheet
- switch from using pill-shaped buttons to using system-like buttons
- add confirmation and warning when deleting an account 
- add confirmation and warning that restoring an account will override the currently signed-in account
- fixed a force try crash when users tried to store an account without opening the game for the first time
- removed various `swiftlint:disable` comments that didn't make much sense, and fixed the listing errors