### PR TITLE
Feat ✨ Delete in-game preferences

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -600,6 +600,7 @@
 				8783D00B26B8C9E600171041 /* URLExtensions.swift in Sources */,
 				ABED59832887A32F004D782B /* MenuBarView.swift in Sources */,
 				538AAE7B26CD41E60009C7AC /* ProcessExtension.swift in Sources */,
+				2878234D28A73FA600E6C27F /* DeletePreferences.swift in Sources */,
 				92EE06D4274EA604002C907B /* PlayAppView.swift in Sources */,
 				9280871D2824AD360034C510 /* Unarchiver.swift in Sources */,
 				92279BBF27610433009F28BF /* AppSettingsView.swift in Sources */,

--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		28361D6428927E3300B35EDB /* StoreGenshinAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28361D6328927E3300B35EDB /* StoreGenshinAccountView.swift */; };
 		28361D662892800200B35EDB /* DeleteStoredGenshinUserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28361D652892800200B35EDB /* DeleteStoredGenshinUserData.swift */; };
 		28361D68289280A300B35EDB /* DeleteGenshinStoredAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28361D67289280A300B35EDB /* DeleteGenshinStoredAccountView.swift */; };
+		2878234D28A73FA600E6C27F /* DeletePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2878234C28A73FA600E6C27F /* DeletePreferences.swift */; };
 		365AFB0628847B2E008B3542 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 365AFB0528847B2E008B3542 /* Sparkle */; settings = {ATTRIBUTES = (Required, ); }; };
 		365AFB0828847B75008B3542 /* Sparkle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 365AFB0728847B75008B3542 /* Sparkle.swift */; };
 		3665EF8928832400007CF915 /* PlayCoverSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3665EF8828832400007CF915 /* PlayCoverSettingsView.swift */; };
@@ -76,6 +77,7 @@
 		28361D6328927E3300B35EDB /* StoreGenshinAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreGenshinAccountView.swift; sourceTree = "<group>"; };
 		28361D652892800200B35EDB /* DeleteStoredGenshinUserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteStoredGenshinUserData.swift; sourceTree = "<group>"; };
 		28361D67289280A300B35EDB /* DeleteGenshinStoredAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteGenshinStoredAccountView.swift; sourceTree = "<group>"; };
+		2878234C28A73FA600E6C27F /* DeletePreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePreferences.swift; sourceTree = "<group>"; };
 		365AFB0728847B75008B3542 /* Sparkle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sparkle.swift; sourceTree = "<group>"; };
 		3665EF8828832400007CF915 /* PlayCoverSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayCoverSettingsView.swift; sourceTree = "<group>"; usesTabs = 0; };
 		36B26B96288C724600859EFD /* UpdateSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSettings.swift; sourceTree = "<group>"; };
@@ -280,6 +282,7 @@
 				28361D5F28927CAC00B35EDB /* SaveGenshinUserData.swift */,
 				28361D652892800200B35EDB /* DeleteStoredGenshinUserData.swift */,
 				6E66B0BE289DE6240099B907 /* Store.swift */,
+				2878234C28A73FA600E6C27F /* DeletePreferences.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";

--- a/PlayCover/Utils/DeletePreferences.swift
+++ b/PlayCover/Utils/DeletePreferences.swift
@@ -1,0 +1,18 @@
+//
+//  DeletePreferences.swift
+//  PlayCover
+//
+//  Created by José Elias Moreno villegas on 12/08/22.
+//
+
+import Foundation
+
+func deletePreferences(app: String) {
+    let plist = "/Users/\(NSUserName())/Library/Containers/\(app)/Data/Library/Preferences/\(app).plist"
+    let fileManager = FileManager.default
+    do {
+        try fileManager.removeItem(atPath: plist)
+    } catch {
+        Log.shared.error("Error removing preferences: \(error)")
+    }
+}

--- a/PlayCover/View/PlayAppView.swift
+++ b/PlayCover/View/PlayAppView.swift
@@ -13,6 +13,7 @@ struct PlayAppView: View {
     @State private var showSettings = false
     @State private var showClearCacheAlert = false
     @State private var showClearCacheToast = false
+    @State private var showClearPreferencesAlert = false
 
     @Environment(\.colorScheme) var colorScheme
 
@@ -78,6 +79,12 @@ struct PlayAppView: View {
                     showClearCacheAlert.toggle()
                 }, label: {
                     Text("playapp.clearCache")
+                    Image(systemName: "xmark.bin")
+                })
+                Button(action: {
+                    showClearPreferencesAlert.toggle()
+                }, label: {
+                    Text("playapp.clearPreferences")
                     Image(systemName: "xmark.bin")
                 })
 
@@ -157,6 +164,12 @@ struct PlayAppView: View {
                 Button("button.Proceed", role: .cancel) {
                     app.container?.clear()
                     showClearCacheToast.toggle()
+                }
+                Button("button.Cancel", role: .cancel) {}
+            }.alert("alert.app.preferences", isPresented: $showClearPreferencesAlert) {
+                Button("button.Proceed", role: .cancel) {
+                    deletePreferences(app: app.info.bundleIdentifier)
+                    showClearPreferencesAlert.toggle()
                 }
                 Button("button.Cancel", role: .cancel) {}
             }.toast(isPresenting: $showClearCacheToast) {

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -11,6 +11,7 @@
 "playapp.storeCurrentAccount" = "Store current account";
 "playapp.activateAccount" = "Activate an account";
 "playapp.deleteAccount" = "Delete an account";
+"playapp.clearPreferences" = "Clear app Preferences";
 
 "storeAccount.selectAccRegion" = "Select account region";
 "storeAccount.selectAccRegion.usa" = "America";
@@ -38,6 +39,7 @@
 "alert.kmImported" = "Keymapping imported!";
 "alert.errorImportKm" = "Error occured when importing!";
 "alert.app.delete" = "All app data will be erased. You may need to download app files again. Do you wish to continue?";
+"alert.app.preferences" = "All game preferences will be deleted, You may need to configure your in-game settings(region) and wait a couple of seconds until game assets are located (They won't be downloaded the game will just verify them). Do you wish to continue?";
 "alert.wrongFileType" = "Wrong file type";
 "alert.wrongFileType.message" = "Choose an .ipa file";
 "alert.followInstructionsAndRestartApp" = "Please follow the given instructions, and restart the App.";

--- a/PlayCover/es.lproj/Localizable.strings
+++ b/PlayCover/es.lproj/Localizable.strings
@@ -11,6 +11,7 @@
 "playapp.storeCurrentAccount" = "Store current account";
 "playapp.activateAccount" = "Activate an account";
 "playapp.deleteAccount" = "Delete an account";
+"playapp.clearPreferences" = "Borrar preferencias";
 
 "storeAccount.selectAccRegion" = "Select account region";
 "storeAccount.selectAccRegion.usa" = "America";
@@ -38,6 +39,7 @@
 "alert.kmImported" = "Keymapping imported!";
 "alert.errorImportKm" = "Error occured when importing!";
 "alert.app.delete" = "All app data will be erased. You may need to download app files again. Do you wish to continue?";
+"alert.app.preferences" = "All game preferences will be deleted, You may need to configure your in-game settings(region) and wait a couple of seconds until game assets are located (They won't be downloaded the game will just verify them). Do you wish to continue?";
 "alert.wrongFileType" = "Wrong file type";
 "alert.wrongFileType.message" = "Choose an .ipa file";
 "alert.followInstructionsAndRestartApp" = "Please follow the given instructions, and restart the App.";
@@ -85,6 +87,7 @@
 
 "settings.picker.displayRefreshRate" = "Screen refresh rate";
 "settings.picker.screenSize" = "Display resolution";
+"settings.picker.ipadModel" = "Seleciona un modelo de Ipad";
 
 "settings.slider.mouseSensitivity" = "Mouse sensitivity: ";
 


### PR DESCRIPTION
This PR adds a new item to context menu, it removes all bundle preferences, I tested on genshin and game automatically should create the preferences again after restarting the game.

This PR also fixes screen bug on Playtools 1.1.6 when you quit the game using cmd + w and increases the quality of the game. more noticeable on fullscreen (At least on my screen and for my testers).