### PR TITLE
Add iPad Pro 6th generation (M2) model identifier

### DIFF
--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -176,6 +176,7 @@ struct GraphicsView: View {
                         Text("iPad Pro (12.9-inch) (1st gen) | A9X | 4GB").tag("iPad6,7")
                         Text("iPad Pro (12.9-inch) (3rd gen) | A12Z | 4GB").tag("iPad8,6")
                         Text("iPad Pro (12.9-inch) (5th gen) | M1 | 8GB").tag("iPad13,8")
+                        Text("iPad Pro (12.9-inch) (6th gen) | M2 | 8GB").tag("iPad14,5")
                         Divider()
                         Text("iPhone 13 Pro Max | A15 | 6GB").tag("iPhone14,3")
                         Text("iPhone 14 Pro Max | A16 | 6GB").tag("iPhone15,3")


### PR DESCRIPTION
This PR requires https://github.com/PlayCover/PlayTools/pull/46.

This adds support for the iPad M2 model identifier. This will enable additional allocation of GPU resources, which was the main improvement in the M2 chip. The extra resources can be easily allocated starting with the M1 Pro, which still exceeds the graphics capacity of the M2. With due optimizations from apps, this should alleviate the main bottleneck in higher end Apple Silicon Macs.

This has been tested and proven to impersonate the correct iPad model.