### PR TITLE
refactor: Reimplement SoundDeviceService with CoreAudio

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -37,7 +37,6 @@
 		9221730A27623DA100C8A3A2 /* StoreApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9221730927623DA100C8A3A2 /* StoreApp.swift */; };
 		92279BBF27610433009F28BF /* AppSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92279BBE27610433009F28BF /* AppSettingsView.swift */; };
 		922ED9BA272DEEDB008CA401 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922ED9B9272DEEDB008CA401 /* MainView.swift */; };
-		92324086283FBA34006C46DE /* SimplyCoreAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 92324085283FBA34006C46DE /* SimplyCoreAudio */; };
 		923421F7275F40300030CD7D /* AppContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923421F6275F40300030CD7D /* AppContainer.swift */; };
 		9256220127491E4700728698 /* NSData+Reading.m in Sources */ = {isa = PBXBuildFile; fileRef = 925621FD27491E4700728698 /* NSData+Reading.m */; };
 		9256220327491E4700728698 /* operations.m in Sources */ = {isa = PBXBuildFile; fileRef = 925621FF27491E4700728698 /* operations.m */; };
@@ -170,7 +169,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				92324086283FBA34006C46DE /* SimplyCoreAudio in Frameworks */,
 				365AFB0628847B2E008B3542 /* Sparkle in Frameworks */,
 				AA818CB5287ABEC3000BEE9D /* Yams in Frameworks */,
 				AA818CB2287ABE9B000BEE9D /* AlertToast in Frameworks */,
@@ -413,7 +411,6 @@
 			);
 			name = PlayCover;
 			packageProductDependencies = (
-				92324085283FBA34006C46DE /* SimplyCoreAudio */,
 				AA818CB1287ABE9B000BEE9D /* AlertToast */,
 				AA818CB4287ABEC3000BEE9D /* Yams */,
 				365AFB0528847B2E008B3542 /* Sparkle */,
@@ -458,7 +455,6 @@
 			);
 			mainGroup = 8783CFEE26B8C52D00171041;
 			packageReferences = (
-				92324084283FBA34006C46DE /* XCRemoteSwiftPackageReference "SimplyCoreAudio" */,
 				AA818CB0287ABE9B000BEE9D /* XCRemoteSwiftPackageReference "AlertToast" */,
 				AA818CB3287ABEC3000BEE9D /* XCRemoteSwiftPackageReference "Yams" */,
 				365AFB0428847B2E008B3542 /* XCRemoteSwiftPackageReference "Sparkle" */,
@@ -868,14 +864,6 @@
 				minimumVersion = 2.0.0;
 			};
 		};
-		92324084283FBA34006C46DE /* XCRemoteSwiftPackageReference "SimplyCoreAudio" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/rnine/SimplyCoreAudio.git";
-			requirement = {
-				branch = develop;
-				kind = branch;
-			};
-		};
 		AA818CB0287ABE9B000BEE9D /* XCRemoteSwiftPackageReference "AlertToast" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/elai950/AlertToast.git";
@@ -900,11 +888,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 365AFB0428847B2E008B3542 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
-		};
-		92324085283FBA34006C46DE /* SimplyCoreAudio */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 92324084283FBA34006C46DE /* XCRemoteSwiftPackageReference "SimplyCoreAudio" */;
-			productName = SimplyCoreAudio;
 		};
 		AA818CB1287ABE9B000BEE9D /* AlertToast */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/PlayCover/de.lproj/Localizable.strings
+++ b/PlayCover/de.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "soundAlert.messageText" = "Incorrect Audio Settings Detected!";
 "soundAlert.informativeText" = "Your current output device does not have a sample rate of 48 or 44.1 KHz! Crashes may occur. Would you like to change your current output device's sample rate to 48 KHz?";
 "soundAlert.successText" = "Current output device sample rate set to 48 KHz";
+"soundAlert.failureText" = "Failed to set current output device's sample rate to 48 KHz. You can manually set sample rate in ‘Audio MIDI Setup’ app";
 
 "xcode.install.message" = "You need to install Xcode Commandline tools and restart this App.";
 "xcode.install.success" = "Xcode tools installation succeeded";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "soundAlert.messageText" = "Incorrect Audio Settings Detected!";
 "soundAlert.informativeText" = "Your current output device does not have a sample rate of 48 or 44.1 KHz! Crashes may occur. Would you like to change your current output device's sample rate to 48 KHz?";
 "soundAlert.successText" = "Current output device sample rate set to 48 KHz";
+"soundAlert.failureText" = "Failed to set current output device's sample rate to 48 KHz. You can manually set sample rate in ‘Audio MIDI Setup’ app";
 
 "xcode.install.message" = "You need to install Xcode Commandline tools and restart this App.";
 "xcode.install.success" = "Xcode tools installation succeeded";

--- a/PlayCover/es.lproj/Localizable.strings
+++ b/PlayCover/es.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "soundAlert.messageText" = "Incorrect Audio Settings Detected!";
 "soundAlert.informativeText" = "Your current output device does not have a sample rate of 48 or 44.1 KHz! Crashes may occur. Would you like to change your current output device's sample rate to 48 KHz?";
 "soundAlert.successText" = "Current output device sample rate set to 48 KHz";
+"soundAlert.failureText" = "Failed to set current output device's sample rate to 48 KHz. You can manually set sample rate in ‘Audio MIDI Setup’ app";
 
 "xcode.install.message" = "You need to install Xcode Commandline tools and restart this App.";
 "xcode.install.success" = "Xcode tools installation succeeded";

--- a/PlayCover/fr.lproj/Localizable.strings
+++ b/PlayCover/fr.lproj/Localizable.strings
@@ -128,6 +128,7 @@
 "soundAlert.messageText" = "Paramètres Audio Incorrects Détectés!";
 "soundAlert.informativeText" = "Votre sortie audio actuelle n'a pas un taux d'échantillonnage de 48 ou 44.1 KHz! Des erreurs peuvent survenir. Voulez-vous changer le taux d'échantillonnage de votre sortie audio actuelle à 48 KHz?";
 "soundAlert.successText" = "Définir le taux d'échantillonnage de votre sortie audio à 48 KHz";
+"soundAlert.failureText" = "Failed to set current output device's sample rate to 48 KHz. You can manually set sample rate in ‘Audio MIDI Setup’ app";
 
 "xcode.install.message" = "Veuiller installer Xcode Commandline tools et redémarrer l'application.";
 "xcode.install.success" = "Succès de l'installation de Xcode tools";

--- a/PlayCover/id.lproj/Localizable.strings
+++ b/PlayCover/id.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "soundAlert.messageText" = "Incorrect Audio Settings Detected!";
 "soundAlert.informativeText" = "Your current output device does not have a sample rate of 48 or 44.1 KHz! Crashes may occur. Would you like to change your current output device's sample rate to 48 KHz?";
 "soundAlert.successText" = "Current output device sample rate set to 48 KHz";
+"soundAlert.failureText" = "Failed to set current output device's sample rate to 48 KHz. You can manually set sample rate in ‘Audio MIDI Setup’ app";
 
 "xcode.install.message" = "You need to install Xcode Commandline tools and restart this App.";
 "xcode.install.success" = "Xcode tools installation succeeded";

--- a/PlayCover/it.lproj/Localizable.strings
+++ b/PlayCover/it.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "soundAlert.messageText" = "Incorrect Audio Settings Detected!";
 "soundAlert.informativeText" = "Your current output device does not have a sample rate of 48 or 44.1 KHz! Crashes may occur. Would you like to change your current output device's sample rate to 48 KHz?";
 "soundAlert.successText" = "Current output device sample rate set to 48 KHz";
+"soundAlert.failureText" = "Failed to set current output device's sample rate to 48 KHz. You can manually set sample rate in ‘Audio MIDI Setup’ app";
 
 "xcode.install.message" = "You need to install Xcode Commandline tools and restart this App.";
 "xcode.install.success" = "Xcode tools installation succeeded";

--- a/PlayCover/ja.lproj/Localizable.strings
+++ b/PlayCover/ja.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "soundAlert.messageText" = "Incorrect Audio Settings Detected!";
 "soundAlert.informativeText" = "Your current output device does not have a sample rate of 48 or 44.1 KHz! Crashes may occur. Would you like to change your current output device's sample rate to 48 KHz?";
 "soundAlert.successText" = "Current output device sample rate set to 48 KHz";
+"soundAlert.failureText" = "Failed to set current output device's sample rate to 48 KHz. You can manually set sample rate in ‘Audio MIDI Setup’ app";
 
 "xcode.install.message" = "You need to install Xcode Commandline tools and restart this App.";
 "xcode.install.success" = "Xcode tools installation succeeded";

--- a/PlayCover/ko.lproj/Localizable.strings
+++ b/PlayCover/ko.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "soundAlert.messageText" = "Incorrect Audio Settings Detected!";
 "soundAlert.informativeText" = "Your current output device does not have a sample rate of 48 or 44.1 KHz! Crashes may occur. Would you like to change your current output device's sample rate to 48 KHz?";
 "soundAlert.successText" = "Current output device sample rate set to 48 KHz";
+"soundAlert.failureText" = "Failed to set current output device's sample rate to 48 KHz. You can manually set sample rate in ‘Audio MIDI Setup’ app";
 
 "xcode.install.message" = "You need to install Xcode Commandline tools and restart this App.";
 "xcode.install.success" = "Xcode tools installation succeeded";

--- a/PlayCover/ru.lproj/Localizable.strings
+++ b/PlayCover/ru.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "soundAlert.messageText" = "Incorrect Audio Settings Detected!";
 "soundAlert.informativeText" = "Your current output device does not have a sample rate of 48 or 44.1 KHz! Crashes may occur. Would you like to change your current output device's sample rate to 48 KHz?";
 "soundAlert.successText" = "Current output device sample rate set to 48 KHz";
+"soundAlert.failureText" = "Failed to set current output device's sample rate to 48 KHz. You can manually set sample rate in ‘Audio MIDI Setup’ app";
 
 "xcode.install.message" = "You need to install Xcode Commandline tools and restart this App.";
 "xcode.install.success" = "Xcode tools installation succeeded";

--- a/PlayCover/vi.lproj/Localizable.strings
+++ b/PlayCover/vi.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "soundAlert.messageText" = "Incorrect Audio Settings Detected!";
 "soundAlert.informativeText" = "Your current output device does not have a sample rate of 48 or 44.1 KHz! Crashes may occur. Would you like to change your current output device's sample rate to 48 KHz?";
 "soundAlert.successText" = "Current output device sample rate set to 48 KHz";
+"soundAlert.failureText" = "Failed to set current output device's sample rate to 48 KHz. You can manually set sample rate in ‘Audio MIDI Setup’ app";
 
 "xcode.install.message" = "You need to install Xcode Commandline tools and restart this App.";
 "xcode.install.success" = "Xcode tools installation succeeded";

--- a/PlayCover/zh-Hans.lproj/Localizable.strings
+++ b/PlayCover/zh-Hans.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "soundAlert.messageText" = "监测到声音设置有问题";
 "soundAlert.informativeText" = "现有的音响设备并无 48 或者 44.1 KHz 采样率! 应用可能会崩溃。你希望把现有的音响设备设置成 48 KHz 采样率吗?";
 "soundAlert.successText" = "现有音响设备采样率已设为 48 KHz";
+"soundAlert.failureText" = "Failed to set current output device's sample rate to 48 KHz. You can manually set sample rate in ‘Audio MIDI Setup’ app";
 
 "xcode.install.message" = "开始之前，你需要先安装 Xcode 终端工具并重启此应用";
 "xcode.install.success" = "Xcode 终端工具安装成功！";


### PR DESCRIPTION
This PR will get rid of [SimplyCoreAudio](https://github.com/rnine/SimplyCoreAudio) dependency and reimplement `SoundDeviceService` with Apple's CoreAudio.