### PR TITLE
Fix #397 (invisible windows)

### DIFF
--- a/PlayCover/Model/AppInfo.swift
+++ b/PlayCover/Model/AppInfo.swift
@@ -199,7 +199,5 @@ public class AppInfo {
         if Double(minimumOSVersion)! > 11.0 {
             minimumOSVersion = Int(minimumVersion).description
         }
-
-        supportsTrueScreenSizeOnMac = true
     }
 }


### PR DESCRIPTION
Do not add `UISupportsTrueScreenSizeOnMac` to apps.

Per Apple documentation, this key tells macOS the app is (among other things) capable of handling any display size and "all conceivable aspect ratios", which is obviously something we can't presume. I can image this would (if the window was visible) cause other bugs to pop up around UI and input mapping.

Finally, the actual reason windows aren't visible is actually pretty simple. The root application delegate class for iOS on Mac apps (`UINSApplicationDelegate`) receives a `didCreateUIScene` callback (or notification, didn't look much further into it) on `didCreateUIScene:transitionContextDictionary:` which falls through to `_configureWindowControllerCreatingIfNeededForScene:transitionContextDictionary:`, where the main window controller is created. The root class for iOS on Mac (and Catalyst) window controllers is `UINSSceneWindowController` which has a method called `_showWindowPostLoadIsFirstWindow:transitionContextDictionary:` (invoked during  `_configureWindowController...`) which checks for the `UISupportsTrueScreenSizeOnMac` key and SKIPS calling `[NSWindow makeKeyAndOrderFront:]` if found.

tl;dr: Window controller never calls `[NSWindow makeKeyAndOrderFront:]` if `UISupportsTrueScreenSizeOnMac` is true.
