### PR TITLE
fix: Reset all settings not resetting all settings

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -230,7 +230,8 @@ class AppSettings {
     }
 
     func reset() {
-        dictionary.removeAll()
+        allPrefs.removeValue(forKey: info.bundleIdentifier)
+        createSettingsIfNotExists()
     }
 
     init(_ info: AppInfo, container: AppContainer?) {

--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -230,10 +230,7 @@ class AppSettings {
     }
 
     func reset() {
-        adaptiveDisplay = info.isGame
-        keymapping = info.isGame
-        disableTimeout = false
-        layout = []
+        dictionary.removeAll()
     }
 
     init(_ info: AppInfo, container: AppContainer?) {

--- a/PlayCover/View/AppSettingsView.swift
+++ b/PlayCover/View/AppSettingsView.swift
@@ -106,6 +106,9 @@ struct AppSettingsView: View {
                 Button("settings.reset") {
                     resetCompletedAlert.toggle()
                     settings.reset()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                        presentationMode.wrappedValue.dismiss()
+                    }
                 }.controlSize(.large).padding()
                 Button("button.OK") {
                     settings.keymapping = keymapping


### PR DESCRIPTION
Addresses #151

Fixed the reset() method which should now correctly nuke all settings for a given application