### PR TITLE
fix: min width layout appearance

### DIFF
--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -125,7 +125,7 @@ struct MainView: View {
                 .frame(height: 150)
             }
         }
-        .frame(minWidth: 650, minHeight: 330)
+        .frame(minWidth: 675, minHeight: 330)
     }
 
     func installXcodeCli() {


### PR DESCRIPTION
## How it was

<img width="652" alt="Screenshot 2022-08-26 at 09 40 03" src="https://user-images.githubusercontent.com/69932531/187018892-e2823d70-cb91-4968-99b4-4bfc757defd9.png">
<img width="651" alt="Screenshot 2022-08-26 at 09 40 16" src="https://user-images.githubusercontent.com/69932531/187018893-6c41614b-408b-4012-8375-07388c304696.png">

## How it is right now

https://user-images.githubusercontent.com/69932531/187018612-b7f2c599-28dd-4833-81b2-9280bf895c56.mov



