### PR TITLE
feature: ✨ Now you can switch between Ipad models on app settings.

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -191,6 +191,17 @@ class AppSettings {
             dictionary = dict
         }
     }
+    private static let ipadModel = "pc.ipadModel"
+    var ipadModel: String {
+        get {
+            dictionary[AppSettings.ipadModel] as? String ?? "iPad8,6"
+        }
+        set {
+            var dict = dictionary
+            dict[AppSettings.ipadModel] = newValue
+            dictionary = dict
+        }
+    }
 
     private var allPrefs: [String: Any] {
         get {
@@ -250,7 +261,8 @@ class AppSettings {
                                       AppSettings.sensivity: 50,
                                       AppSettings.gameWindowSizeHeight: 1080,
                                       AppSettings.gameWindowSizeWidth: 1920,
-                                      AppSettings.enableWindowAutoSize: false
+                                      AppSettings.enableWindowAutoSize: false,
+                                      AppSettings.ipadModel: "iPad8,6"
                                       ]
         }
     }

--- a/PlayCover/View/AppSettingsView.swift
+++ b/PlayCover/View/AppSettingsView.swift
@@ -23,6 +23,7 @@ struct AppSettingsView: View {
     @State var resetCompletedAlert: Bool = false
     @State var selectedWindowSize: Int
     @State var enableWindowAutoSize: Bool
+    @State var ipadModel: String
     @Environment(\.presentationMode) var presentationMode
 
     var body: some View {
@@ -82,6 +83,11 @@ struct AppSettingsView: View {
                     Text("60 Hz").tag(0)
                     Text("120 Hz").tag(1)
                 }).pickerStyle(SegmentedPickerStyle()).frame(maxWidth: 300).padding()
+                Picker(selection: $ipadModel, label: Text("settings.picker.ipadModel"), content: {
+                    Text("1st Gen").tag("iPad6,7")
+                    Text("3rd Gen").tag("iPad8,6")
+                    Text("5th Gen").tag("iPad13,8")
+                }).pickerStyle(SegmentedPickerStyle()).frame(maxWidth: 300).padding()
                 if adaptiveDisplay && !enableWindowAutoSize {
                     Spacer()
                     Picker(selection: $selectedWindowSize, label: Text("settings.picker.screenSize"), content: {
@@ -114,6 +120,7 @@ struct AppSettingsView: View {
                     settings.bypass = bypass
                     settings.gamingMode = gamingMode
                     settings.enableWindowAutoSize = adaptiveDisplay ? enableWindowAutoSize : false
+                    settings.ipadModel = ipadModel
                     if enableWindowAutoSize {
                         settings.gameWindowSizeHeight = Float(NSScreen.main?.visibleFrame.height ?? 1080)
                         settings.gameWindowSizeWidth = Float(NSScreen.main?.visibleFrame.width ?? 1920)

--- a/PlayCover/View/PlayAppView.swift
+++ b/PlayCover/View/PlayAppView.swift
@@ -144,7 +144,8 @@ struct PlayAppView: View {
                                 selectedWindowSize: app.settings.gameWindowSizeHeight == 1080
                                 ? 0
                                 : app.settings.gameWindowSizeHeight == 1440 ? 1 : 2,
-                                enableWindowAutoSize: app.settings.enableWindowAutoSize
+                                enableWindowAutoSize: app.settings.enableWindowAutoSize,
+                                ipadModel: app.settings.ipadModel
                 ).frame(minWidth: 500)
             }.sheet(isPresented: $showChangeGenshinAccount) {
                 ChangeGenshinAccountView()

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -85,6 +85,7 @@
 
 "settings.picker.displayRefreshRate" = "Screen refresh rate";
 "settings.picker.screenSize" = "Display resolution";
+"settings.picker.ipadModel" = "Select Ipad Pro model";
 
 "settings.slider.mouseSensitivity" = "Mouse sensitivity: ";
 


### PR DESCRIPTION
Like the title says, this PR aims to add a picker on app settings to let the user select an ipad pro model to run the app on.
The models I added are Ipad pro 1st, 3rd and 5th gen. I plan to add iphone later but I still have to think in a way to avoid problems with this.

This PR needs https://github.com/PlayCover/PlayTools/pull/13 to work