### PR TITLE
fix!: better error handling for shell commands + empty entitlement fix

### DIFF
--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -126,9 +126,19 @@ class PlayTools {
         return PLAY_COVER_PATH
     }
 
-    static func fetchEntitlements(_ exec: URL) throws -> String {
-        try shell.sh("codesign --display --entitlements - --xml '\(exec.path)' | xmllint --format -", pipeStdErr: false)
-    }
+	static func fetchEntitlements(_ exec: URL) throws -> String {
+        do {
+            return  try shell.sh("codesign --display --entitlements - --xml '\(exec.path)'" +
+                            " | xmllint --format -", pipeStdErr: false)
+        } catch {
+            if error.localizedDescription.contains("Document is empty") {
+                // Empty entitlements
+                return ""
+            } else {
+                throw error
+            }
+        }
+	}
 
     private static func binPath(_ bin: String) throws -> URL {
         URL(fileURLWithPath: try shell.sh("which \(bin)").trimmingCharacters(in: .newlines))


### PR DESCRIPTION
This patch could be breaking stuff elsewhere, please test before merge.

- Make `shell.sh` throws the content of `stderr` **if pipeStdErr is set to false**. This allows better error handling and alerting in case a shell command fails to run properly
- Handle cases where the app being installed has no entitlement. Partially fixes #214 