### PR TITLE
Fix clear app cache not working

### DIFF
--- a/PlayCover/Views/App Views/PlayAppView.swift
+++ b/PlayCover/Views/App Views/PlayAppView.swift
@@ -124,6 +124,7 @@ struct PlayAppView: View {
             }
             .alert("alert.app.delete", isPresented: $showClearCacheAlert) {
                 Button("button.Proceed", role: .cancel) {
+                    app.clearAllCache()
                     showClearCacheToast.toggle()
                 }
                 Button("button.Cancel", role: .cancel) { }


### PR DESCRIPTION
Fixes the bug where pressing "Clear app data" does nothing (accidentally introduced in #413). Fixes #451.