### PR TITLE
Fix automatic screen size detection

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -16,7 +16,7 @@ struct AppSettingsData: Codable {
     var iosDeviceModel = "iPad13,8"
     var windowWidth = 1920
     var windowHeight = 1080
-    var resolution = 2
+    var resolution = 1
     var aspectRatio = 1
     var notch: Bool = NSScreen.hasNotch()
     var bypass = false

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -296,6 +296,15 @@ struct GraphicsView: View {
         }
         return (height / heightRatio) * widthRatio
     }
+   func getHeightForNotch(_ width: Int, _ height: Int) -> Int {
+        let wFloat = Float(width)
+        let hFloat = Float(height)
+        if NSScreen.hasNotch() && (hFloat/wFloat)*16.0 > 10.3 && (hFloat/wFloat)*16.0 < 10.4 {
+            return Int((wFloat / 16) * 10)
+        } else {
+            return Int(height)
+        }
+    } 
 }
 
 struct JBBypassView: View {
@@ -373,15 +382,6 @@ struct MiscView: View {
                 }
             }
             .padding()
-    func getHeightForNotch(_ width: Int, _ height: Int) -> Int {
-        let wFloat = Float(width)
-        let hFloat = Float(height)
-        if NSScreen.hasNotch() && (hFloat/wFloat)*16.0 > 10.3 && (hFloat/wFloat)*16.0 < 10.4 {
-            return Int((wFloat / 16) * 10)
-        } else {
-            return Int(height)
-        }
-    }
 }
 
 struct InfoView: View {

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -296,7 +296,7 @@ struct GraphicsView: View {
         }
         return (height / heightRatio) * widthRatio
     }
-   func getHeightForNotch(_ width: Int, _ height: Int) -> Int {
+    func getHeightForNotch(_ width: Int, _ height: Int) -> Int {
         let wFloat = Float(width)
         let hFloat = Float(height)
         if NSScreen.hasNotch() && (hFloat/wFloat)*16.0 > 10.3 && (hFloat/wFloat)*16.0 < 10.4 {
@@ -304,7 +304,7 @@ struct GraphicsView: View {
         } else {
             return Int(height)
         }
-    } 
+    }
 }
 
 struct JBBypassView: View {
@@ -382,6 +382,8 @@ struct MiscView: View {
                 }
             }
             .padding()
+        }
+    }
 }
 
 struct InfoView: View {

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -206,6 +206,12 @@ struct GraphicsView: View {
                         }
                         .pickerStyle(.radioGroup)
                         .horizontalRadioGroupLayout()
+                    } else if settings.settings.resolution == 1 {
+                        let width = Int(NSScreen.main?.frame.width ?? 1920)
+                        let height = getHeightForNotch(width, Int(NSScreen.main?.frame.height ?? 1080))
+                        Text("settings.text.detectedResolution")
+                        Spacer()
+                        Text("\(width) x \(height)")
                     }
                 }
                 HStack {
@@ -242,8 +248,8 @@ struct GraphicsView: View {
         switch settings.settings.resolution {
         // Adaptive resolution = Auto
         case 1:
-            width = Int(NSScreen.main?.visibleFrame.width ?? 1920)
-            height = Int(NSScreen.main?.visibleFrame.width ?? 1080)
+            width = Int(NSScreen.main?.frame.width ?? 1920)
+            height = getHeightForNotch(width, Int(NSScreen.main?.frame.height ?? 1080))
         // Adaptive resolution = 1080p
         case 2:
             height = 1080
@@ -367,6 +373,13 @@ struct MiscView: View {
                 }
             }
             .padding()
+    func getHeightForNotch(_ width: Int, _ height: Int) -> Int {
+        let wFloat = Float(width)
+        let hFloat = Float(height)
+        if NSScreen.hasNotch() && (hFloat/wFloat)*16.0 > 10.3 && (hFloat/wFloat)*16.0 < 10.4 {
+            return Int((wFloat / 16) * 10)
+        } else {
+            return Int(height)
         }
     }
 }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -96,6 +96,7 @@
 "settings.picker.adaptiveRes.5" = "Custom";
 "settings.text.customHeight" = "Height";
 "settings.text.customWidth" = "Width";
+"settings.text.detectedResolution" = "Detected Resolution:";
 "settings.picker.aspectRatio" = "Aspect ratio:";
 "settings.toggle.disableDisplaySleep" = "Disable display sleep";
 "settings.toggle.disableDisplaySleep.help" = "Prevent display from turning off while this app is running";


### PR DESCRIPTION
Previous builds of PlayCover had an issue where the automatic screen size option would not use the correct aspect ratio (and apparently eventually became square?)

This fix sets the window size to the size of the full screen. If a notch is detected, it forces the aspect ratio to 16:10, which is the correct ratio of the screen size without the notch.