### PR TITLE
Updated IPA Source Management

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		6ED6ACA428A949A30040D234 /* AppSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED6ACA328A949A30040D234 /* AppSettingsView.swift */; };
 		6ED6ACA628A96E570040D234 /* DeletePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED6ACA528A96E570040D234 /* DeletePreferences.swift */; };
 		6EE8265028E8AB2B003935BC /* DownloadVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE8264F28E8AB2B003935BC /* DownloadVM.swift */; };
+		6EF893D528F34CD1004AB6D9 /* NetworkVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF893D428F34CD1004AB6D9 /* NetworkVM.swift */; };
 		8783CFFB26B8C52D00171041 /* PlayCoverApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8783CFFA26B8C52D00171041 /* PlayCoverApp.swift */; };
 		8783CFFF26B8C52E00171041 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8783CFFE26B8C52E00171041 /* Assets.xcassets */; };
 		8783D00226B8C52E00171041 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8783D00126B8C52E00171041 /* Preview Assets.xcassets */; };
@@ -127,6 +128,7 @@
 		6ED6ACA328A949A30040D234 /* AppSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsView.swift; sourceTree = "<group>"; };
 		6ED6ACA528A96E570040D234 /* DeletePreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeletePreferences.swift; sourceTree = "<group>"; };
 		6EE8264F28E8AB2B003935BC /* DownloadVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadVM.swift; sourceTree = "<group>"; };
+		6EF893D428F34CD1004AB6D9 /* NetworkVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkVM.swift; sourceTree = "<group>"; };
 		81C2786C28D4A5A300E208D7 /* pt-br */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-br"; path = "pt-br.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		8783CFF726B8C52D00171041 /* PlayCover.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PlayCover.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8783CFFA26B8C52D00171041 /* PlayCoverApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayCoverApp.swift; sourceTree = "<group>"; };
@@ -286,6 +288,7 @@
 			children = (
 				B1084E1E28AA80F400E399FA /* AppSettingsVM.swift */,
 				9272F19C273B74C800DFBEF1 /* AppsVM.swift */,
+				6EF893D428F34CD1004AB6D9 /* NetworkVM.swift */,
 				6EE8264F28E8AB2B003935BC /* DownloadVM.swift */,
 				928C01D8272E162C007EB2DF /* InstallVM.swift */,
 				6E66B0BE289DE6240099B907 /* StoreVM.swift */,
@@ -666,6 +669,7 @@
 				6ED6379D28DAAAC100B506FA /* IPASourceSettings.swift in Sources */,
 				5314D1EE26C402EC00A0A727 /* Shell.swift in Sources */,
 				6E7CA16528B4D02900216CD8 /* ITunesResponse.swift in Sources */,
+				6EF893D528F34CD1004AB6D9 /* NetworkVM.swift in Sources */,
 				8783D00B26B8C9E600171041 /* URLExtensions.swift in Sources */,
 				6EB4B57428C93E0600630890 /* LegacySettings.swift in Sources */,
 				ABED59832887A32F004D782B /* MenuBarView.swift in Sources */,

--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		6E7CA16528B4D02900216CD8 /* ITunesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7CA16428B4D02900216CD8 /* ITunesResponse.swift */; };
 		6E7CA16728B4EEAE00216CD8 /* Keymapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7CA16628B4EEAE00216CD8 /* Keymapping.swift */; };
 		6EB4B57428C93E0600630890 /* LegacySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB4B57328C93E0600630890 /* LegacySettings.swift */; };
+		6ED6379D28DAAAC100B506FA /* IPASourceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED6379C28DAAAC100B506FA /* IPASourceSettings.swift */; };
 		6ED6ACA428A949A30040D234 /* AppSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED6ACA328A949A30040D234 /* AppSettingsView.swift */; };
 		6ED6ACA628A96E570040D234 /* DeletePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED6ACA528A96E570040D234 /* DeletePreferences.swift */; };
 		8783CFFB26B8C52D00171041 /* PlayCoverApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8783CFFA26B8C52D00171041 /* PlayCoverApp.swift */; };
@@ -121,6 +122,7 @@
 		6EB4B57328C93E0600630890 /* LegacySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacySettings.swift; sourceTree = "<group>"; };
 		6EC228A028B14A0600D7D73A /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		6EC228A128B1830F00D7D73A /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
+		6ED6379C28DAAAC100B506FA /* IPASourceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPASourceSettings.swift; sourceTree = "<group>"; };
 		6ED6ACA328A949A30040D234 /* AppSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsView.swift; sourceTree = "<group>"; };
 		6ED6ACA528A96E570040D234 /* DeletePreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeletePreferences.swift; sourceTree = "<group>"; };
 		81C2786C28D4A5A300E208D7 /* pt-br */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-br"; path = "pt-br.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 			children = (
 				3665EF8828832400007CF915 /* PlayCoverSettingsView.swift */,
 				36B26B96288C724600859EFD /* UpdateSettings.swift */,
+				6ED6379C28DAAAC100B506FA /* IPASourceSettings.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -657,6 +660,7 @@
 				28361D5E2892781200B35EDB /* RestoreGenshinUserData.swift in Sources */,
 				36B26B97288C724600859EFD /* UpdateSettings.swift in Sources */,
 				8783CFFB26B8C52D00171041 /* PlayCoverApp.swift in Sources */,
+				6ED6379D28DAAAC100B506FA /* IPASourceSettings.swift in Sources */,
 				5314D1EE26C402EC00A0A727 /* Shell.swift in Sources */,
 				6E7CA16528B4D02900216CD8 /* ITunesResponse.swift in Sources */,
 				8783D00B26B8C9E600171041 /* URLExtensions.swift in Sources */,

--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		6ED6379D28DAAAC100B506FA /* IPASourceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED6379C28DAAAC100B506FA /* IPASourceSettings.swift */; };
 		6ED6ACA428A949A30040D234 /* AppSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED6ACA328A949A30040D234 /* AppSettingsView.swift */; };
 		6ED6ACA628A96E570040D234 /* DeletePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED6ACA528A96E570040D234 /* DeletePreferences.swift */; };
+		6EE8265028E8AB2B003935BC /* DownloadVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE8264F28E8AB2B003935BC /* DownloadVM.swift */; };
 		8783CFFB26B8C52D00171041 /* PlayCoverApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8783CFFA26B8C52D00171041 /* PlayCoverApp.swift */; };
 		8783CFFF26B8C52E00171041 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8783CFFE26B8C52E00171041 /* Assets.xcassets */; };
 		8783D00226B8C52E00171041 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8783D00126B8C52E00171041 /* Preview Assets.xcassets */; };
@@ -125,6 +126,7 @@
 		6ED6379C28DAAAC100B506FA /* IPASourceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPASourceSettings.swift; sourceTree = "<group>"; };
 		6ED6ACA328A949A30040D234 /* AppSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsView.swift; sourceTree = "<group>"; };
 		6ED6ACA528A96E570040D234 /* DeletePreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeletePreferences.swift; sourceTree = "<group>"; };
+		6EE8264F28E8AB2B003935BC /* DownloadVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadVM.swift; sourceTree = "<group>"; };
 		81C2786C28D4A5A300E208D7 /* pt-br */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-br"; path = "pt-br.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		8783CFF726B8C52D00171041 /* PlayCover.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PlayCover.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8783CFFA26B8C52D00171041 /* PlayCoverApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayCoverApp.swift; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 			children = (
 				B1084E1E28AA80F400E399FA /* AppSettingsVM.swift */,
 				9272F19C273B74C800DFBEF1 /* AppsVM.swift */,
+				6EE8264F28E8AB2B003935BC /* DownloadVM.swift */,
 				928C01D8272E162C007EB2DF /* InstallVM.swift */,
 				6E66B0BE289DE6240099B907 /* StoreVM.swift */,
 				6E66B0D828A135360099B907 /* ToastVM.swift */,
@@ -671,6 +674,7 @@
 				92EE06D4274EA604002C907B /* PlayAppView.swift in Sources */,
 				B17FD04728C7B0D900B1D4CA /* AssetsExtractor.swift in Sources */,
 				9256220327491E4700728698 /* operations.m in Sources */,
+				6EE8265028E8AB2B003935BC /* DownloadVM.swift in Sources */,
 				6E06193A28B3C42E0012C771 /* DeleteGenshinAccountView.swift in Sources */,
 				28361D662892800200B35EDB /* DeleteStoredGenshinUserData.swift in Sources */,
 				53D9DAF326C1849D0071959E /* PlayCoverError.swift in Sources */,

--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -183,7 +183,11 @@ class Installer {
 
     /// Generates a wrapper bundle for an iOS app that allows it to be launched from Finder and other macOS UIs
     static func wrap(_ baseApp: BaseApp) throws -> URL {
-        let location = PlayTools.playCoverContainer.appendingPathComponent(baseApp.url.lastPathComponent)
+        let info = AppInfo(contentsOf: baseApp.url
+            .appendingPathComponent("Info.plist"))
+        let location = PlayTools.playCoverContainer
+            .appendingPathComponent(info.displayName)
+            .appendingPathExtension("app")
         if FileManager.default.fileExists(atPath: location.path) {
             try FileManager.default.removeItem(at: location)
         }

--- a/PlayCover/Model/AppInfo.swift
+++ b/PlayCover/Model/AppInfo.swift
@@ -132,7 +132,7 @@ public class AppInfo {
     }
 
     var bundleName: String {
-        if self[string: "CFBundleName"] == nil {
+        if self[string: "CFBundleName"] == nil || self[string: "CFBundleName"] == "" {
             return self[string: "CFBundleDisplayName"]!
         } else {
             return self[string: "CFBundleName"]!
@@ -140,7 +140,7 @@ public class AppInfo {
     }
 
     var displayName: String {
-        if self[string: "CFBundleDisplayName"] == nil {
+        if self[string: "CFBundleDisplayName"] == nil || self[string: "CFBundleDisplayName"] == "" {
             return self[string: "CFBundleName"]!
         } else {
             return self[string: "CFBundleDisplayName"]!

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -84,12 +84,9 @@ class PlayApp: BaseApp {
 
     var icon: NSImage? {
         var highestRes: NSImage?
-        let appDirectoryURL = PlayTools.playCoverContainer
-            .appendingPathComponent(info.executableName)
-            .appendingPathExtension("app")
-        let appDirectoryPath = "\(appDirectoryURL.relativePath)/"
+        let appDirectoryPath = "\(url.relativePath)/"
 
-        if let assetsExtractor = try? AssetsExtractor(appUrl: appDirectoryURL) {
+        if let assetsExtractor = try? AssetsExtractor(appUrl: url) {
             for icon in assetsExtractor.extractIcons() {
                 highestRes = largerImage(image: icon, compareTo: highestRes)
             }

--- a/PlayCover/PlayCoverError.swift
+++ b/PlayCover/PlayCoverError.swift
@@ -5,6 +5,7 @@ import SwiftUI
 enum PlayCoverError: Error {
     case infoPlistNotFound
     case waitInstallation
+    case waitDownload
     case appEncrypted
     case appCorrupted
     case appProhibited
@@ -18,6 +19,8 @@ extension PlayCoverError: LocalizedError {
             return NSLocalizedString("error.corruptedIPA", comment: "")
         case .waitInstallation:
             return NSLocalizedString("error.waitInstallation", comment: "")
+        case .waitDownload:
+            return NSLocalizedString("error.waitDownload", comment: "")
         case .appEncrypted:
             return NSLocalizedString("error.appEncrypted", comment: "")
         case .appCorrupted:

--- a/PlayCover/ViewModel/DownloadVM.swift
+++ b/PlayCover/ViewModel/DownloadVM.swift
@@ -1,0 +1,16 @@
+//
+//  DownloadVM.swift
+//  PlayCover
+//
+//  Created by Isaac Marovitz on 01/10/2022.
+//
+
+import Foundation
+
+class DownloadVM: ObservableObject {
+    @Published var progress: Double = 0
+    @Published var downloading = false
+    @Published var storeAppData: StoreAppData?
+
+    static let shared = DownloadVM()
+}

--- a/PlayCover/ViewModel/NetworkVM.swift
+++ b/PlayCover/ViewModel/NetworkVM.swift
@@ -1,0 +1,91 @@
+//
+//  NetworkVM.swift
+//  PlayCover
+//
+//  Created by Isaac Marovitz on 09/10/2022.
+//
+
+// import Network
+
+// I wanted to use the Network API for this, but it's completely missing
+// so shitty old API it is :D
+
+/*class NetworkVM: ObservableObject {
+
+    static let shared = NetworkVM()
+
+    @Published var networkConnection = false
+
+    private init() {
+        configureNetworkMonitor()
+    }
+
+    func configureNetworkMonitor() {
+        let monitor = NWPathMonitor()
+
+        monitor.pathUpdateHandler = { path in
+            if path.status != .satisfied {
+                self.networkConnection = false
+            } else {
+                self.networkConnection = true
+            }
+        }
+
+        monitor.start(queue: DispatchQueue.global(qos: .background))
+    }
+}
+*/
+
+import SystemConfiguration
+import Foundation
+
+class NetworkVM {
+    static func isConnectedToNetwork() -> Bool {
+        guard let flags = getFlags() else { return false }
+        let isReachable = flags.contains(.reachable)
+        let needsConnection = flags.contains(.connectionRequired)
+        let result = (isReachable && !needsConnection)
+
+        if !result {
+            let networkToastExists = ToastVM.shared.toasts.contains { $0.toastType == .network }
+            if !networkToastExists {
+                ToastVM.shared.showToast(toastType: .network, toastDetails: String("No internet connection!"))
+            }
+        }
+
+        return result
+    }
+
+    static func getFlags() -> SCNetworkReachabilityFlags? {
+        guard let reachability = ipv4Reachability() ?? ipv6Reachability() else { return nil }
+        var flags = SCNetworkReachabilityFlags()
+        if !SCNetworkReachabilityGetFlags(reachability, &flags) {
+            return nil
+        }
+        return flags
+    }
+
+    static func ipv4Reachability() -> SCNetworkReachability? {
+        var zeroAddress = sockaddr_in()
+        zeroAddress.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        zeroAddress.sin_family = sa_family_t(AF_INET)
+
+        return withUnsafePointer(to: &zeroAddress, {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                SCNetworkReachabilityCreateWithAddress(nil, $0)
+            }
+        })
+    }
+
+    static func ipv6Reachability() -> SCNetworkReachability? {
+        var zeroAddress = sockaddr_in6()
+        zeroAddress.sin6_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        zeroAddress.sin6_family = sa_family_t(AF_INET6)
+
+        return withUnsafePointer(to: &zeroAddress, {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                SCNetworkReachabilityCreateWithAddress(nil, $0)
+            }
+        })
+    }
+}

--- a/PlayCover/ViewModel/NetworkVM.swift
+++ b/PlayCover/ViewModel/NetworkVM.swift
@@ -49,7 +49,10 @@ class NetworkVM {
         if !result {
             let networkToastExists = ToastVM.shared.toasts.contains { $0.toastType == .network }
             if !networkToastExists {
-                ToastVM.shared.showToast(toastType: .network, toastDetails: String("No internet connection!"))
+                ToastVM.shared.showToast(
+                    toastType: .network,
+                    toastDetails: NSLocalizedString("ipaLibrary.noNetworkConnection.toast", comment: "")
+                )
             }
         }
 

--- a/PlayCover/ViewModel/StoreVM.swift
+++ b/PlayCover/ViewModel/StoreVM.swift
@@ -21,9 +21,10 @@ class StoreVM: ObservableObject {
 
     func appendAppData(_ data: [StoreAppData]) {
         for element in data {
-            if let index = apps.firstIndex(where: {$0.id == element.id}) {
+            if let index = apps.firstIndex(where: {$0.bundleID == element.bundleID}) {
                 if apps[index].version < element.version {
                     apps[index] = element
+                    continue
                 }
             } else {
                 apps.append(element)
@@ -139,15 +140,9 @@ class StoreVM: ObservableObject {
 }
 
 struct StoreAppData: Decodable {
-    enum Region: String, Decodable {
-        // swiftlint:disable identifier_name
-        case Global, CN
-    }
-
-    var id: String
+    var bundleID: String
     let name: String
     let version: String
-    let icon: String
+    let itunesLookup: String
     let link: String
-    let region: Region
 }

--- a/PlayCover/ViewModel/StoreVM.swift
+++ b/PlayCover/ViewModel/StoreVM.swift
@@ -16,6 +16,7 @@ class StoreVM: ObservableObject {
     }
 
     @Published var apps: [StoreAppData] = []
+    @Published var filteredApps: [StoreAppData] = []
     @Published var sources: [SourceData] = []
 
     func appendAppData(_ data: [StoreAppData]) {
@@ -28,16 +29,17 @@ class StoreVM: ObservableObject {
                 apps.append(element)
             }
         }
+        fetchApps()
     }
 
-    func fetchApps() -> [StoreAppData] {
+    func fetchApps() {
         var result = apps
         if !uif.searchText.isEmpty {
             result = result.filter({
                 $0.name.lowercased().contains(uif.searchText.lowercased())
             })
         }
-        return result
+        filteredApps = result
     }
 
     func resolveSources() {
@@ -79,6 +81,7 @@ class StoreVM: ObservableObject {
                 return
             }
         }
+        fetchApps()
     }
 
     func deleteSource(_ selected: inout Set<UUID>) {

--- a/PlayCover/ViewModel/StoreVM.swift
+++ b/PlayCover/ViewModel/StoreVM.swift
@@ -84,6 +84,8 @@ class StoreVM: ObservableObject {
     }
 
     func resolveSources() {
+        if !NetworkVM.isConnectedToNetwork() { return }
+
         apps.removeAll()
         for index in 0..<sources.endIndex {
             sources[index].status = .checking

--- a/PlayCover/ViewModel/StoreVM.swift
+++ b/PlayCover/ViewModel/StoreVM.swift
@@ -139,7 +139,7 @@ class StoreVM: ObservableObject {
     }
 }
 
-struct StoreAppData: Decodable {
+struct StoreAppData: Decodable, Equatable {
     var bundleID: String
     let name: String
     let version: String

--- a/PlayCover/ViewModel/ToastVM.swift
+++ b/PlayCover/ViewModel/ToastVM.swift
@@ -24,5 +24,5 @@ struct ToastInfo: Hashable {
 }
 
 enum ToastType {
-    case notice, error
+    case notice, error, network
 }

--- a/PlayCover/Views/App Views/StoreAppView.swift
+++ b/PlayCover/Views/App Views/StoreAppView.swift
@@ -44,13 +44,12 @@ struct StoreAppView: View {
             })
 
             observation = downloadTask.progress.observe(\.fractionCompleted) { progress, _ in
-                DispatchQueue.main.async {
-                    downloadVM.progress = progress.fractionCompleted
-                }
+                downloadVM.progress = progress.fractionCompleted
             }
 
             downloadTask.resume()
             downloadVM.downloading = true
+            downloadVM.progress = 0
             downloadVM.storeAppData = app
         } else {
             Log.shared.error(PlayCoverError.waitDownload)

--- a/PlayCover/Views/App Views/StoreAppView.swift
+++ b/PlayCover/Views/App Views/StoreAppView.swift
@@ -111,19 +111,25 @@ struct StoreAppConditionalView: View {
                 HStack(alignment: .center, spacing: 0) {
                     Image(systemName: "arrow.down.circle")
                         .padding(.leading, 15)
-                    AsyncImage(url: URL(string: itunesData?.results[0].artworkUrl512 ?? "")) { image in
-                        image
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                    } placeholder: {
-                        ProgressView()
-                            .progressViewStyle(.circular)
+                    ZStack {
+                        AsyncImage(url: URL(string: itunesData?.results[0].artworkUrl512 ?? "")) { image in
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                        } placeholder: {
+                            ProgressView()
+                                .progressViewStyle(.circular)
+                        }
+                            .frame(width: 30, height: 30)
+                            .cornerRadius(7.5)
+                            .shadow(radius: 1)
+                            .padding(.horizontal, 15)
+                            .padding(.vertical, 5)
+                        if downloadVM.downloading && downloadVM.storeAppData == app {
+                            ProgressView(value: downloadVM.progress)
+                                .progressViewStyle(.circular)
+                        }
                     }
-                        .frame(width: 30, height: 30)
-                        .cornerRadius(7.5)
-                        .shadow(radius: 1)
-                        .padding(.horizontal, 15)
-                        .padding(.vertical, 5)
                     Text(app.name)
                         .foregroundColor(selected?.bundleID == app.bundleID ?
                                          selectedTextColor : Color.primary)

--- a/PlayCover/Views/App Views/StoreAppView.swift
+++ b/PlayCover/Views/App Views/StoreAppView.swift
@@ -194,7 +194,9 @@ struct StoreAppConditionalView: View {
     }
 
     func getITunesData(_ itunesLookup: String) async -> ITunesResponse? {
-        let url = URL(string: itunesLookup)!
+        if !NetworkVM.isConnectedToNetwork() { return nil }
+        guard let url = URL(string: itunesLookup) else { return nil }
+
         do {
             let (data, _) = try await URLSession.shared.data(for: URLRequest(url: url))
             let decoder = JSONDecoder()
@@ -203,7 +205,7 @@ struct StoreAppConditionalView: View {
                 return jsonResult
             }
         } catch {
-            Log.shared.error(error)
+            print("Error getting iTunes data from URL: \(itunesLookup): \(error)")
         }
 
         return nil

--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -41,7 +41,7 @@ struct MainView: View {
                             Label("sidebar.appLibrary", systemImage: "square.grid.2x2")
                         }
                         NavigationLink(destination: IPALibraryView(selectedBackgroundColor: $selectedBackgroundColor,
-                                                                   selectedTextColor: $selectedTextColor),
+                                                                   selectedTextColor: $selectedTextColor).environmentObject(store),
                                        tag: 2, selection: self.$selectedView) {
                             Label("sidebar.ipaLibrary", systemImage: "arrow.down.circle")
                         }

--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -41,7 +41,8 @@ struct MainView: View {
                             Label("sidebar.appLibrary", systemImage: "square.grid.2x2")
                         }
                         NavigationLink(destination: IPALibraryView(selectedBackgroundColor: $selectedBackgroundColor,
-                                                                   selectedTextColor: $selectedTextColor).environmentObject(store),
+                                                                   selectedTextColor: $selectedTextColor)
+                            .environmentObject(store),
                                        tag: 2, selection: self.$selectedView) {
                             Label("sidebar.ipaLibrary", systemImage: "arrow.down.circle")
                         }

--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -14,7 +14,6 @@ struct MainView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.controlActiveState) var controlActiveState
 
-    @EnvironmentObject var install: InstallVM
     @EnvironmentObject var apps: AppsVM
     @EnvironmentObject var store: StoreVM
     @EnvironmentObject var integrity: AppIntegrity
@@ -107,6 +106,7 @@ struct MainView: View {
                     ToastView()
                         .environmentObject(ToastVM.shared)
                         .environmentObject(InstallVM.shared)
+                        .environmentObject(DownloadVM.shared)
                         .frame(width: collapsed ? viewWidth : (viewWidth - navWidth))
                         .animation(.spring(), value: collapsed)
                 }

--- a/PlayCover/Views/MenuBarView.swift
+++ b/PlayCover/Views/MenuBarView.swift
@@ -89,7 +89,7 @@ struct PlayCoverViewMenuView: Commands {
             }
         }
         CommandGroup(before: .sidebar) {
-            Button("Resolve Sources") {
+            Button("preferences.button.resolveSources") {
                 StoreVM.shared.resolveSources()
             }
             .keyboardShortcut("R", modifiers: [.command])

--- a/PlayCover/Views/MenuBarView.swift
+++ b/PlayCover/Views/MenuBarView.swift
@@ -59,6 +59,8 @@ struct PlayCoverViewMenuView: Commands {
             Button("menubar.exportToSideloady") {
                 if InstallVM.shared.installing {
                     Log.shared.error(PlayCoverError.waitInstallation)
+                } else if DownloadVM.shared.downloading {
+                    Log.shared.error(PlayCoverError.waitDownload)
                 } else {
                     NSOpenPanel.selectIPA { result in
                         if case .success(let url) = result {

--- a/PlayCover/Views/MenuBarView.swift
+++ b/PlayCover/Views/MenuBarView.swift
@@ -88,5 +88,12 @@ struct PlayCoverViewMenuView: Commands {
                 }
             }
         }
+        CommandGroup(before: .sidebar) {
+            Button("Resolve Sources") {
+                StoreVM.shared.resolveSources()
+            }
+            .keyboardShortcut("R", modifiers: [.command])
+            Divider()
+        }
     }
 }

--- a/PlayCover/Views/PlayCoverApp.swift
+++ b/PlayCover/Views/PlayCoverApp.swift
@@ -35,6 +35,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 struct PlayCoverApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject var updaterViewModel = UpdaterViewModel()
+    var storeVM = StoreVM.shared
 
     @State var xcodeCliInstalled = shell.isXcodeCliToolsInstalled
     @State var isSigningSetupShown = false
@@ -45,7 +46,7 @@ struct PlayCoverApp: App {
                      isSigningSetupShown: $isSigningSetupShown)
                 .environmentObject(InstallVM.shared)
                 .environmentObject(AppsVM.shared)
-                .environmentObject(StoreVM.shared)
+                .environmentObject(storeVM)
                 .environmentObject(AppIntegrity())
                 .onAppear {
                     NSWindow.allowsAutomaticWindowTabbing = false
@@ -63,6 +64,7 @@ struct PlayCoverApp: App {
 
         Settings {
             PlayCoverSettingsView(updaterViewModel: updaterViewModel)
+                .environmentObject(storeVM)
         }
     }
 }

--- a/PlayCover/Views/PlayCoverApp.swift
+++ b/PlayCover/Views/PlayCoverApp.swift
@@ -56,10 +56,10 @@ struct PlayCoverApp: App {
         }
         .handlesExternalEvents(matching: ["{same path of URL?}"]) // create new window if doesn't exist
         .commands {
+            SidebarCommands()
             PlayCoverMenuView(isSigningSetupShown: $isSigningSetupShown)
             PlayCoverHelpMenuView(updaterViewModel: updaterViewModel)
             PlayCoverViewMenuView()
-            SidebarCommands()
         }
 
         Settings {

--- a/PlayCover/Views/Settings/IPASourceSettings.swift
+++ b/PlayCover/Views/Settings/IPASourceSettings.swift
@@ -136,7 +136,7 @@ struct StatusBadgeView: View {
         })
         .buttonStyle(.plain)
         .popover(isPresented: $showingPopover) {
-            Text(popoverText)
+            Text(NSLocalizedString(popoverText, comment: ""))
                 .padding(10)
         }
     }

--- a/PlayCover/Views/Settings/IPASourceSettings.swift
+++ b/PlayCover/Views/Settings/IPASourceSettings.swift
@@ -33,13 +33,13 @@ struct IPASourceSettings: View {
                     Button(action: {
                         addSource()
                     }, label: {
-                        Text("Add Source")
+                        Text("preferences.button.addSource")
                             .frame(width: 130)
                     })
                     Button(action: {
                         storeVM.deleteSource(&selected)
                     }, label: {
-                        Text("Delete Source")
+                        Text("preferences.button.deleteSource")
                             .frame(width: 130)
                     })
                     .disabled(!selectedNotEmpty)
@@ -48,14 +48,14 @@ struct IPASourceSettings: View {
                     Button(action: {
                         storeVM.moveSourceUp(&selected)
                     }, label: {
-                        Text("Move Source Up")
+                        Text("preferences.button.moveSourceUp")
                             .frame(width: 130)
                     })
                     .disabled(!selectedNotEmpty)
                     Button(action: {
                         storeVM.moveSourceDown(&selected)
                     }, label: {
-                        Text("Move Source Down")
+                        Text("preferences.button.moveSourceDown")
                             .frame(width: 130)
                     })
                     .disabled(!selectedNotEmpty)
@@ -64,7 +64,7 @@ struct IPASourceSettings: View {
                     Button(action: {
                         storeVM.resolveSources()
                     }, label: {
-                        Text("Resolve Sources")
+                        Text("preferences.button.resolveSources")
                             .frame(width: 130)
                     })
                 }
@@ -102,17 +102,17 @@ struct SourceView: View {
             case .valid:
                 StatusBadgeView(imageName: "checkmark.circle.fill",
                                 imageColor: .green,
-                                popoverText: "Link valid",
+                                popoverText: "preferences.popover.valid",
                                 showingPopover: $showingPopover)
             case .badurl:
                 StatusBadgeView(imageName: "xmark.circle.fill",
                                 imageColor: .red,
-                                popoverText: "URL invalid",
+                                popoverText: "preferences.popover.badurl",
                                 showingPopover: $showingPopover)
             case .badjson:
                 StatusBadgeView(imageName: "xmark.circle.fill",
                                 imageColor: .red,
-                                popoverText: "JSON not found or invalid",
+                                popoverText: "preferences.popover.badjson",
                                 showingPopover: $showingPopover)
             case .checking:
                 EmptyView()
@@ -156,7 +156,7 @@ struct AddSourceView: View {
 
     var body: some View {
         VStack {
-            TextField(text: $newSource, label: {Text("Source URL...")})
+            TextField(text: $newSource, label: {Text("preferences.textfield.url")})
             Spacer()
                 .frame(height: 20)
             HStack {
@@ -164,17 +164,17 @@ struct AddSourceView: View {
                 case .valid:
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundColor(.green)
-                    Text("Link valid")
+                    Text("preferences.popover.valid")
                         .font(.system(.subheadline))
                 case .badurl:
                     Image(systemName: "xmark.circle.fill")
                         .foregroundColor(.red)
-                    Text("URL invalid")
+                    Text("preferences.popover.badurl")
                         .font(.system(.subheadline))
                 case .badjson:
                     Image(systemName: "xmark.circle.fill")
                         .foregroundColor(.red)
-                    Text("JSON not found or invalid")
+                    Text("preferences.popover.badjson")
                         .font(.system(.subheadline))
                 case .checking:
                     EmptyView()
@@ -183,7 +183,7 @@ struct AddSourceView: View {
                 Button(action: {
                     addSourceSheet.toggle()
                 }, label: {
-                    Text("Cancel")
+                    Text("button.Cancel")
                 })
                 Button(action: {
                     if newSourceURL != nil {
@@ -191,7 +191,7 @@ struct AddSourceView: View {
                         addSourceSheet.toggle()
                     }
                 }, label: {
-                    Text("Done")
+                    Text("button.OK")
                 })
                 .tint(.accentColor)
                 .keyboardShortcut(.defaultAction)

--- a/PlayCover/Views/Settings/IPASourceSettings.swift
+++ b/PlayCover/Views/Settings/IPASourceSettings.swift
@@ -11,6 +11,24 @@ struct SourceData: Identifiable, Hashable {
     var id = UUID()
     var source: String
     var status: SourceValidation = .valid
+
+    enum SourceDataKeys: String, CodingKey {
+        case source
+    }
+}
+
+extension SourceData: Encodable {
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: SourceDataKeys.self)
+        try container.encode(source, forKey: .source)
+    }
+}
+
+extension SourceData: Decodable {
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: SourceDataKeys.self)
+        source = try values.decode(String.self, forKey: .source)
+    }
 }
 
 struct IPASourceSettings: View {

--- a/PlayCover/Views/Settings/IPASourceSettings.swift
+++ b/PlayCover/Views/Settings/IPASourceSettings.swift
@@ -1,0 +1,148 @@
+//
+//  IPASourceSettings.swift
+//  PlayCover
+//
+//  Created by Isaac Marovitz on 20/09/2022.
+//
+
+import SwiftUI
+
+struct SourceData: Identifiable, Hashable {
+    var id = UUID()
+    var source: String
+}
+
+struct IPASourceSettings: View {
+    @State var selected = Set<UUID>()
+    @State var selectedNotEmpty = false
+    @State var addSourceSheet = false
+
+    @State var sources: [SourceData] = [
+        SourceData(source: "https://www.ipasrcool.net"),
+        SourceData(source: "https://super.cool.app"),
+        SourceData(source: "https://www.super-dooper-derypt.org"),
+        SourceData(source: "https://www.ipasrcool.net"),
+        SourceData(source: "https://super.cool.app"),
+        SourceData(source: "https://www.super-dooper-derypt.org"),
+        SourceData(source: "https://www.ipasrcool.net"),
+        SourceData(source: "https://super.cool.app"),
+        SourceData(source: "https://www.super-dooper-derypt.org")
+    ]
+
+    var body: some View {
+        Form {
+            HStack {
+                List(sources, id: \.id, selection: $selected) { name in
+                    Text(name.source)
+                }
+                .listStyle(.bordered(alternatesRowBackgrounds: true))
+                Spacer()
+                    .frame(width: 20)
+                VStack {
+                    Button(action: {
+                        addSource()
+                    }, label: {
+                        Text("Add Source")
+                            .frame(width: 130)
+                    })
+                    Button(action: {
+                        deleteSource()
+                    }, label: {
+                        Text("Delete Source")
+                            .frame(width: 130)
+                    })
+                    .disabled(!selectedNotEmpty)
+                    Spacer()
+                        .frame(height: 20)
+                    Button(action: {
+                        moveSourceUp()
+                    }, label: {
+                        Text("Move Source Up")
+                            .frame(width: 130)
+                    })
+                    .disabled(!selectedNotEmpty)
+                    Button(action: {
+                        moveSourceDown()
+                    }, label: {
+                        Text("Move Source Down")
+                            .frame(width: 130)
+                    })
+                    .disabled(!selectedNotEmpty)
+                }
+            }
+        }
+        .onChange(of: selected) { _ in
+            if selected.count > 0 {
+                selectedNotEmpty = true
+            } else {
+                selectedNotEmpty = false
+            }
+        }
+        .padding(20)
+        .frame(width: 600, height: 300, alignment: .center)
+        .sheet(isPresented: $addSourceSheet) {
+            AddSourceView(sources: $sources, addSourceSheet: $addSourceSheet)
+        }
+    }
+
+    func addSource() {
+        addSourceSheet.toggle()
+    }
+
+    func deleteSource() {
+        sources.removeAll(where: { selected.contains($0.id) })
+        selected.removeAll()
+    }
+
+    func moveSourceUp() {
+        let selectedData = sources.filter({ selected.contains($0.id) })
+        sources.removeAll(where: { selected.contains($0.id) })
+        sources.insert(contentsOf: selectedData, at: 0)
+    }
+
+    func moveSourceDown() {
+        let selectedData = sources.filter({ selected.contains($0.id) })
+        sources.removeAll(where: { selected.contains($0.id) })
+        sources.append(contentsOf: selectedData)
+    }
+}
+
+struct AddSourceView: View {
+    @State var newSource = ""
+    @Binding var sources: [SourceData]
+    @Binding var addSourceSheet: Bool
+
+    var body: some View {
+        VStack {
+            TextField(text: $newSource, label: {Text("Source URL...")})
+            HStack {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(.green)
+                Text("Link Valid")
+                    .font(.system(.subheadline))
+                Spacer()
+                Button(action: {
+                    addSourceSheet.toggle()
+                }, label: {
+                    Text("Cancel")
+                })
+                Button(action: {
+                    sources.append(SourceData(source: newSource))
+                    addSourceSheet.toggle()
+                }, label: {
+                    Text("Done")
+                })
+                .tint(.accentColor)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding()
+        .frame(width: 400, height: 100)
+    }
+}
+
+struct IPASourceSettings_Previews: PreviewProvider {
+    static var previews: some View {
+        IPASourceSettings()
+    }
+}

--- a/PlayCover/Views/Settings/IPASourceSettings.swift
+++ b/PlayCover/Views/Settings/IPASourceSettings.swift
@@ -103,14 +103,22 @@ struct IPASourceSettings: View {
 
     func moveSourceUp() {
         let selectedData = sources.filter({ selected.contains($0.id) })
+        var index = sources.firstIndex(of: selectedData.first!)! - 1
         sources.removeAll(where: { selected.contains($0.id) })
-        sources.insert(contentsOf: selectedData, at: 0)
+        if index < 0 {
+            index = 0
+        }
+        sources.insert(contentsOf: selectedData, at: index)
     }
 
     func moveSourceDown() {
         let selectedData = sources.filter({ selected.contains($0.id) })
+        var index = sources.firstIndex(of: selectedData.first!)! + 1
         sources.removeAll(where: { selected.contains($0.id) })
-        sources.append(contentsOf: selectedData)
+        if index > sources.endIndex {
+            index = sources.endIndex
+        }
+        sources.insert(contentsOf: selectedData, at: index)
     }
 }
 

--- a/PlayCover/Views/Settings/IPASourceSettings.swift
+++ b/PlayCover/Views/Settings/IPASourceSettings.swift
@@ -107,19 +107,42 @@ struct IPASourceSettings: View {
     }
 }
 
+enum SourceValidation {
+    case valid, badurl, badjson, checking
+}
+
 struct AddSourceView: View {
     @State var newSource = ""
+    @State var newSourceURL: URL?
+    @State var sourceValidationState = SourceValidation.checking
     @Binding var sources: [SourceData]
     @Binding var addSourceSheet: Bool
 
     var body: some View {
         VStack {
             TextField(text: $newSource, label: {Text("Source URL...")})
+            Spacer()
+                .frame(height: 20)
             HStack {
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundColor(.green)
-                Text("Link Valid")
-                    .font(.system(.subheadline))
+                switch sourceValidationState {
+                case .valid:
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.green)
+                    Text("Link valid")
+                        .font(.system(.subheadline))
+                case .badurl:
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.red)
+                    Text("URL invalid")
+                        .font(.system(.subheadline))
+                case .badjson:
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.red)
+                    Text("JSON not found or invalid")
+                        .font(.system(.subheadline))
+                case .checking:
+                    EmptyView()
+                }
                 Spacer()
                 Button(action: {
                     addSourceSheet.toggle()
@@ -127,17 +150,56 @@ struct AddSourceView: View {
                     Text("Cancel")
                 })
                 Button(action: {
-                    sources.append(SourceData(source: newSource))
-                    addSourceSheet.toggle()
+                    if newSourceURL != nil {
+                        sources.append(SourceData(source: newSourceURL!.absoluteString))
+                        addSourceSheet.toggle()
+                    }
                 }, label: {
                     Text("Done")
                 })
                 .tint(.accentColor)
                 .keyboardShortcut(.defaultAction)
+                .disabled(sourceValidationState != .valid)
             }
         }
         .padding()
         .frame(width: 400, height: 100)
+        .onChange(of: newSource) { source in
+            validateSource(source)
+        }
+    }
+
+    func validateSource(_ source: String) {
+        sourceValidationState = .checking
+        DispatchQueue.global(qos: .userInteractive).async {
+            if let url = URL(string: source) {
+                newSourceURL = url
+                if StoreVM.checkAvaliability(url: newSourceURL!) {
+                    do {
+                        if newSourceURL!.scheme == nil {
+                            newSourceURL = URL(string: "https://" + newSourceURL!.absoluteString)!
+                        }
+                        let contents = try String(contentsOf: newSourceURL!)
+                        let jsonData = contents.data(using: .utf8)!
+                        do {
+                            let data: [StoreAppData] = try JSONDecoder().decode([StoreAppData].self, from: jsonData)
+                            if data.count > 0 {
+                                sourceValidationState = .valid
+                                return
+                            }
+                        } catch {
+                            sourceValidationState = .badjson
+                            return
+                        }
+                    } catch {
+                        sourceValidationState = .badurl
+                        return
+                    }
+                }
+            }
+            sourceValidationState = .badurl
+            return
+        }
     }
 }
 

--- a/PlayCover/Views/Settings/IPASourceSettings.swift
+++ b/PlayCover/Views/Settings/IPASourceSettings.swift
@@ -98,7 +98,7 @@ struct IPASourceSettings: View {
         .padding(20)
         .frame(width: 600, height: 300, alignment: .center)
         .sheet(isPresented: $addSourceSheet) {
-            AddSourceView(addSourceSheet: $addSourceSheet, settings: self)
+            AddSourceView(addSourceSheet: $addSourceSheet)
                 .environmentObject(storeVM)
         }
     }
@@ -170,7 +170,6 @@ struct AddSourceView: View {
     @State var sourceValidationState = SourceValidation.checking
     @Binding var addSourceSheet: Bool
     @EnvironmentObject var storeVM: StoreVM
-    var settings: IPASourceSettings
 
     var body: some View {
         VStack {

--- a/PlayCover/Views/Settings/PlayCoverSettingsView.swift
+++ b/PlayCover/Views/Settings/PlayCoverSettingsView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct PlayCoverSettingsView: View {
     @ObservedObject var updaterViewModel: UpdaterViewModel
+    @EnvironmentObject var storeVM: StoreVM
 
     private enum Tabs: Hashable {
         case updates, ipasource
@@ -27,6 +28,7 @@ struct PlayCoverSettingsView: View {
                     Label("preferences.tab.ipasource", systemImage: "list.bullet")
                 }
                 .tag(Tabs.ipasource)
+                .environmentObject(storeVM)
         }
     }
 }

--- a/PlayCover/Views/Settings/PlayCoverSettingsView.swift
+++ b/PlayCover/Views/Settings/PlayCoverSettingsView.swift
@@ -12,7 +12,7 @@ struct PlayCoverSettingsView: View {
     @ObservedObject var updaterViewModel: UpdaterViewModel
 
     private enum Tabs: Hashable {
-        case updates
+        case updates, ipasource
     }
 
     var body: some View {
@@ -22,6 +22,11 @@ struct PlayCoverSettingsView: View {
                     Label("preferences.tab.updates", systemImage: "square.and.arrow.down")
                 }
                 .tag(Tabs.updates)
+            IPASourceSettings()
+                .tabItem {
+                    Label("preferences.tab.ipasource", systemImage: "list.bullet")
+                }
+                .tag(Tabs.ipasource)
         }
     }
 }

--- a/PlayCover/Views/Sidebar Views/AppLibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/AppLibraryView.swift
@@ -22,8 +22,8 @@ struct AppLibraryView: View {
 
     var body: some View {
         VStack(alignment: .leading) {
-            if !isList {
-                ScrollView {
+            ScrollView {
+                if !isList {
                     LazyVGrid(columns: gridLayout, alignment: .center) {
                         ForEach(appsVM.apps, id: \.url) { app in
                             PlayAppView(selectedBackgroundColor: $selectedBackgroundColor,
@@ -35,9 +35,7 @@ struct AppLibraryView: View {
                     }
                     .padding()
                     Spacer()
-                }
-            } else {
-                ScrollView {
+                } else {
                     VStack {
                         ForEach(appsVM.apps, id: \.url) { app in
                             PlayAppView(selectedBackgroundColor: $selectedBackgroundColor,

--- a/PlayCover/Views/Sidebar Views/AppLibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/AppLibraryView.swift
@@ -72,6 +72,8 @@ struct AppLibraryView: View {
                 Button(action: {
                     if installVM.installing {
                         Log.shared.error(PlayCoverError.waitInstallation)
+                    } else if DownloadVM.shared.downloading {
+                        Log.shared.error(PlayCoverError.waitDownload)
                     } else {
                         selectFile()
                     }
@@ -106,6 +108,9 @@ struct AppLibraryView: View {
         .onDrop(of: ["public.url", "public.file-url"], isTargeted: nil) { (items) -> Bool in
             if installVM.installing {
                 Log.shared.error(PlayCoverError.waitInstallation)
+                return false
+            } else if DownloadVM.shared.downloading {
+                Log.shared.error(PlayCoverError.waitDownload)
                 return false
             } else if let item = items.first {
                 if let identifier = item.registeredTypeIdentifiers.first {

--- a/PlayCover/Views/Sidebar Views/AppLibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/AppLibraryView.swift
@@ -25,7 +25,7 @@ struct AppLibraryView: View {
             if !isList {
                 ScrollView {
                     LazyVGrid(columns: gridLayout, alignment: .center) {
-                        ForEach(appsVM.apps, id: \.info.bundleIdentifier) { app in
+                        ForEach(appsVM.apps, id: \.url) { app in
                             PlayAppView(selectedBackgroundColor: $selectedBackgroundColor,
                                         selectedTextColor: $selectedTextColor,
                                         selected: $selected,
@@ -39,7 +39,7 @@ struct AppLibraryView: View {
             } else {
                 ScrollView {
                     VStack {
-                        ForEach(appsVM.apps, id: \.info.bundleIdentifier) { app in
+                        ForEach(appsVM.apps, id: \.url) { app in
                             PlayAppView(selectedBackgroundColor: $selectedBackgroundColor,
                                         selectedTextColor: $selectedTextColor,
                                         selected: $selected,

--- a/PlayCover/Views/Sidebar Views/IPALibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/IPALibraryView.swift
@@ -55,13 +55,13 @@ struct IPALibraryView: View {
             if storeVM.sources.count == 0 {
                 VStack {
                     Spacer()
-                    Text("No IPA Sources Added")
+                    Text("ipaLibrary.noSources.title")
                         .font(.title)
                         .padding(.bottom, 2)
-                    Text("You currently have no IPA Sources added. Click the button below to add one.")
+                    Text("ipaLibrary.noSources.subtitle")
                         .font(.subheadline)
                         .foregroundColor(.secondary)
-                    Button("Add Source", action: {
+                    Button("ipaLibrary.noSources.button", action: {
                         addSourcePresented.toggle()
                     })
                     Spacer()

--- a/PlayCover/Views/Sidebar Views/IPALibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/IPALibraryView.swift
@@ -29,6 +29,7 @@ struct IPALibraryView: View {
                                          selected: $selected,
                                          app: app,
                                          isList: isList)
+                            .environmentObject(DownloadVM.shared)
                         }
                     }
                     .padding()
@@ -43,6 +44,7 @@ struct IPALibraryView: View {
                                          selected: $selected,
                                          app: app,
                                          isList: isList)
+                            .environmentObject(DownloadVM.shared)
                         }
                         Spacer()
                     }

--- a/PlayCover/Views/Sidebar Views/IPALibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/IPALibraryView.swift
@@ -17,6 +17,7 @@ struct IPALibraryView: View {
     @State private var searchString = ""
     @State private var isList = UserDefaults.standard.bool(forKey: "IPALibrayView")
     @State private var selected: StoreAppData?
+    // @State private var apps: [StoreAppData] = []
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -65,10 +66,13 @@ struct IPALibraryView: View {
             }
         }
         .searchable(text: $searchString, placement: .toolbar)
+        /*.onAppear {
+            apps = storeVM.fetchApps()
+        }
         .onChange(of: searchString, perform: { value in
             uif.searchText = value
-            storeVM.fetchApps()
-        })
+            apps = storeVM.fetchApps()
+        })*/
         .onChange(of: isList, perform: { value in
             UserDefaults.standard.set(value, forKey: "IPALibrayView")
         })

--- a/PlayCover/Views/Sidebar Views/IPALibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/IPALibraryView.swift
@@ -23,7 +23,7 @@ struct IPALibraryView: View {
             if !isList {
                 ScrollView {
                     LazyVGrid(columns: gridLayout, alignment: .center) {
-                        ForEach(storeVM.filteredApps, id: \.id) { app in
+                        ForEach(storeVM.filteredApps, id: \.bundleID) { app in
                             StoreAppView(selectedBackgroundColor: $selectedBackgroundColor,
                                          selectedTextColor: $selectedTextColor,
                                          selected: $selected,
@@ -37,7 +37,7 @@ struct IPALibraryView: View {
             } else {
                 ScrollView {
                     VStack {
-                        ForEach(storeVM.filteredApps, id: \.id) { app in
+                        ForEach(storeVM.filteredApps, id: \.bundleID) { app in
                             StoreAppView(selectedBackgroundColor: $selectedBackgroundColor,
                                          selectedTextColor: $selectedTextColor,
                                          selected: $selected,

--- a/PlayCover/Views/Sidebar Views/IPALibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/IPALibraryView.swift
@@ -17,14 +17,13 @@ struct IPALibraryView: View {
     @State private var searchString = ""
     @State private var isList = UserDefaults.standard.bool(forKey: "IPALibrayView")
     @State private var selected: StoreAppData?
-    // @State private var apps: [StoreAppData] = []
 
     var body: some View {
         VStack(alignment: .leading) {
             if !isList {
                 ScrollView {
                     LazyVGrid(columns: gridLayout, alignment: .center) {
-                        ForEach(storeVM.apps, id: \.id) { app in
+                        ForEach(storeVM.filteredApps, id: \.id) { app in
                             StoreAppView(selectedBackgroundColor: $selectedBackgroundColor,
                                          selectedTextColor: $selectedTextColor,
                                          selected: $selected,
@@ -38,7 +37,7 @@ struct IPALibraryView: View {
             } else {
                 ScrollView {
                     VStack {
-                        ForEach(storeVM.apps, id: \.id) { app in
+                        ForEach(storeVM.filteredApps, id: \.id) { app in
                             StoreAppView(selectedBackgroundColor: $selectedBackgroundColor,
                                          selectedTextColor: $selectedTextColor,
                                          selected: $selected,
@@ -66,13 +65,10 @@ struct IPALibraryView: View {
             }
         }
         .searchable(text: $searchString, placement: .toolbar)
-        /*.onAppear {
-            apps = storeVM.fetchApps()
-        }
-        .onChange(of: searchString, perform: { value in
+        .onChange(of: searchString) { value in
             uif.searchText = value
-            apps = storeVM.fetchApps()
-        })*/
+            storeVM.fetchApps()
+        }
         .onChange(of: isList, perform: { value in
             UserDefaults.standard.set(value, forKey: "IPALibrayView")
         })

--- a/PlayCover/Views/ToastView.swift
+++ b/PlayCover/Views/ToastView.swift
@@ -48,7 +48,7 @@ struct ToastView: View {
             }
             if downloadVM.downloading {
                 VStack {
-                    Text("Downloading...")
+                    Text("playapp.download")
                     ProgressView(value: downloadVM.progress)
                 }
                 .padding()

--- a/PlayCover/Views/ToastView.swift
+++ b/PlayCover/Views/ToastView.swift
@@ -22,6 +22,8 @@ struct ToastView: View {
                         Image(systemName: "info.circle")
                     case .error:
                         Image(systemName: "exclamationmark.triangle")
+                    case .network:
+                        Image(systemName: "info.circle")
                     }
                     Text(toast.toastDetails)
                 }

--- a/PlayCover/Views/ToastView.swift
+++ b/PlayCover/Views/ToastView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ToastView: View {
     @EnvironmentObject var toastVM: ToastVM
     @EnvironmentObject var installVM: InstallVM
+    @EnvironmentObject var downloadVM: DownloadVM
 
     var body: some View {
         VStack(spacing: -20) {
@@ -45,9 +46,21 @@ struct ToastView: View {
                 .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
                 .padding()
             }
+            if downloadVM.downloading {
+                VStack {
+                    Text("Downloading...")
+                    ProgressView(value: downloadVM.progress)
+                }
+                .padding()
+                .frame(maxWidth: .infinity)
+                .background(.regularMaterial, in:
+                    RoundedRectangle(cornerRadius: 10))
+                .padding()
+            }
         }
         .animation(.easeInOut(duration: 0.25), value: toastVM.toasts.count)
         .animation(.easeInOut(duration: 0.25), value: installVM.installing)
+        .animation(.easeInOut(duration: 0.25), value: downloadVM.downloading)
     }
 }
 
@@ -56,5 +69,6 @@ struct ToastView_Preview: PreviewProvider {
         ToastView()
             .environmentObject(ToastVM.shared)
             .environmentObject(InstallVM.shared)
+            .environmentObject(DownloadVM.shared)
     }
 }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -26,7 +26,7 @@
 "preferences.popover.valid" = "Link Valid";
 "preferences.popover.badurl"  = "URL Invalid!";
 "preferences.popover.badjson" = "JSON Invalid or Not Found!";
-"preferences.textfield.url" = "Source URL..."
+"preferences.textfield.url" = "Source URL...";
 
 "sidebar.appLibrary" = "App Library";
 "sidebar.ipaLibrary" = "IPA Library";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -18,6 +18,15 @@
 "preferences.tab.updates" = "Updates";
 "preferences.toggle.automaticUpdates" = "Automatically check for updates";
 "preferences.tab.ipasource" = "IPA Sources";
+"preferences.button.addSource" = "Add Source";
+"preferences.button.deleteSource" = "Delete Source";
+"preferences.button.moveSourceUp" = "Move Source Up";
+"preferences.button.moveSourceDown" = "Move Source Down";
+"preferences.button.resolveSources" = "Resolve Sources";
+"preferences.popover.valid" = "Link Valid";
+"preferences.popover.badurl"  = "URL Invalid!";
+"preferences.popover.badjson" = "JSON Invalid or Not Found!";
+"preferences.textfield.url" = "Source URL..."
 
 "sidebar.appLibrary" = "App Library";
 "sidebar.ipaLibrary" = "IPA Library";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "ipaLibrary.noSources.title" = "No IPA Sources Added";
 "ipaLibrary.noSources.subtitle" = "You currently have no IPA Sources added. Click the button below to add one.";
 "ipaLibrary.noSources.button" = "Add Source";
-
+"ipaLibrary.noNetworkConnection.toast" = "No internet connection!";
 
 "preferences.button.checkForUpdates" = "Check for updates now...";
 "preferences.tab.updates" = "Updates";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -17,6 +17,7 @@
 "preferences.button.checkForUpdates" = "Check for updates now...";
 "preferences.tab.updates" = "Updates";
 "preferences.toggle.automaticUpdates" = "Automatically check for updates";
+"preferences.tab.ipasource" = "IPA Sources";
 
 "sidebar.appLibrary" = "App Library";
 "sidebar.ipaLibrary" = "IPA Library";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -15,6 +15,11 @@
 "playapp.deleteAccount" = "Delete Account";
 "playapp.clearPreferences" = "Clear App Preferences";
 
+"ipaLibrary.noSources.title" = "No IPA Sources Added";
+"ipaLibrary.noSources.subtitle" = "You currently have no IPA Sources added. Click the button below to add one.";
+"ipaLibrary.noSources.button" = "Add Source";
+
+
 "preferences.button.checkForUpdates" = "Check for updates now...";
 "preferences.tab.updates" = "Updates";
 "preferences.toggle.automaticUpdates" = "Automatically check for updates";
@@ -49,6 +54,7 @@
 "storeAccount.alert.deleteAccount" = "Really Delete Account?";
 "storeAccount.alert.deleteAccount.button" = "Delete Account";
 
+"playapp.download" = "Downloading...";
 "playapp.install.unzip" = "Extracting app from .ipa file...";
 "playapp.install.createWrapper" = "Creating app wrapper...";
 "playapp.install.installPlayTools" = "Installing PlayTools...";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -1,4 +1,5 @@
 "playapp.add" = "Add app";
+"playapp.addSource" = "Add source";
 "playapp.settings" = "Settings";
 "playapp.showInFinder" = "Show in Finder";
 "playapp.openCache" = "Open App Data";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -83,6 +83,7 @@
 
 "error.corruptedIPA" = "This .ipa file is corrupted. It does not contains \"Info.plist\" file.";
 "error.waitInstallation" = "Please wait for the current installation to finish!";
+"error.waitDownload" = "Please wait for the current download to finish!";
 "error.appEncrypted" = "This app is encrypted! Please use a decrypted IPA. iMazing IPAs are not supported!";
 "error.appCorrupted" = "Something went wrong with this IPA. Please try to use another IPA file.";
 "error.appProhibited" = "Using this app through PlayCover will likely result in a ban!";


### PR DESCRIPTION
https://user-images.githubusercontent.com/42140194/193436833-dc2819ca-d6fc-4d17-a657-5bae5b250d5a.mov

- Remove hardcoded `.json` both for flexability, and for copyright
- Allow users to add their own in-app IPA sources
- In-app downloads

**Other Changes/Bug Fixes:**
- `.app` folders will be renamed to match display name at install time. This means apps will now display with the correct name in the dock
- Updated the format of IPA Source `.json`s, an example of which can be found [here](https://raw.githubusercontent.com/IsaacMarovitz/PlayCover-IPA-Source-Tests/main/updatedsource.json)
- Fixed an issue where duplicate apps in the `Containers` folder with the same bundle ID would display incorrectly in grid view, but correctly in list view
- Fixed an issue where the display name of apps was sometimes equal to ""
- Cleaned up App Library and IPA Library views

