### PR TITLE
refactor: Use discardableResult to suppress warning

### DIFF
--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -30,7 +30,7 @@ class Installer {
                 }
                 try PlayTools.replaceLibraries(atURL: macho)
                 try PlayTools.convertMacho(macho)
-                _ = try fakesign(macho)
+                try fakesign(macho)
             }
 
             // -rwxr-xr-x
@@ -192,6 +192,6 @@ class Installer {
 
     /// Regular codesign, does not accept entitlements. Used to re-seal an app after you've modified it.
     static func fakesign(_ url: URL) throws {
-        _ = try shell.shello("/usr/bin/codesign", "-fs-", url.path)
+        try shell.shello("/usr/bin/codesign", "-fs-", url.path)
     }
 }

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -8,7 +8,7 @@ import Foundation
 class PlayTools {
     static func replaceLibraries(atURL url: URL) throws {
         Log.shared.log("Replacing libswiftUIKit.dylib")
-        _ = try shell.shello(
+        try shell.shello(
             install_name_tool.path ,
             "-change", "@rpath/libswiftUIKit.dylib", "/System/iOSSupport/usr/lib/swift/libswiftUIKit.dylib",
             url.path
@@ -34,7 +34,7 @@ class PlayTools {
 
     static func convertMacho(_ macho: URL) throws {
         Log.shared.log("Converting \(macho.lastPathComponent) binary")
-        _ = try shell.shello(
+        try shell.shello(
             vtool.path,
             "-set-build-version", "maccatalyst", "11.0", "14.0",
             "-replace", "-output",
@@ -63,7 +63,7 @@ class PlayTools {
                     try fileMgr.delete(at: URL(fileURLWithPath: PLAY_TOOLS_FRAMEWORKS_PATH))
                 }
                 Log.shared.log("Copying PlayTools to Frameworks")
-                _ = try shell.sh("cp -r \(tools.esc) \(PLAY_TOOLS_FRAMEWORKS_PATH)")
+                try shell.sh("cp -r \(tools.esc) \(PLAY_TOOLS_FRAMEWORKS_PATH)")
             } catch {
                 Log.shared.error(error)
             }

--- a/PlayCover/Utils/Shell.swift
+++ b/PlayCover/Utils/Shell.swift
@@ -10,7 +10,8 @@ let shell = Shell.self
 class Shell: ObservableObject {
     static let shared = Shell()
 
-	static func sh(_ command: String, print: Bool = true, pipeStdErr: Bool = true) throws -> String {
+    @discardableResult
+    static func sh(_ command: String, print: Bool = true, pipeStdErr: Bool = true) throws -> String {
 		let task = Process()
 		let pipe = Pipe()
 
@@ -36,6 +37,7 @@ class Shell: ObservableObject {
 		return output
 	}
 
+    @discardableResult
     internal static func shello(print: Bool = true, _ binary: String, _ args: String...) throws -> String {
         let process = Process()
 		let pipe = Pipe()


### PR DESCRIPTION
Instead of using `_  = expression()` to suppress "Result of call to 'xxx' is unused" warning, use `@discardableResult` to suppress warning. 