### PR TITLE
Fix failed progress bar

### DIFF
--- a/PlayCover/ViewModel/InstallVM.swift
+++ b/PlayCover/ViewModel/InstallVM.swift
@@ -30,7 +30,7 @@ class InstallVM: ObservableObject {
             self.status = NSLocalizedString(step.rawValue, comment: "")
             if step == .begin {
                 self.installing = true
-            } else if step == .finish {
+            } else if step == .finish || step == .failed {
                 self.progress = 1.0
                 DispatchQueue.global(qos: .userInteractive).async {
                     usleep(1500000)


### PR DESCRIPTION
Fixes bug where when installing an IPA fails, the progress bar persists on the screen. Fixes #493.