### PR TITLE
[Enhancement] Further imitate Finder behaviour

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		53F4D29F26C43C690020167C /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		53F50C4826E3CA42007AD2D3 /* AppLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLibraryView.swift; sourceTree = "<group>"; };
 		53F5E74226C1D37E005AED1D /* FileExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExtensions.swift; sourceTree = "<group>"; };
+		68154F5328B1081500ECA007 /* fa-IR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "fa-IR"; path = "fa-IR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		6E06193528B3C4090012C771 /* StoreGenshinAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreGenshinAccountView.swift; sourceTree = "<group>"; };
 		6E06193728B3C4240012C771 /* ChangeGenshinAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeGenshinAccountView.swift; sourceTree = "<group>"; };
 		6E06193928B3C42E0012C771 /* DeleteGenshinAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteGenshinAccountView.swift; sourceTree = "<group>"; };
@@ -114,11 +115,10 @@
 		6E7BEDCB28C3AD0300DFF0EB /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6E7CA16428B4D02900216CD8 /* ITunesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ITunesResponse.swift; sourceTree = "<group>"; };
 		6E7CA16628B4EEAE00216CD8 /* Keymapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keymapping.swift; sourceTree = "<group>"; };
-		6ED6ACA328A949A30040D234 /* AppSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsView.swift; sourceTree = "<group>"; };
-		6ED6ACA528A96E570040D234 /* DeletePreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeletePreferences.swift; sourceTree = "<group>"; };
-		68154F5328B1081500ECA007 /* fa-IR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "fa-IR"; path = "fa-IR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		6EC228A028B14A0600D7D73A /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		6EC228A128B1830F00D7D73A /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
+		6ED6ACA328A949A30040D234 /* AppSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsView.swift; sourceTree = "<group>"; };
+		6ED6ACA528A96E570040D234 /* DeletePreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeletePreferences.swift; sourceTree = "<group>"; };
 		8783CFF726B8C52D00171041 /* PlayCover.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PlayCover.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8783CFFA26B8C52D00171041 /* PlayCoverApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayCoverApp.swift; sourceTree = "<group>"; };
 		8783CFFE26B8C52E00171041 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -485,6 +485,9 @@
 				vi,
 				it,
 				uk,
+				"fa-IR",
+				"zh-Hant",
+				ar,
 			);
 			mainGroup = 8783CFEE26B8C52D00171041;
 			packageReferences = (

--- a/PlayCover/Views/App Views/PlayAppView.swift
+++ b/PlayCover/Views/App Views/PlayAppView.swift
@@ -6,12 +6,9 @@
 import SwiftUI
 
 struct PlayAppView: View {
-    @Binding var selectedBackgroundColor: Color
-    @Binding var selectedTextColor: Color
-    @Binding var selected: PlayApp?
-
     @State var app: PlayApp
     @State var isList: Bool
+    @Binding var selected: PlayApp?
 
     @State private var showSettings = false
     @State private var showClearCacheAlert = false
@@ -26,11 +23,7 @@ struct PlayAppView: View {
     @State private var showDeleteGenshinAccount = false
 
     var body: some View {
-        PlayAppConditionalView(selectedBackgroundColor: $selectedBackgroundColor,
-                               selectedTextColor: $selectedTextColor,
-                               selected: $selected,
-                               app: app,
-                               isList: isList)
+        PlayAppConditionalView(app: app, isList: isList, selected: $selected)
             .gesture(TapGesture(count: 2).onEnded {
                 shell.removeTwitterSessionCookie()
                 app.launch()
@@ -43,11 +36,6 @@ struct PlayAppView: View {
                     showSettings.toggle()
                 }, label: {
                     Text("playapp.settings")
-                })
-                Button(action: {
-                    app.openAppCache()
-                }, label: {
-                    Text("playapp.openCache")
                 })
                 Button(action: {
                     app.showInFinder()
@@ -74,8 +62,7 @@ struct PlayAppView: View {
                     })
                 }
                 Group {
-                    if app.info.bundleIdentifier.contains("GenshinImpact")
-                        || app.info.bundleIdentifier.contains("Yuanshen") {
+                    if app.info.bundleIdentifier == "com.miHoYo.GenshinImpact" {
                         Divider()
                         Button(action: {
                             showStoreGenshinAccount.toggle()
@@ -156,12 +143,12 @@ struct PlayAppView: View {
 }
 
 struct PlayAppConditionalView: View {
-    @Binding var selectedBackgroundColor: Color
-    @Binding var selectedTextColor: Color
-    @Binding var selected: PlayApp?
-
     @State var app: PlayApp
     @State var isList: Bool
+    @State var selectedBackgroundColor = Color.accentColor.opacity(0.6)
+    @Binding var selected: PlayApp?
+    @Environment(\.colorScheme) var colorScheme
+    @Environment(\.controlActiveState) var controlActiveState
 
     var body: some View {
         if isList {
@@ -175,58 +162,54 @@ struct PlayAppConditionalView: View {
                         .shadow(radius: 1)
                         .padding(.horizontal, 15)
                         .padding(.vertical, 5)
-                } else {
-                    ProgressView()
-                        .progressViewStyle(.circular)
-                        .frame(width: 60, height: 60)
+                    Text(app.name)
+                    Spacer()
+                    Text(app.settings.info.bundleVersion)
+                        .padding(.horizontal, 15)
+                        .foregroundColor(.secondary)
                 }
-                Text(app.name)
-                    .foregroundColor(selected?.info.bundleIdentifier == app.info.bundleIdentifier ?
-                                     selectedTextColor : Color.primary)
-                Spacer()
-                Text(app.settings.info.bundleVersion)
-                    .padding(.horizontal, 15)
-                    .foregroundColor(.secondary)
             }
             .contentShape(Rectangle())
-            .background(
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(selected?.info.bundleIdentifier == app.info.bundleIdentifier ?
-                        selectedBackgroundColor : Color.clear)
-                    .brightness(-0.2)
-                )
+            .onChange(of: controlActiveState) { state in
+                if state == .inactive {
+                    selectedBackgroundColor = .gray.opacity(0.6)
+                } else {
+                    selectedBackgroundColor = .accentColor.opacity(0.6)
+                }
+            }
+            .background(selected?.info.bundleIdentifier == app.info.bundleIdentifier ?
+                        selectedBackgroundColor.cornerRadius(4) : Color.clear.cornerRadius(4))
         } else {
             VStack(alignment: .center, spacing: 0) {
-                VStack {
-                    if let img = app.icon {
+                if let img = app.icon {
+                    VStack {
                         Image(nsImage: img)
                             .resizable()
                             .aspectRatio(contentMode: .fit)
-                            .frame(width: 60, height: 60)
-                            .cornerRadius(15)
-                            .shadow(radius: 1)
-                    } else {
-                        ProgressView()
-                            .progressViewStyle(.circular)
-                            .frame(width: 60, height: 60)
+                            .frame(width: 50, height: 50)
+                            .cornerRadius(12)
+                            .shadow(radius: 1, y: 1)
+                        Text(app.name)
+                            .font(.system(size: 12))
+                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 2)
+                            .onChange(of: controlActiveState) { state in
+                                if state == .inactive {
+                                    selectedBackgroundColor = .gray.opacity(0.6)
+                                } else {
+                                    selectedBackgroundColor = .accentColor.opacity(0.6)
+                                }
+                            }
+                            .background(selected?.info.bundleIdentifier == app.info.bundleIdentifier ?
+                                        selectedBackgroundColor.cornerRadius(4) : Color.clear.cornerRadius(4))
+                            .frame(height: 20, alignment: .top)
                     }
-                    Text(app.name)
-                        .lineLimit(1)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 2)
-                        .foregroundColor(selected?.info.bundleIdentifier == app.info.bundleIdentifier ?
-                                         selectedTextColor : Color.primary)
-                        .background(
-                            RoundedRectangle(cornerRadius: 4)
-                                .fill(selected?.info.bundleIdentifier == app.info.bundleIdentifier ?
-                                      selectedBackgroundColor : Color.clear)
-                                .brightness(-0.2)
-                            )
-                        .frame(width: 150, height: 20)
                 }
             }
-            .frame(width: 150, height: 150)
+            .frame(width: 110, height: 100)
         }
     }
 }

--- a/PlayCover/Views/App Views/StoreAppView.swift
+++ b/PlayCover/Views/App Views/StoreAppView.swift
@@ -8,20 +8,16 @@
 import SwiftUI
 
 struct StoreAppView: View {
-    @Binding var selectedBackgroundColor: Color
-    @Binding var selectedTextColor: Color
-    @Binding var selected: StoreAppData?
-
     @State var app: StoreAppData
     @State var isList: Bool
+    @Binding var selected: StoreAppData?
+
+    @State var isHover = false
 
     var body: some View {
-        StoreAppConditionalView(selectedBackgroundColor: $selectedBackgroundColor,
-                                selectedTextColor: $selectedTextColor,
-                                selected: $selected,
-                                app: app,
-                                isList: isList)
+        StoreAppConditionalView(app: app, isList: isList, selected: $selected, isHover: $isHover)
             .gesture(TapGesture(count: 2).onEnded {
+                isHover = false
                 if let url = URL(string: app.link) {
                     NSWorkspace.shared.open(url)
                 }
@@ -29,17 +25,22 @@ struct StoreAppView: View {
             .simultaneousGesture(TapGesture().onEnded {
                 selected = app
             })
+            .onHover(perform: { hovering in
+                isHover = hovering
+            })
     }
 }
 
 struct StoreAppConditionalView: View {
-    @Binding var selectedBackgroundColor: Color
-    @Binding var selectedTextColor: Color
-    @Binding var selected: StoreAppData?
-
     @State var app: StoreAppData
     @State var isList: Bool
     @State var iconUrl: URL?
+    @State var selectedBackgroundColor = Color.accentColor.opacity(0.6)
+    @Binding var selected: StoreAppData?
+    @Environment(\.colorScheme) var colorScheme
+    @Environment(\.controlActiveState) var controlActiveState
+
+    @Binding var isHover: Bool
 
     var body: some View {
         Group {
@@ -61,51 +62,63 @@ struct StoreAppConditionalView: View {
                         .padding(.horizontal, 15)
                         .padding(.vertical, 5)
                     Text(app.name)
-                        .foregroundColor(selected?.id == app.id ?
-                                         selectedTextColor : Color.primary)
                     Spacer()
                     Text(app.version)
                         .padding(.horizontal, 15)
                         .foregroundColor(.secondary)
                 }
                 .contentShape(Rectangle())
-                .background(
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(selected?.id == app.id ?
-                              selectedBackgroundColor : Color.clear)
-                        .brightness(-0.2)
-                )
+                .onChange(of: controlActiveState) { state in
+                    if state == .inactive {
+                        selectedBackgroundColor = .gray.opacity(0.6)
+                    } else {
+                        selectedBackgroundColor = .accentColor.opacity(0.6)
+                    }
+                }
+                .background(selected?.id == app.id ?
+                            selectedBackgroundColor.cornerRadius(4) : Color.clear.cornerRadius(4))
             } else {
                 VStack(alignment: .center, spacing: 0) {
                     VStack {
                         AsyncImage(url: iconUrl) { image in
-                                image
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                            } placeholder: {
-                                ProgressView()
-                                    .progressViewStyle(.circular)
-                            }
-                            .frame(width: 60, height: 60)
-                            .cornerRadius(15)
-                            .shadow(radius: 1)
-                        Text("\(Image(systemName: "arrow.down.circle")) \(app.name)")
-                            .lineLimit(1)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 2)
-                            .foregroundColor(selected?.id == app.id ?
-                                             selectedTextColor : Color.primary)
-                            .background(
-                                RoundedRectangle(cornerRadius: 4)
-                                    .fill(selected?.id == app.id ?
-                                          selectedBackgroundColor : Color.clear)
-                                    .brightness(-0.2)
-                            )
-                            .frame(width: 150, height: 20)
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                        } placeholder: {
+                            ProgressView()
+                                .progressViewStyle(.circular)
+                        }
+                        .frame(width: 50, height: 50)
+                        .cornerRadius(12)
+                        .shadow(radius: 1, y: 1)
+                        HStack {
+                            Image(systemName: "arrow.down.circle")
+                                .font(.system(size: 12))
+                                .padding(.trailing, -6)
+                                .padding(.vertical, 3)
+                            Text(app.name)
+                                .font(.system(size: 12))
+                                .lineLimit(2)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal, 4)
+                                .padding(.vertical, 3)
+                                .onChange(of: controlActiveState) { state in
+                                    if state == .inactive {
+                                        selectedBackgroundColor = .gray.opacity(0.6)
+                                    } else {
+                                        selectedBackgroundColor = .accentColor.opacity(0.6)
+                                    }
+                                }
+                                .background(selected?.id == app.id ?
+                                            selectedBackgroundColor.cornerRadius(4) : Color.clear.cornerRadius(4))
+                                .frame(height: 20, alignment: .top)
+                        }
+                        .padding(.top, 2)
+                        .offset(x: -7)
                     }
                 }
-                .frame(width: 150, height: 150)
+                .frame(width: 110, height: 100)
             }
         }
         .task {

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -42,10 +42,6 @@ struct AppSettingsView: View {
                     .tabItem {
                         Text("settings.tab.graphics")
                     }
-                JBBypassView(settings: $viewModel.settings)
-                    .tabItem {
-                        Text("settings.tab.jbBypass")
-                    }
                 MiscView(settings: $viewModel.settings)
                     .tabItem {
                         Text("settings.tab.misc")
@@ -133,7 +129,7 @@ struct GraphicsView: View {
 
     var body: some View {
         ScrollView {
-            VStack {
+            VStack(alignment: .leading) {
                 HStack {
                     Text("settings.picker.iosDevice")
                     Spacer()
@@ -209,18 +205,19 @@ struct GraphicsView: View {
                     }
                 }
                 HStack {
-                    Picker("settings.picker.refreshRate", selection: $settings.settings.refreshRate) {
+                    Text("settings.picker.refreshRate")
+                    Spacer()
+                    Picker("", selection: $settings.settings.refreshRate) {
                         Text("60 Hz").tag(60)
-                        Text("75 HZ").tag(75)
+                        Text("75 Hz").tag(75)
                         Text("120 Hz").tag(120)
                     }
                     .pickerStyle(.segmented)
                     .fixedSize()
-                    .frame(alignment: .leading)
-                    Spacer()
-                    Toggle("settings.toggle.disableDisplaySleep", isOn: $settings.settings.disableTimeout)
-                        .help("settings.toggle.disableDisplaySleep.help")
                 }
+                .padding(.top, settings.settings.resolution >= 2 ? 0 : 10)
+                Toggle("settings.toggle.disableDisplaySleep", isOn: $settings.settings.disableTimeout)
+                    .help("settings.toggle.disableDisplaySleep.help")
                 Spacer()
             }
             .padding()
@@ -297,23 +294,6 @@ struct GraphicsView: View {
             heightRatio = 9
         }
         return (height / heightRatio) * widthRatio
-    }
-}
-
-struct JBBypassView: View {
-    @Binding var settings: AppSettings
-
-    var body: some View {
-        ScrollView {
-            VStack {
-                HStack {
-                    Toggle("settings.toggle.jbBypass", isOn: $settings.settings.bypass)
-                        .help("settings.toggle.jbBypass.help")
-                    Spacer()
-                }
-            }
-            .padding()
-        }
     }
 }
 

--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -35,13 +35,11 @@ struct MainView: View {
             NavigationView {
                 GeometryReader { sidebarGeom in
                     List {
-                        NavigationLink(destination: AppLibraryView(selectedBackgroundColor: $selectedBackgroundColor,
-                                                                   selectedTextColor: $selectedTextColor),
+                        NavigationLink(destination: AppLibraryView(),
                                        tag: 1, selection: self.$selectedView) {
                             Label("sidebar.appLibrary", systemImage: "square.grid.2x2")
                         }
-                        NavigationLink(destination: IPALibraryView(selectedBackgroundColor: $selectedBackgroundColor,
-                                                                   selectedTextColor: $selectedTextColor),
+                        NavigationLink(destination: IPALibraryView(),
                                        tag: 2, selection: self.$selectedView) {
                             Label("sidebar.ipaLibrary", systemImage: "arrow.down.circle")
                         }

--- a/PlayCover/Views/Sidebar Views/AppLibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/AppLibraryView.swift
@@ -9,10 +9,7 @@ struct AppLibraryView: View {
     @EnvironmentObject var appsVM: AppsVM
     @EnvironmentObject var installVM: InstallVM
 
-    @Binding var selectedBackgroundColor: Color
-    @Binding var selectedTextColor: Color
-
-    @State private var gridLayout = [GridItem(.adaptive(minimum: 150, maximum: 150))]
+    @State private var gridLayout = [GridItem(.adaptive(minimum: 100.5, maximum: .infinity))]
     @State private var searchString = ""
     @State private var isList = UserDefaults.standard.bool(forKey: "AppLibrayView")
     @State private var selected: PlayApp?
@@ -20,36 +17,28 @@ struct AppLibraryView: View {
 
     var body: some View {
         VStack(alignment: .leading) {
-            GeometryReader { geom in
+            GeometryReader { _ in
                 if !isList {
                     ScrollView {
                         LazyVGrid(columns: gridLayout, alignment: .leading) {
                             ForEach(appsVM.apps, id: \.info.bundleIdentifier) { app in
-                                PlayAppView(selectedBackgroundColor: $selectedBackgroundColor,
-                                            selectedTextColor: $selectedTextColor,
-                                            selected: $selected,
-                                            app: app,
-                                            isList: isList)
+                                PlayAppView(app: app, isList: isList, selected: $selected)
                             }
                         }
                         .padding()
-                        .animation(.spring(blendDuration: 0.1), value: geom.size.width)
                         Spacer()
                     }
                 } else {
                     ScrollView {
                         VStack {
                             ForEach(appsVM.apps, id: \.info.bundleIdentifier) { app in
-                                PlayAppView(selectedBackgroundColor: $selectedBackgroundColor,
-                                            selectedTextColor: $selectedTextColor,
-                                            selected: $selected,
-                                            app: app,
-                                            isList: isList)
+                                PlayAppView(app: app, isList: isList, selected: $selected)
                             }
                             Spacer()
                         }
                         .padding()
                     }
+                    .padding(.leading, 20)
                 }
             }
         }

--- a/PlayCover/Views/Sidebar Views/IPALibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/IPALibraryView.swift
@@ -10,70 +10,70 @@ import SwiftUI
 struct IPALibraryView: View {
     @EnvironmentObject var storeVM: StoreVM
 
-    @Binding var selectedBackgroundColor: Color
-    @Binding var selectedTextColor: Color
-
-    @State private var gridLayout = [GridItem(.adaptive(minimum: 150, maximum: 150))]
+    @State private var gridLayout = [GridItem(.adaptive(minimum: 100.5, maximum: .infinity))]
     @State private var searchString = ""
     @State private var isList = UserDefaults.standard.bool(forKey: "IPALibrayView")
     @State private var selected: StoreAppData?
 
+    @Environment(\.colorScheme) var colorScheme
+
     var body: some View {
-        VStack(alignment: .leading) {
-            GeometryReader { geom in
-                if !isList {
-                    ScrollView {
-                        LazyVGrid(columns: gridLayout, alignment: .leading) {
-                            ForEach(storeVM.apps, id: \.id) { app in
-                                StoreAppView(selectedBackgroundColor: $selectedBackgroundColor,
-                                             selectedTextColor: $selectedTextColor,
-                                             selected: $selected,
-                                             app: app,
-                                             isList: isList)
+        ZStack {
+            VStack(alignment: .leading) {
+                GeometryReader { _ in
+                    if !isList {
+                        ScrollView {
+                            LazyVGrid(columns: gridLayout, alignment: .leading) {
+                                ForEach(storeVM.apps, id: \.id) { app in
+                                    StoreAppView(app: app, isList: isList, selected: $selected)
+                                }
                             }
-                        }
-                        .padding()
-                        .animation(.spring(blendDuration: 0.1), value: geom.size.width)
-                        Spacer()
-                    }
-                } else {
-                    ScrollView {
-                        VStack {
-                            ForEach(storeVM.apps, id: \.id) { app in
-                                StoreAppView(selectedBackgroundColor: $selectedBackgroundColor,
-                                             selectedTextColor: $selectedTextColor,
-                                             selected: $selected,
-                                             app: app,
-                                             isList: isList)
-                            }
+                            .padding()
                             Spacer()
                         }
-                        .padding()
+                    } else {
+                        ScrollView {
+                            VStack {
+                                ForEach(storeVM.apps, id: \.id) { app in
+                                    StoreAppView(app: app, isList: isList, selected: $selected)
+                                }
+                                Spacer()
+                            }
+                            .padding()
+                        }
+                        .padding(.leading, 20)
                     }
                 }
             }
-        }
-        .onTapGesture {
-            selected = nil
-        }
-        .navigationTitle("sidebar.ipaLibrary")
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Picker("", selection: $isList) {
-                    Image(systemName: "square.grid.2x2")
-                        .tag(false)
-                    Image(systemName: "list.bullet")
-                        .tag(true)
-                }.pickerStyle(.segmented)
+            .onTapGesture {
+                selected = nil
             }
+            .navigationTitle("sidebar.ipaLibrary")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Picker("", selection: $isList) {
+                        Image(systemName: "square.grid.2x2")
+                            .tag(false)
+                        Image(systemName: "list.bullet")
+                            .tag(true)
+                    }.pickerStyle(.segmented)
+                }
+            }
+            .searchable(text: $searchString, placement: .toolbar)
+            .onChange(of: searchString, perform: { value in
+                uif.searchText = value
+                storeVM.fetchApps()
+            })
+            .onChange(of: isList, perform: { value in
+                UserDefaults.standard.set(value, forKey: "IPALibrayView")
+            })
         }
-        .searchable(text: $searchString, placement: .toolbar)
-        .onChange(of: searchString, perform: { value in
-            uif.searchText = value
-            storeVM.fetchApps()
-        })
-        .onChange(of: isList, perform: { value in
-            UserDefaults.standard.set(value, forKey: "IPALibrayView")
-        })
+    }
+}
+
+struct IPALibraryView_Previews: PreviewProvider {
+    static var previews: some View {
+        IPALibraryView()
+            .environmentObject(StoreVM.shared)
     }
 }


### PR DESCRIPTION
Recreated the wrapping configuration, sizing, and padding of app icons to match Finder style
<img width="776" alt="截屏2022-09-06 下午6 43 09" src="https://user-images.githubusercontent.com/66894537/188616076-69cb09ab-ea1c-4587-9b47-29f25df6024e.png">


Video illustration:

https://user-images.githubusercontent.com/66894537/188617921-777d0e85-923c-4338-bbf1-e10ddbef69ec.mp4

(Video shows a side-by-side comparison between PlayCover and Finder in the Applications folder)