### PR TITLE
fix!: Sanitization for IPA path strings 

### DIFF
--- a/PlayCover/Utils/URLExtensions.swift
+++ b/PlayCover/Utils/URLExtensions.swift
@@ -9,7 +9,13 @@ import SwiftUI
 
 extension String {
     var esc: String {
-        replacingOccurrences(of: " ", with: "\\ ")
+        let esc = ["\\", "\"", "'", " ", "(", ")", "[", "]", "{", "}", "&", "|",
+                   ";", "<", ">", "`", "$", "!", "*", "?", "#", "~", "="]
+        var str = self
+        for char in esc {
+            str = str.replacingOccurrences(of: char, with: "\\" + char)
+        }
+        return str
     }
 
     func copyToClipBoard() {


### PR DESCRIPTION
This PR attempts to fix for a potential security issue in PlayCover IPA extraction where it may be vulnerable to shell command injections.

For example: two IPA files could be delivered to an user
- `valid.ipa` <-- Valid ZIP archive (can be hidden, so that zip exits with code 0)
- `valid.ipa;some_command|printf .ipa` <-- also a valid IPA file

When the second IPA is selected to be install, PlayCover will run

`/bin/zsh -c "unzip -oq /path/to/file/valid.ipa;some_command&&printf\ .ipa -d <tempdir>`

Which:
- Extracts the first IPA to the **working directory** (not the allocated temp dir since we escaped that)
- Runs whatever command is specified (`some_command`)

Examples:
- `valid.ipa;as|printf .ipa` which should hang PlayCover indefinitely as `as` waits for input
- `-;bluetoothd&&.ipa` which will crash your Mac