### PR TITLE
Improve PlayTools installer interactions

### DIFF
--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -37,17 +37,11 @@ class Installer {
 
     // swiftlint:disable function_body_length
     static func install(ipaUrl: URL, export: Bool, returnCompletion: @escaping (URL?) -> Void) {
-        let installPlayTools: Bool
-
-        if InstallSettings.shared.showInstallPlayToolsPopup {
-            installPlayTools = !export ? installPlayToolsPopup() : InstallSettings.shared.alwaysInstallPlayTools
-        } else {
-            if Installer.isOptionKeyHeld {
-                installPlayTools = installPlayToolsPopup()
-            } else {
-                installPlayTools = InstallSettings.shared.alwaysInstallPlayTools
-            }
-        }
+        // If (the option key is held or the install playtools popup settings is true) and its not an export,
+        //    then show the installer dialog
+        let installPlayTools = ((Installer.isOptionKeyHeld || InstallSettings.shared.showInstallPlayToolsPopup) &&
+                                !export) ?
+            installPlayToolsPopup() : InstallSettings.shared.alwaysInstallPlayTools
 
         InstallVM.shared.next(.begin, 0.0, 0.0)
 
@@ -218,8 +212,6 @@ class Installer {
     }
     
     static var isOptionKeyHeld: Bool {
-        get {
-            NSEvent.modifierFlags.contains(.option)
-        }
+        NSEvent.modifierFlags.contains(.option)
     }
 }

--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -29,8 +29,8 @@ class Installer {
         let response = alert.runModal()
 
         if alert.suppressionButton?.state == .on && response != .alertThirdButtonReturn {
-            InstallSettings.shared.showInstallPlayToolsPopup = false
-            InstallSettings.shared.alwaysInstallPlayTools = response == .alertFirstButtonReturn
+            InstallPreferences.shared.showInstallPopup = false
+            InstallPreferences.shared.alwaysInstallPlayTools = response == .alertFirstButtonReturn
         }
 
         return response == .alertThirdButtonReturn ? nil : response == .alertFirstButtonReturn
@@ -40,9 +40,8 @@ class Installer {
     static func install(ipaUrl: URL, export: Bool, returnCompletion: @escaping (URL?) -> Void) {
         // If (the option key is held or the install playtools popup settings is true) and its not an export,
         //    then show the installer dialog
-        let installPlayTools = ((Installer.isOptionKeyHeld || InstallSettings.shared.showInstallPlayToolsPopup) &&
-                                !export) ?
-            installPlayToolsPopup() : InstallSettings.shared.alwaysInstallPlayTools
+        let installPlayTools = ((Installer.isOptionKeyHeld || InstallPreferences.shared.showInstallPopup) &&
+                                !export) ? installPlayToolsPopup() : InstallPreferences.shared.alwaysInstallPlayTools
 
         if let installPlayTools {
             InstallVM.shared.next(.begin, 0.0, 0.0)

--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -12,7 +12,9 @@ class Installer {
     static func installPlayToolsPopup() -> Bool {
         let alert = NSAlert()
         alert.messageText = NSLocalizedString("alert.install.injectPlayTools", comment: "")
-        alert.informativeText = NSLocalizedString("alert.install.injectPlayToolsInApp", comment: "")
+        alert.informativeText = NSLocalizedString("alert.install.playToolsInformative", comment: "")
+
+        alert.alertStyle = .informational
 
         alert.showsSuppressionButton = true
         alert.suppressionButton?.toolTip = NSLocalizedString("alert.supression", comment: "String")
@@ -20,7 +22,8 @@ class Installer {
         let yes = alert.addButton(withTitle: NSLocalizedString("button.Yes", comment: ""))
         alert.addButton(withTitle: NSLocalizedString("button.No", comment: ""))
 
-        yes.hasDestructiveAction = true
+        // Set default button to install playtools
+        yes.keyEquivalent = "\r"
 
         let response = alert.runModal()
 

--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -210,7 +210,7 @@ class Installer {
     static func fakesign(_ url: URL) throws {
         try shell.shello("/usr/bin/codesign", "-fs-", url.path)
     }
-    
+
     static var isOptionKeyHeld: Bool {
         NSEvent.modifierFlags.contains(.option)
     }

--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -11,7 +11,7 @@ class Installer {
 
     static func installPlayToolsPopup() -> Bool {
         let alert = NSAlert()
-        alert.messageText = NSLocalizedString("alert.install.injectPlayTools", comment: "")
+        alert.messageText = NSLocalizedString("alert.install.injectPlayToolsQuestion", comment: "")
         alert.informativeText = NSLocalizedString("alert.install.playToolsInformative", comment: "")
 
         alert.alertStyle = .informational
@@ -93,7 +93,11 @@ class Installer {
                 } else {
                     finalURL = try wrap(app)
                     let installedApp = PlayApp(appUrl: finalURL)
-                    try PlayTools.installPluginInIPA(installedApp.url)
+
+                    if installPlayTools {
+                        try PlayTools.installPluginInIPA(installedApp.url)
+                    }
+
                     installedApp.sign()
                 }
 

--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -37,8 +37,17 @@ class Installer {
 
     // swiftlint:disable function_body_length
     static func install(ipaUrl: URL, export: Bool, returnCompletion: @escaping (URL?) -> Void) {
-        let installPlayTools = (InstallSettings.shared.showInstallPlayToolsPopup && !export) ?
-            installPlayToolsPopup() : InstallSettings.shared.alwaysInstallPlayTools
+        let installPlayTools: Bool
+
+        if InstallSettings.shared.showInstallPlayToolsPopup {
+            installPlayTools = !export ? installPlayToolsPopup() : InstallSettings.shared.alwaysInstallPlayTools
+        } else {
+            if Installer.isOptionKeyHeld {
+                installPlayTools = installPlayToolsPopup()
+            } else {
+                installPlayTools = InstallSettings.shared.alwaysInstallPlayTools
+            }
+        }
 
         InstallVM.shared.next(.begin, 0.0, 0.0)
 
@@ -206,5 +215,11 @@ class Installer {
     /// Regular codesign, does not accept entitlements. Used to re-seal an app after you've modified it.
     static func fakesign(_ url: URL) throws {
         try shell.shello("/usr/bin/codesign", "-fs-", url.path)
+    }
+    
+    static var isOptionKeyHeld: Bool {
+        get {
+            NSEvent.modifierFlags.contains(.option)
+        }
     }
 }

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -27,7 +27,12 @@ class PlayApp: BaseApp, ObservableObject {
             if try !Entitlements.areEntitlementsValid(app: self) {
                 sign()
             }
-            try PlayTools.installPluginInIPA(url)
+
+            // If the app does not have PlayTools, do not install PlugIns
+            if hasPlayTools {
+                try PlayTools.installPluginInIPA(url)
+            }
+
             if try !PlayTools.isInstalled() {
                 Log.shared.error("PlayTools are not installed! Please move PlayCover.app into Applications!")
             } else if try !PlayTools.isValidArch(executable.path) {

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -168,13 +168,19 @@ class PlayTools {
         do {
             remove_play_tools_from(exec.path, playToolsPath.path)
 
-            let bundleTarget = exec.deletingLastPathComponent()
+            let pluginUrl = exec.deletingLastPathComponent()
                 .appendingPathComponent("PlugIns")
+
+            let bundleTarget = pluginUrl
                 .appendingPathComponent("AKInterface")
                 .appendingPathExtension("bundle")
 
             if FileManager.default.fileExists(atPath: bundleTarget.path) {
                 try FileManager.default.removeItem(at: bundleTarget)
+            }
+
+            if try FileManager.default.contentsOfDirectory(atPath: pluginUrl.esc).isEmpty {
+                try FileManager.default.removeItem(at: pluginUrl)
             }
 
             shell.signApp(exec)

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -168,17 +168,14 @@ class PlayTools {
         do {
             remove_play_tools_from(exec.path, playToolsPath.path)
 
-            let pluginsURL = exec.appendingPathComponent("PlugIns")
-
-            let bundleTarget = pluginsURL
+            let bundleTarget = exec.deletingLastPathComponent()
+                .appendingPathComponent("PlugIns")
                 .appendingPathComponent("AKInterface")
                 .appendingPathExtension("bundle")
 
             if FileManager.default.fileExists(atPath: bundleTarget.path) {
                 try FileManager.default.removeItem(at: bundleTarget)
             }
-
-            Shell.codesign(bundleTarget)
 
             shell.signApp(exec)
         } catch {

--- a/PlayCover/Views/Settings/InstallSettings.swift
+++ b/PlayCover/Views/Settings/InstallSettings.swift
@@ -7,17 +7,32 @@
 
 import SwiftUI
 
+class InstallPreferences: NSObject, ObservableObject {
+    static var shared = InstallPreferences()
+
+    @objc @AppStorage("AlwaysInstallPlayTools") var alwaysInstallPlayTools = true
+
+    @AppStorage("ShowInstallPopup") var showInstallPopup = false
+}
+
 struct InstallSettings: View {
     public static var shared = InstallSettings()
 
-    @AppStorage("ShowInstallPlayToolsPopup") var showInstallPlayToolsPopup = false
-    @AppStorage("AlwaysInstallPlayTools") var alwaysInstallPlayTools = true
+    @ObservedObject var installPreferences = InstallPreferences.shared
 
     var body: some View {
         Form {
-            Toggle("preferences.toggle.showInstallPopup", isOn: $showInstallPlayToolsPopup)
-            Toggle("preferences.toggle.alwaysInstallPlayTools", isOn: $alwaysInstallPlayTools)
-                .disabled(showInstallPlayToolsPopup)
+            Toggle("preferences.toggle.showInstallPopup", isOn: $installPreferences.showInstallPopup)
+            GroupBox {
+                HStack {
+                    VStack(alignment: .leading) {
+                        Toggle("preferences.toggle.alwaysInstallPlayTools",
+                               isOn: $installPreferences.alwaysInstallPlayTools)
+                    }
+                    Spacer()
+                }
+            }.disabled(installPreferences.showInstallPopup)
+            Spacer()
         }
         .padding(20)
         .frame(width: 350, height: 100, alignment: .center)

--- a/PlayCover/Views/Settings/InstallSettings.swift
+++ b/PlayCover/Views/Settings/InstallSettings.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct InstallSettings: View {
     public static var shared = InstallSettings()
 
-    @AppStorage("ShowInstallPlayToolsPopup") var showInstallPlayToolsPopup = true
+    @AppStorage("ShowInstallPlayToolsPopup") var showInstallPlayToolsPopup = false
     @AppStorage("AlwaysInstallPlayTools") var alwaysInstallPlayTools = true
 
     var body: some View {

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -95,7 +95,7 @@
 "alert.wrongFileType.subtitle" = "PlayCover can only install valid .ipa files.";
 "alert.install.injectPlayTools" = "Inject PlayTools";
 "alert.install.injectPlayToolsQuestion" = "Do you want to inject PlayTools into this application?";
-"alert.install.playToolsInformative" = "PlayTools is a tool that allows you to bind keys to screen touches, custom display resolutions, and more, but may break certain apps";
+"alert.install.playToolsInformative" = "PlayTools is a tool that allows you to bind keys to screen touches, custom display resolutions, and more, but it may break certain apps";
 "alert.supression" = "You can change this in the PlayCover preferences";
 
 "button.OK" = "OK";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -94,7 +94,7 @@
 "alert.wrongFileType.title" = "Wrong file type!";
 "alert.wrongFileType.subtitle" = "PlayCover can only install valid .ipa files.";
 "alert.install.injectPlayTools" = "Do you want to inject PlayTools into this application?";
-"alert.install.playToolsInformative" = "PlayTools is a tool that allows you to bind keys to screen touches, custom display resolutions, and more";
+"alert.install.playToolsInformative" = "PlayTools is a tool that allows you to bind keys to screen touches, custom display resolutions, and more, but may break certain apps";
 "alert.supression" = "You can change this in the PlayCover preferences";
 
 "button.OK" = "OK";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -93,7 +93,8 @@
 "alert.legacyImport.subtitle" = "Legacy settings and keymapping files were detected. Would you like to convert these files to the new format?";
 "alert.wrongFileType.title" = "Wrong file type!";
 "alert.wrongFileType.subtitle" = "PlayCover can only install valid .ipa files.";
-"alert.install.injectPlayTools" = "Do you want to inject PlayTools into this application?";
+"alert.install.injectPlayTools" = "Inject PlayTools";
+"alert.install.injectPlayToolsQuestion" = "Do you want to inject PlayTools into this application?";
 "alert.install.playToolsInformative" = "PlayTools is a tool that allows you to bind keys to screen touches, custom display resolutions, and more, but may break certain apps";
 "alert.supression" = "You can change this in the PlayCover preferences";
 

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -93,8 +93,8 @@
 "alert.legacyImport.subtitle" = "Legacy settings and keymapping files were detected. Would you like to convert these files to the new format?";
 "alert.wrongFileType.title" = "Wrong file type!";
 "alert.wrongFileType.subtitle" = "PlayCover can only install valid .ipa files.";
-"alert.install.injectPlayTools" = "Inject PlayTools";
-"alert.install.injectPlayToolsInApp"= "Do you want to inject PlayTools into this application?";
+"alert.install.injectPlayTools" = "Do you want to inject PlayTools into this application?";
+"alert.install.playToolsInformative"= "PlayTools is a tool that allows you to bind keys to screen touches, custom display resolutions, and more";
 "alert.supression" = "You can change this in the PlayCover preferences";
 
 "button.OK" = "OK";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -94,7 +94,7 @@
 "alert.wrongFileType.title" = "Wrong file type!";
 "alert.wrongFileType.subtitle" = "PlayCover can only install valid .ipa files.";
 "alert.install.injectPlayTools" = "Do you want to inject PlayTools into this application?";
-"alert.install.playToolsInformative"= "PlayTools is a tool that allows you to bind keys to screen touches, custom display resolutions, and more";
+"alert.install.playToolsInformative" = "PlayTools is a tool that allows you to bind keys to screen touches, custom display resolutions, and more";
 "alert.supression" = "You can change this in the PlayCover preferences";
 
 "button.OK" = "OK";


### PR DESCRIPTION
Makes the PlayTools install popup clearer by including what it does, and not appear to the regular user

* Make install popup not popup by default, and triggered by holding option key
* Clarify what PlayTools does and not make the button destructive
* Allow user to cancel installation process when using the install popup
* Remove AKInterface if PlayTools is not installed to restore app to it's original state

- [x] Make install popup appear only when the user presses the option key while installing or configures it in settings
- [x] Improved install alert