### PR TITLE
feat: Add support for new app setting plist

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -10,6 +10,7 @@ import AppKit
 struct AppSettingsData: Codable {
     var keymapping: Bool = true
     var mouseMapping: Bool = true
+    var keymap: [[CGFloat]] = []
     var sensitivity: Float = 50
 
     var disableTimeout: Bool = false

--- a/PlayCover/Model/Keymapping.swift
+++ b/PlayCover/Model/Keymapping.swift
@@ -35,7 +35,7 @@ struct MouseAreaModel: Codable {
 struct Keymap: Codable {
     var buttonModels: [ButtonModel] = []
     var joystickModel: [JoystickModel] = []
-    var mouseAreaMode: [MouseAreaModel] = []
+    var mouseAreaModel: [MouseAreaModel] = []
     var bundleIdentifier: String
     var version: String = "2.0.0"
 }

--- a/PlayCover/Rules/default.yaml
+++ b/PlayCover/Rules/default.yaml
@@ -66,7 +66,7 @@ whitelist:
 allow:
     - (allow user-preference-write (preference-domain ".GlobalPreferences"))
     - (allow user-preference-read (preference-domain ".GlobalPreferences"))
-    - (allow file* file-read* file-write* file-write-data file-read-metadata file-ioctl (literal "/Users/${NSUserName}/Library/Preferences/playcover.plist"))
+    - (allow file* file-read* file-write* file-write-data file-read-metadata file-ioctl (subpath "/Users/${NSUserName}/Library/Preferences/io.playcover.PlayCover"))
     - (allow file* file-read* file-read-metadata file-ioctl (subpath "/Users/${NSUserName}/Library/Frameworks/PlayTools.framework"))
 
 bypass:

--- a/PlayCover/Rules/default.yaml
+++ b/PlayCover/Rules/default.yaml
@@ -66,7 +66,7 @@ whitelist:
 allow:
     - (allow user-preference-write (preference-domain ".GlobalPreferences"))
     - (allow user-preference-read (preference-domain ".GlobalPreferences"))
-    - (allow file* file-read* file-write* file-write-data file-read-metadata file-ioctl (subpath "/Users/${NSUserName}/Library/Preferences/io.playcover.PlayCover"))
+    - (allow file* file-read* file-write* file-write-data file-read-metadata file-ioctl (subpath "/Users/${NSUserName}/Library/Containers/io.playcover.PlayCover"))
     - (allow file* file-read* file-read-metadata file-ioctl (subpath "/Users/${NSUserName}/Library/Frameworks/PlayTools.framework"))
 
 bypass:


### PR DESCRIPTION
Fix sandbox profile to add access to setting file.
This and https://github.com/PlayCover/PlayTools/pull/20 are interdependent