### PR TITLE
French localization quick fix and change of documentation source

### DIFF
--- a/PlayCover/View/MenuBarView.swift
+++ b/PlayCover/View/MenuBarView.swift
@@ -29,7 +29,7 @@ struct PlayCoverHelpMenuView: Commands {
 
         CommandGroup(replacing: .help) {
             Button("menubar.documentation") {
-                NSWorkspace.shared.open(URL(string: "https://github.com/PlayCover/PlayCover/wiki")!)
+                NSWorkspace.shared.open(URL(string: "https://docs.playcover.io")!)
             }
             Divider()
             Button("menubar.website") {

--- a/PlayCover/fr.lproj/Localizable.strings
+++ b/PlayCover/fr.lproj/Localizable.strings
@@ -92,15 +92,15 @@
 "setupView.header" = "Suivez les étapes ci-dessous pour résoudre des problèmes courants"; 
 "setupView.subheader" = "Ex: Ne pas pouvoir se connecter, certains applications ne marchent pas";
 
-"setupView.1" = "1) Éteignez votre Mac"; 
-"setupView.2" = "2) Attendez au moins 20 secondes pour que votre Mac se ferme et ensuite maintenir le bouton d'alimentation enfoncé";
-"setupView.3" = "3) Quand \"Loading Startup Options\" apparait, relachez le bouton d'alimentation"; 
-"setupView.4" = "4) Cliquez l'option Recovery Mode boot"; 
-"setupView.5" = "5) Ouvrez Terminal (Barre de menu -> Utilités -> Terminal)";
-"setupView.6" = "6) Entrez: "; 
-"setupView.7" = "7) Entrez la commande. Ensuite, entrez votre mot de passe (Le texte sera caché)"; 
-"setupView.8" = "8) Cliquez sur le symbole Apple dans la barre du menu et redémarrer."; 
-"setupView.9" = "Si vous rencontrez un erreur, recommencez le processus."; 
+"setupView.step1" = "1) Éteignez votre Mac"; 
+"setupView.step2" = "2) Attendez au moins 20 secondes pour que votre Mac se ferme et ensuite maintenir le bouton d'alimentation enfoncé";
+"setupView.step3" = "3) Quand \"Loading Startup Options\" apparait, relachez le bouton d'alimentation"; 
+"setupView.step4" = "4) Cliquez l'option Recovery Mode boot"; 
+"setupView.step5" = "5) Ouvrez Terminal (Barre de menu -> Utilités -> Terminal)";
+"setupView.step6" = "6) Entrez: "; 
+"setupView.step7" = "7) Entrez la commande. Ensuite, entrez votre mot de passe (Le texte sera caché)"; 
+"setupView.step8" = "8) Cliquez sur le symbole Apple dans la barre du menu et redémarrer."; 
+"setupView.step9" = "Si vous rencontrez un erreur, recommencez le processus."; 
 
 "setupView.vidTutorials" = "Tutoriels Vidéo";
 "setupView.youtube" = "YouTube";

--- a/PlayCover/fr.lproj/Localizable.strings
+++ b/PlayCover/fr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"playapp.add" = "Ajouter une app"
+"playapp.add" = "Ajouter une app";
 "playapp.settings" = "Paramètres";
 "playapp.showInFinder" = "Afficher dans le Finder";
 "playapp.openCache" = "Ouvrir les caches de l'app";

--- a/PlayCover/zh-Hans.lproj/Localizable.strings
+++ b/PlayCover/zh-Hans.lproj/Localizable.strings
@@ -94,15 +94,15 @@
 "setupView.header" = "按照以下指示操作即可修复常见问题";
 "setupView.subheader" = "解决账号无法登录，应用闪退等问题";
 
-"setupView.1" = "1) 将 Mac 关机";
-"setupView.2" = "2) 等待20秒以让 Mac 完全关机, 然后按住电源按钮";
-"setupView.3" = "3) 当 \"正在加载启动选项\" 在苹果图标底下出现时, 松开电源按钮";
-"setupView.4" = "4) 单击 恢复模式";
-"setupView.5" = "5) 在恢复模式下， 打开终端 (菜单栏 -> 实用工具 -> 终端)";
-"setupView.6" = "6) 输入: ";
-"setupView.7" = "7) 输入并回车上述命令后， 键入 Mac 的用户登录密码（密码字样不会显示在屏幕上）";
-"setupView.8" = "8) 重启 Mac";
-"setupView.9" = "如果遇到了任何错误或问题，重复上述操作";
+"setupView.step1" = "1) 将 Mac 关机";
+"setupView.step2" = "2) 等待20秒以让 Mac 完全关机, 然后按住电源按钮";
+"setupView.step3" = "3) 当 \"正在加载启动选项\" 在苹果图标底下出现时, 松开电源按钮";
+"setupView.step4" = "4) 单击 恢复模式";
+"setupView.step5" = "5) 在恢复模式下， 打开终端 (菜单栏 -> 实用工具 -> 终端)";
+"setupView.step6" = "6) 输入: ";
+"setupView.step7" = "7) 输入并回车上述命令后， 键入 Mac 的用户登录密码（密码字样不会显示在屏幕上）";
+"setupView.step8" = "8) 重启 Mac";
+"setupView.step9" = "如果遇到了任何错误或问题，重复上述操作";
 
 "setupView.vidTutorials" = "视频教程";
 "setupView.youtube" = "油管";


### PR DESCRIPTION
A semicolon was added to the French localization, making the app buildable again. The documentation source was changed to https://docs.playcover.io.