### PR TITLE
fix: Fix infinity loop in SetupView's alert modal

### DIFF
--- a/PlayCover/Utils/Shell.swift
+++ b/PlayCover/Utils/Shell.swift
@@ -143,7 +143,7 @@ class Shell: ObservableObject {
         }
 
     @discardableResult
-    static func shell(_ command: String, print: Bool = true) -> String {
+    static func shell(_ command: String, print: Bool = false) -> String {
         let task = Process()
         let pipe = Pipe()
 

--- a/PlayCover/Utils/SystemConfig.swift
+++ b/PlayCover/Utils/SystemConfig.swift
@@ -7,6 +7,8 @@ import Foundation
 
 class SystemConfig {
 
+    static var isFirstTimePlaySign = false
+
 	static let isPlaySignActive: Bool = {
         return isSIPDisabled() && isPRAMValid()
     }()
@@ -16,25 +18,16 @@ class SystemConfig {
                           "boot-args=amfi_get_out_of_my_way=0x1 ipc_control_port_options=0"], argc)
     }
 
-    static var firstTimeSIP = true
-    static var firstTimeBootArgs = true
-
     static func isSIPDisabled() -> Bool {
-        let check = shell.shell("csrutil status", print: firstTimeSIP)
-        firstTimeSIP = false
+        let check = shell.shell("csrutil status")
         return check.contains("unknown") || check.contains("disabled")
     }
 
     static func isPRAMValid() -> Bool {
-        let check = shell.shell("nvram boot-args", print: firstTimeBootArgs)
-        firstTimeBootArgs = false
-        for option in NVRAM_OPTIONS {
-            if check.contains(option) {
-                return true
-            }
+        let check = shell.shell("nvram boot-args")
+        for option in NVRAM_OPTIONS where check.contains(option) {
+            return true
         }
-
-        print(firstTimeBootArgs)
         return false
     }
 

--- a/PlayCover/View/AppsView.swift
+++ b/PlayCover/View/AppsView.swift
@@ -12,6 +12,7 @@ import AppKit
 struct AppsView: View {
     @Binding public var bottomPadding: CGFloat
     @Binding public var xcodeCliInstalled: Bool
+    @Binding var isPlaySignActive: Bool
 
     @EnvironmentObject var appVm: AppsVM
 
@@ -59,7 +60,14 @@ struct AppsView: View {
 				}
 				.frame(maxWidth: .infinity, maxHeight: .infinity)
 				.padding(.top, 16).padding(.bottom, bottomPadding + 16)
-			} else {
+            } else if SystemConfig.isFirstTimePlaySign && isPlaySignActive {
+                VStack(spacing: 12) {
+                    Text("setup.requireReboot")
+                        .font(.title2)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.top, 16).padding(.bottom, bottomPadding + 16)
+            } else {
                 GeometryReader { geom in
                     ScrollView {
                         LazyVGrid(columns: gridLayout, alignment: .leading, spacing: 10) {

--- a/PlayCover/View/MainView.swift
+++ b/PlayCover/View/MainView.swift
@@ -66,6 +66,7 @@ struct MainView: View {
     @State var showSetup = false
     @State var noticesExpanded = false
     @State var bottomHeight: CGFloat = 0
+    @State var isPlaySignActive = SystemConfig.isPlaySignActive
     @Binding var showToast: Bool
     @Binding public var xcodeCliInstalled: Bool
 
@@ -99,7 +100,7 @@ struct MainView: View {
                                         .rotationEffect(Angle(degrees: noticesExpanded ? 180 : 0))
                                 }
                                 Spacer()
-                                if !SystemConfig.isPlaySignActive {
+                                if !isPlaySignActive {
                                     HStack {
                                         Button("bottomBar.setupViewButton") { showSetup = true }
                                             .buttonStyle(.borderedProminent).tint(.accentColor).controlSize(.large)
@@ -140,7 +141,7 @@ struct MainView: View {
                 AlertToast(type: .regular, title: NSLocalizedString("logs.copied", comment: ""))
             }
             .sheet(isPresented: $showSetup) {
-                SetupView()
+                SetupView(isPlaySignActive: $isPlaySignActive)
             }
             .alert(NSLocalizedString("alert.moveAppToApplications",
                                      comment: ""), isPresented: $integrity.integrityOff) {

--- a/PlayCover/View/MainView.swift
+++ b/PlayCover/View/MainView.swift
@@ -73,8 +73,11 @@ struct MainView: View {
     var body: some View {
         if apps.updatingApps { ProgressView() } else {
             ZStack(alignment: .bottom) {
-                AppsView(bottomPadding: $bottomHeight, xcodeCliInstalled: $xcodeCliInstalled)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity).environmentObject(AppsVM.shared)
+                AppsView(
+                    bottomPadding: $bottomHeight,
+                    xcodeCliInstalled: $xcodeCliInstalled,
+                    isPlaySignActive: $isPlaySignActive
+                ).frame(maxWidth: .infinity, maxHeight: .infinity).environmentObject(AppsVM.shared)
 
                 VStack(alignment: .leading, spacing: 0) {
                     if install.installing {

--- a/PlayCover/View/PlayAppView.swift
+++ b/PlayCover/View/PlayAppView.swift
@@ -19,7 +19,6 @@ struct PlayAppView: View {
 
     @State var isHover: Bool = false
 
-    @State var showSetup: Bool = false
     @State var showImportSuccess: Bool = false
     @State var showImportFail: Bool = false
     @State private var showChangeGenshinAccount: Bool = false
@@ -154,8 +153,6 @@ struct PlayAppView: View {
                 ChangeGenshinAccountView()
             }.sheet(isPresented: $showStoreGenshinAccount) {
                 StoreGenshinAccountView()
-            }.sheet(isPresented: $showSetup) {
-                SetupView()
             }.sheet(isPresented: $showDeleteGenshinAccount) {
                 DeleteGenshinStoredAccountView()
             }.alert("alert.app.delete", isPresented: $showClearCacheAlert) {

--- a/PlayCover/View/SetupView.swift
+++ b/PlayCover/View/SetupView.swift
@@ -44,6 +44,7 @@ struct SetupView: View {
             if SystemConfig.enablePlaySign(strResponse) {
                 if SystemConfig.isPRAMValid() {
                     isPlaySignActive = true
+                    SystemConfig.isFirstTimePlaySign = true
                     presentationMode.wrappedValue.dismiss()
                     Log.shared.msg(NSLocalizedString("setup.requireReboot", comment: ""))
                 } else {

--- a/PlayCover/View/SetupView.swift
+++ b/PlayCover/View/SetupView.swift
@@ -11,7 +11,9 @@ import SwiftUI
 struct SetupView: View {
     @Environment(\.presentationMode) var presentationMode
 
-    typealias PromptResponseClosure = (_ strResponse: String, _ bResponse: Bool) -> Void
+    @Binding var isPlaySignActive: Bool
+
+    typealias PromptResponseClosure = (_ strResponse: String) -> Void
 
     func promptForReply(_ strMsg: String, _ strInformative: String, completion: PromptResponseClosure) {
         let alert: NSAlert = NSAlert()
@@ -22,31 +24,28 @@ struct SetupView: View {
         alert.informativeText = strInformative
 
         let txt = NSSecureTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
-
         txt.stringValue = ""
 
         alert.accessoryView = txt
         let response: NSApplication.ModalResponse = alert.runModal()
 
-        var bResponse = false
         if response == NSApplication.ModalResponse.alertFirstButtonReturn {
-            bResponse = true
+            completion(txt.stringValue)
+        } else {
+            presentationMode.wrappedValue.dismiss()
         }
-
-        completion(txt.stringValue, bResponse)
-
     }
 
     func playSignPromt(_ firstTime: Bool) {
         let text = firstTime ? NSLocalizedString("setup.enterLoginPassword", comment: "") :
             NSLocalizedString("setup.incorrectPassword", comment: "")
 
-        promptForReply(text,
-                       NSLocalizedString("setup.enterLoginPassword.info", comment: "")) { strResponse, _ in
+        promptForReply(text, NSLocalizedString("setup.enterLoginPassword.info", comment: "")) { strResponse in
             if SystemConfig.enablePlaySign(strResponse) {
                 if SystemConfig.isPRAMValid() {
+                    isPlaySignActive = true
                     presentationMode.wrappedValue.dismiss()
-                    Log.shared.msg("setup.enterLoginPassword")
+                    Log.shared.msg(NSLocalizedString("setup.requireReboot", comment: ""))
                 } else {
                     playSignPromt(false)
                 }
@@ -130,9 +129,16 @@ struct SetupView: View {
                     .padding()
                     .font(.system(size: 18.0, weight: .thin))
                     .padding()
-                Button("setupView.pressButtonAndEnterPassword.button") {
-                    playSignPromt(true)
-                }.padding()
+                HStack {
+                    Spacer()
+                    Button("setupView.pressButtonAndEnterPassword.button") {
+                        playSignPromt(true)
+                    }.padding()
+                    Button("button.Cancel") {
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                    Spacer()
+                }
             }
         }.frame(maxWidth: 750)
     }

--- a/PlayCover/de.lproj/Localizable.strings
+++ b/PlayCover/de.lproj/Localizable.strings
@@ -117,7 +117,7 @@
 "setup.enterLoginPassword" = "Please enter your user password";
 "setup.incorrectPassword" = "Password incorrect. Please try again";
 "setup.enterLoginPassword.info" = "Enter the password used to unlock your Mac.";
-"setup.enterLoginPassword" = "Please restart your Mac for changes to take effect.";
+"setup.requireReboot" = "Please restart your Mac for changes to take effect.";
 
 "menubar.log.copy" = "Copy Logs";
 "menubar.documentation" = "Documentation";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -117,7 +117,7 @@
 "setup.enterLoginPassword" = "Please enter your user password";
 "setup.incorrectPassword" = "Password incorrect. Please try again";
 "setup.enterLoginPassword.info" = "Enter the password used to unlock your Mac.";
-"setup.enterLoginPassword" = "Please restart your Mac for changes to take effect.";
+"setup.requireReboot" = "Please restart your Mac for changes to take effect.";
 
 "menubar.log.copy" = "Copy Logs";
 "menubar.documentation" = "Documentation";

--- a/PlayCover/es.lproj/Localizable.strings
+++ b/PlayCover/es.lproj/Localizable.strings
@@ -117,7 +117,7 @@
 "setup.enterLoginPassword" = "Please enter your user password";
 "setup.incorrectPassword" = "Password incorrect. Please try again";
 "setup.enterLoginPassword.info" = "Enter the password used to unlock your Mac.";
-"setup.enterLoginPassword" = "Please restart your Mac for changes to take effect.";
+"setup.requireReboot" = "Please restart your Mac for changes to take effect.";
 
 "menubar.log.copy" = "Copy Logs";
 "menubar.documentation" = "Documentation";

--- a/PlayCover/fr.lproj/Localizable.strings
+++ b/PlayCover/fr.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "setup.enterLoginPassword" = "Veuillez entrer votre mot de passe"; 
 "setup.incorrectPassword" = "Mot de passe incorrect. Veuillez réessayer."; 
 "setup.enterLoginPassword.info" = "Entrer le mot de passe utilisé pour déverrouiller votre Mac."; 
-"setup.enterLoginPassword" = "Veuillez redémarrer votre Mac pour que les changements prennent effet."; 
+"setup.requireReboot" = "Veuillez redémarrer votre Mac pour que les changements prennent effet."; 
 
 "menubar.log.copy" = "Copier le registre";
 "menubar.documentation" = "Documentation"; 

--- a/PlayCover/id.lproj/Localizable.strings
+++ b/PlayCover/id.lproj/Localizable.strings
@@ -117,7 +117,7 @@
 "setup.enterLoginPassword" = "Please enter your user password";
 "setup.incorrectPassword" = "Password incorrect. Please try again";
 "setup.enterLoginPassword.info" = "Enter the password used to unlock your Mac.";
-"setup.enterLoginPassword" = "Please restart your Mac for changes to take effect.";
+"setup.requireReboot" = "Please restart your Mac for changes to take effect.";
 
 "menubar.log.copy" = "Copy Logs";
 "menubar.documentation" = "Documentation";

--- a/PlayCover/it.lproj/Localizable.strings
+++ b/PlayCover/it.lproj/Localizable.strings
@@ -117,7 +117,7 @@
 "setup.enterLoginPassword" = "Please enter your user password";
 "setup.incorrectPassword" = "Password incorrect. Please try again";
 "setup.enterLoginPassword.info" = "Enter the password used to unlock your Mac.";
-"setup.enterLoginPassword" = "Please restart your Mac for changes to take effect.";
+"setup.requireReboot" = "Please restart your Mac for changes to take effect.";
 
 "menubar.log.copy" = "Copy Logs";
 "menubar.documentation" = "Documentation";

--- a/PlayCover/ja.lproj/Localizable.strings
+++ b/PlayCover/ja.lproj/Localizable.strings
@@ -117,7 +117,7 @@
 "setup.enterLoginPassword" = "Please enter your user password";
 "setup.incorrectPassword" = "Password incorrect. Please try again";
 "setup.enterLoginPassword.info" = "Enter the password used to unlock your Mac.";
-"setup.enterLoginPassword" = "Please restart your Mac for changes to take effect.";
+"setup.requireReboot" = "Please restart your Mac for changes to take effect.";
 
 "menubar.log.copy" = "Copy Logs";
 "menubar.documentation" = "Documentation";

--- a/PlayCover/ko.lproj/Localizable.strings
+++ b/PlayCover/ko.lproj/Localizable.strings
@@ -117,7 +117,7 @@
 "setup.enterLoginPassword" = "Please enter your user password";
 "setup.incorrectPassword" = "Password incorrect. Please try again";
 "setup.enterLoginPassword.info" = "Enter the password used to unlock your Mac.";
-"setup.enterLoginPassword" = "Please restart your Mac for changes to take effect.";
+"setup.requireReboot" = "Please restart your Mac for changes to take effect.";
 
 "menubar.log.copy" = "Copy Logs";
 "menubar.documentation" = "Documentation";

--- a/PlayCover/ru.lproj/Localizable.strings
+++ b/PlayCover/ru.lproj/Localizable.strings
@@ -117,7 +117,7 @@
 "setup.enterLoginPassword" = "Please enter your user password";
 "setup.incorrectPassword" = "Password incorrect. Please try again";
 "setup.enterLoginPassword.info" = "Enter the password used to unlock your Mac.";
-"setup.enterLoginPassword" = "Please restart your Mac for changes to take effect.";
+"setup.requireReboot" = "Please restart your Mac for changes to take effect.";
 
 "menubar.log.copy" = "Copy Logs";
 "menubar.documentation" = "Documentation";

--- a/PlayCover/vi.lproj/Localizable.strings
+++ b/PlayCover/vi.lproj/Localizable.strings
@@ -117,7 +117,7 @@
 "setup.enterLoginPassword" = "Please enter your user password";
 "setup.incorrectPassword" = "Password incorrect. Please try again";
 "setup.enterLoginPassword.info" = "Enter the password used to unlock your Mac.";
-"setup.enterLoginPassword" = "Please restart your Mac for changes to take effect.";
+"setup.requireReboot" = "Please restart your Mac for changes to take effect.";
 
 "menubar.log.copy" = "Copy Logs";
 "menubar.documentation" = "Documentation";

--- a/PlayCover/zh-Hans.lproj/Localizable.strings
+++ b/PlayCover/zh-Hans.lproj/Localizable.strings
@@ -117,7 +117,7 @@
 "setup.enterLoginPassword" = "请输入管理员登录密码";
 "setup.incorrectPassword" = "密码错误，请重试";
 "setup.enterLoginPassword.info" = "输入用来登录这台 Mac 的密码";
-"setup.enterLoginPassword" = "请重启 Mac 以使更改生效";
+"setup.requireReboot" = "请重启 Mac 以使更改生效";
 
 "menubar.log.copy" = "复制日志";
 "menubar.documentation" = "使用手册";


### PR DESCRIPTION
Fix infinity loop when entering mac password to enable PlaySign.
Fix showing raw key string and duplicate key string with different value. (Duplicate `setup.enterLoginPassword`)
SetupView Button will disappear right after Enabling PlaySign.

Currently, after enabling play sign button will remain and if you click button app does not response and cmd+Q to quit is not work. And there's no way to cancel entering password in alert modal because it keep asking for password with new alert modal