### PR TITLE
fix: removing black bars when auto window size is enabled

### DIFF
--- a/PlayCover/View/PlayAppView.swift
+++ b/PlayCover/View/PlayAppView.swift
@@ -46,8 +46,10 @@ struct PlayAppView: View {
                 isHover = false
                 shell.removeTwitterSessionCookie()
                 if app.settings.enableWindowAutoSize {
-                    app.settings.gameWindowSizeWidth = Float(NSScreen.main?.visibleFrame.width ?? 1920)
-                    app.settings.gameWindowSizeHeight = Float(NSScreen.main?.visibleFrame.height ?? 1080)
+                    // Float(NSScreen.main?.visibleFrame.width ?? 1920)
+                    app.settings.gameWindowSizeWidth = Float(NSScreen.main?.frame.width ?? 1920)
+                    // Float(NSScreen.main?.visibleFrame.height ?? 1080)
+                    app.settings.gameWindowSizeHeight = Float(NSScreen.main?.frame.height ?? 1080)
                 }
                 app.launch()
             }


### PR DESCRIPTION
I changed from visibleFrame to frame to calculate screen aspect ratio so we can have full size on full screen when auto window size is enabled.
```swift
if app.settings.enableWindowAutoSize {
                    // Float(NSScreen.main?.visibleFrame.width ?? 1920)
                    app.settings.gameWindowSizeWidth = Float(NSScreen.main?.frame.width ?? 1920)
                    // Float(NSScreen.main?.visibleFrame.height ?? 1080)
                    app.settings.gameWindowSizeHeight = Float(NSScreen.main?.frame.height ?? 1080)
                }
```
The difference with visible frame is that frame takes the space taken by the dock and menu bar.
