### PR TITLE
fix!: detect encrypted Mach-O only on the 64-bit slice

### DIFF
--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -43,8 +43,12 @@ class PlayTools {
     }
 
     static func isMachoEncrypted(atURL url: URL) throws -> Bool {
-        let otoolOutput = try shell.shello(otool.path, "-l", url.path)
-        if otoolOutput.contains("LC_ENCRYPTION_INFO") && otoolOutput.contains("cryptid 1") {return true}
+        // Split output into blocks
+        let otoolOutput = try shell.shello(otool.path, "-l", url.path).components(separatedBy: "Load command")
+        // Check specifically for encryption info on the 64 bit block
+        for block in otoolOutput where (block.contains("LC_ENCRYPTION_INFO_64") && block.contains("cryptid 1")) {
+            return true
+        }
         return false
     }
 


### PR DESCRIPTION
Fixes an issue where apps that only has the 64-bit slice is decrypted is wrongly detected as encrypted 