### PR TITLE
feat: New App Signing configuration experience.

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		AA71964B287A0EA800623C15 /* PlayRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA71964A287A0EA800623C15 /* PlayRules.swift */; };
 		AA71964D287A35F400623C15 /* com.nexon.bluearchive.yaml in Resources */ = {isa = PBXBuildFile; fileRef = AA71964C287A35F400623C15 /* com.nexon.bluearchive.yaml */; };
 		AA818CB5287ABEC3000BEE9D /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = AA818CB4287ABEC3000BEE9D /* Yams */; };
+		AB671B8C28C9C7DB00B7B102 /* SigningSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB671B8B28C9C7DB00B7B102 /* SigningSetupView.swift */; };
 		ABED59832887A32F004D782B /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABED59822887A32F004D782B /* MenuBarView.swift */; };
 		B1084E1F28AA80F400E399FA /* AppSettingsVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1084E1E28AA80F400E399FA /* AppSettingsVM.swift */; };
 		B1419FB628BA82EE000CB69F /* DiscordActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1419FB528BA82EE000CB69F /* DiscordActivity.swift */; };
@@ -167,6 +168,7 @@
 		AA970FD228793A310099A5D0 /* PlayCoverRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PlayCoverRelease.entitlements; sourceTree = "<group>"; };
 		AAE8809E287ACE9F00FBB23C /* cp_frameworks.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = cp_frameworks.sh; sourceTree = "<group>"; };
 		AAE8809F287ACE9F00FBB23C /* bootstrap.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = bootstrap.sh; sourceTree = "<group>"; };
+		AB671B8B28C9C7DB00B7B102 /* SigningSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningSetupView.swift; sourceTree = "<group>"; };
 		ABED59822887A32F004D782B /* MenuBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		ABF0BA1A285F9ED200FC5259 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B1084E1E28AA80F400E399FA /* AppSettingsVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsVM.swift; sourceTree = "<group>"; };
@@ -212,6 +214,7 @@
 				6E66B0CF289F562A0099B907 /* Sidebar Views */,
 				6E66B0CA289F55180099B907 /* App Views */,
 				36B26B95288C722500859EFD /* Settings */,
+				AB671B8B28C9C7DB00B7B102 /* SigningSetupView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -657,6 +660,7 @@
 				8783D00B26B8C9E600171041 /* URLExtensions.swift in Sources */,
 				ABED59832887A32F004D782B /* MenuBarView.swift in Sources */,
 				538AAE7B26CD41E60009C7AC /* ProcessExtension.swift in Sources */,
+				AB671B8C28C9C7DB00B7B102 /* SigningSetupView.swift in Sources */,
 				92EE06D4274EA604002C907B /* PlayAppView.swift in Sources */,
 				B17FD04728C7B0D900B1D4CA /* AssetsExtractor.swift in Sources */,
 				9256220327491E4700728698 /* operations.m in Sources */,

--- a/PlayCover/Utils/SystemConfig.swift
+++ b/PlayCover/Utils/SystemConfig.swift
@@ -9,7 +9,7 @@ class SystemConfig {
 
     static var isFirstTimePlaySign = false
 
-    static let isPlaySignActive: Bool = isSIPDisabled() && isPRAMValid()
+    static let isPlaySignActive: Bool = isSIPDisabled() && isRunningAMFIEnabled()
 
     static func enablePlaySign(_ argc: String) -> Bool {
         shell.sudosh([
@@ -26,6 +26,14 @@ class SystemConfig {
 
     static func isPRAMValid() -> Bool {
         let check = shell.shell("nvram boot-args")
+        for option in NVRAM_OPTIONS where check.contains(option) {
+            return true
+        }
+        return false
+    }
+
+    static func isRunningAMFIEnabled() -> Bool {
+        let check = shell.shell("sysctl kern.bootargs")
         for option in NVRAM_OPTIONS where check.contains(option) {
             return true
         }

--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -20,6 +20,7 @@ struct MainView: View {
     @EnvironmentObject var integrity: AppIntegrity
 
     @Binding public var xcodeCliInstalled: Bool
+    @Binding public var isSigningSetupShown: Bool
 
     @State private var selectedView: Int? = -1
     @State private var navWidth: CGFloat = 0
@@ -29,7 +30,6 @@ struct MainView: View {
     @State private var xcodeInstallStatus: XcodeInstallStatus = .installing
     @State private var selectedBackgroundColor: Color = Color.accentColor
     @State private var selectedTextColor: Color = Color.black
-
     var body: some View {
         GeometryReader { viewGeom in
             NavigationView {
@@ -212,6 +212,9 @@ struct MainView: View {
                 .padding()
                 .frame(minWidth: 550, minHeight: 150)
             }
+                .sheet(isPresented: $isSigningSetupShown) {
+                    SignSetupView(isSigningSetupShown: $isSigningSetupShown)
+                }
         }
         .frame(minWidth: 675, minHeight: 330)
     }
@@ -301,9 +304,11 @@ struct SplitViewAccessor: NSViewRepresentable {
 
 struct MainView_Previews: PreviewProvider {
     @State static var xcodeCliInstalled = true
+    @State static var isSigningSetupShown = true
 
     static var previews: some View {
-        MainView(xcodeCliInstalled: $xcodeCliInstalled)
+        MainView(xcodeCliInstalled: $xcodeCliInstalled,
+                 isSigningSetupShown: $isSigningSetupShown)
             .environmentObject(InstallVM.shared)
             .environmentObject(AppsVM.shared)
             .environmentObject(StoreVM.shared)

--- a/PlayCover/Views/MenuBarView.swift
+++ b/PlayCover/Views/MenuBarView.swift
@@ -3,15 +3,20 @@
 //  PlayCover
 //
 
+import AppKit
 import SwiftUI
 
 struct PlayCoverMenuView: Commands {
+    @Binding var isSigningSetupShown: Bool
     var body: some Commands {
         CommandGroup(after: .systemServices) {
             Button("menubar.log.copy") {
                 Log.shared.logdata.copyToClipBoard()
             }
             .keyboardShortcut("L", modifiers: [.command, .option])
+            Button("Configure Signing") {
+                isSigningSetupShown = true
+            }
         }
     }
 }

--- a/PlayCover/Views/PlayCoverApp.swift
+++ b/PlayCover/Views/PlayCoverApp.swift
@@ -41,10 +41,12 @@ struct PlayCoverApp: App {
     @StateObject var updaterViewModel = UpdaterViewModel()
 
     @State var xcodeCliInstalled = shell.isXcodeCliToolsInstalled
+    @State var isSigningSetupShown = false
 
     var body: some Scene {
         WindowGroup {
-            MainView(xcodeCliInstalled: $xcodeCliInstalled)
+            MainView(xcodeCliInstalled: $xcodeCliInstalled,
+                     isSigningSetupShown: $isSigningSetupShown)
                 .environmentObject(InstallVM.shared)
                 .environmentObject(AppsVM.shared)
                 .environmentObject(StoreVM.shared)
@@ -57,7 +59,7 @@ struct PlayCoverApp: App {
         }
         .handlesExternalEvents(matching: ["{same path of URL?}"]) // create new window if doesn't exist
         .commands {
-            PlayCoverMenuView()
+            PlayCoverMenuView(isSigningSetupShown: $isSigningSetupShown)
             PlayCoverHelpMenuView(updaterViewModel: updaterViewModel)
             PlayCoverViewMenuView()
             SidebarCommands()

--- a/PlayCover/Views/SigningSetupView.swift
+++ b/PlayCover/Views/SigningSetupView.swift
@@ -113,10 +113,15 @@ struct SignSetupView: View {
                       dismissButton: .default(Text("OK")))
             }
             Divider()
-            Button("Dismiss", role: .cancel) {
-                isSigningSetupShown = false
+            HStack {
+                Button("Open PlayBook") {
+                    NSWorkspace.shared.open(
+                        URL(string: "https://docs.playcover.io/getting_started/troubleshoot_login")!)
+                }
+                Button("Dismiss", role: .cancel) {
+                    isSigningSetupShown = false
+                }
             }
-            .frame(maxWidth: .infinity)
         }
         .padding()
     }

--- a/PlayCover/Views/SigningSetupView.swift
+++ b/PlayCover/Views/SigningSetupView.swift
@@ -1,0 +1,20 @@
+//
+//  SignSetupView.swift
+//  PlayCover
+//
+//  Created by Venti on 08/09/2022.
+//
+
+import SwiftUI
+
+struct SignSetupView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct SignSetupView_Previews: PreviewProvider {
+    static var previews: some View {
+        SignSetupView()
+    }
+}

--- a/PlayCover/Views/SigningSetupView.swift
+++ b/PlayCover/Views/SigningSetupView.swift
@@ -8,13 +8,122 @@
 import SwiftUI
 
 struct SignSetupView: View {
+    @State var commandCopiedAlert = false
+
+    @Binding var isSigningSetupShown: Bool
+
+    var SIPEnabled = !SystemConfig.isSIPDisabled()
+    var AMFIEnabledInNVRAM = SystemConfig.isPRAMValid()
+    var AMFIEnabledInRunningOS = SystemConfig.isRunningAMFIEnabled()
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Group {
+            Text("Configure Package Signing")
+                .font(.largeTitle)
+                .foregroundColor(.gray)
+                .padding()
+
+            GroupBox {
+                Spacer()
+                HStack(alignment: .center) {
+                    Image(systemName: "questionmark.circle.fill")
+                        .help("""
+                        SIP is required to be fully to partially disabled in order for AMFI to be turned off.
+                        """)
+                    Text("System Integrity Protection: ")
+                        .font(.headline)
+                    Text("\(SIPEnabled ? "Enabled" : "Disabled")")
+                        .foregroundColor(SIPEnabled ? .red : .green)
+                        .font(.headline)
+                }
+                Divider()
+                HStack(alignment: .center) {
+                    Image(systemName: "questionmark.circle.fill")
+                        .help("""
+                        AMFI is required to be turned off in order to allow fake signing of apps, \
+                        which helps fixing certain issues with apps that verifies their integrity
+                        """)
+                    Text("Apple Mobile File Integrity: ")
+                        .font(.headline)
+                    if AMFIEnabledInNVRAM {
+                        if !AMFIEnabledInRunningOS {
+                            Text("Pending Reboot")
+                                .foregroundColor(.yellow)
+                                .font(.headline)
+                        } else {
+                            Text("Disabled")
+                                .foregroundColor(.green)
+                                .font(.headline)
+                        }
+                    } else {
+                        Text("Enabled")
+                            .foregroundColor(.red)
+                            .font(.headline)
+                    }
+                }
+                Spacer()
+            }
+            .padding()
+            Group {
+                if SIPEnabled {
+                    Text("Please disable SIP from Recovery Mode")
+                        .font(.subheadline)
+                    Spacer()
+                    Button("Shut down my Mac") {
+                        let source = "tell application \"Finder\"\nshut down\nend tell"
+                        let script = NSAppleScript(source: source)
+                        script?.executeAndReturnError(nil)
+                        isSigningSetupShown = false
+                    }
+                } else {
+                    if !AMFIEnabledInNVRAM && !AMFIEnabledInRunningOS {
+                        Text("Please disable AMFI")
+                            .font(.subheadline)
+                        Spacer()
+                        Button("Copy Command to Clipboard") {
+                            let disableCommand =
+                            """
+                            sudo nvram boot-args=\"amfi_get_out_of_my_way=0x1 ipc_control_port_options=0\" \
+                            && sudo reboot
+                            """
+                            NSPasteboard.general.declareTypes([NSPasteboard.PasteboardType.string], owner: nil)
+                            NSPasteboard.general.setString(disableCommand, forType: NSPasteboard.PasteboardType.string)
+                            commandCopiedAlert = true
+                        }
+                    } else if AMFIEnabledInNVRAM {
+                        if !AMFIEnabledInRunningOS {
+                            Text("AMFI Disabled. Please reboot")
+                                .font(.subheadline)
+                            Spacer()
+                            Button("Restart my Mac") {
+                                let source = "tell application \"Finder\"\nrestart\nend tell"
+                                let script = NSAppleScript(source: source)
+                                script?.executeAndReturnError(nil)
+                                isSigningSetupShown = false
+                            }
+                        } else {
+                            Text("Package Signing has been configured. You're good to go!")
+                        }
+                    }
+                }
+            }
+            .alert(isPresented: $commandCopiedAlert) {
+                Alert(title: Text("Command Copied!"),
+                      message: Text("Please paste and run the command in Terminal.app. Your Mac will reboot after"),
+                      dismissButton: .default(Text("OK")))
+            }
+            Divider()
+            Button("Dismiss", role: .cancel) {
+                isSigningSetupShown = false
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding()
     }
 }
 
 struct SignSetupView_Previews: PreviewProvider {
     static var previews: some View {
-        SignSetupView()
+        SignSetupView(isSigningSetupShown: .constant(true))
     }
 }

--- a/PlayCover/Views/SigningSetupView.swift
+++ b/PlayCover/Views/SigningSetupView.swift
@@ -22,6 +22,13 @@ struct SignSetupView: View {
                 .font(.largeTitle)
                 .foregroundColor(.gray)
                 .padding()
+            Text("""
+                    Package Signing helps fixing issues with apps that uses login, particularly games.
+
+                    After logging in, you may be able to turn Package Signing off, if you so choose.
+                    However, if you get logged out, you will need to enable Package Signing again
+                    """)
+            .multilineTextAlignment(.center)
 
             GroupBox {
                 Spacer()
@@ -114,7 +121,7 @@ struct SignSetupView: View {
             }
             Divider()
             HStack {
-                Button("Open PlayBook") {
+                Button("Help") {
                     NSWorkspace.shared.open(
                         URL(string: "https://docs.playcover.io/getting_started/troubleshoot_login")!)
                 }
@@ -122,6 +129,7 @@ struct SignSetupView: View {
                     isSigningSetupShown = false
                 }
             }
+            .fixedSize(horizontal: true, vertical: true)
         }
         .padding()
     }


### PR DESCRIPTION
This commit brings a new, guided approach for configuring app signing (which make login in apps like Genshin works)

The "wizard" guides the user through disabling SIP and disabling AMFI in a more visual manner.

Here is what it looks like:
Menu accessible via PlayCover > Configure Signing:
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/23693150/189166113-353fc846-a74b-4d5d-9051-16074b34f296.png">

AMFI:
![out](https://user-images.githubusercontent.com/23693150/189166819-ab2b472a-ce55-4b0a-aac0-4871f4b8edfc.gif)

Signing ready:
![image](https://user-images.githubusercontent.com/23693150/189167037-b6cb7d88-c3fc-4ce3-a13f-94e1d1f8883e.png)

