### PR TITLE
Release Temporary Directories

### DIFF
--- a/PlayCover/Model/AppContainer.swift
+++ b/PlayCover/Model/AppContainer.swift
@@ -25,11 +25,7 @@ struct AppContainer {
     }()
 
     public func clear() {
-        do {
-            try FileManager.default.delete(at: containerUrl)
-        } catch {
-            Log.shared.error(error)
-        }
+        FileManager.default.delete(at: containerUrl)
     }
 
     public static func containers() throws -> [String: AppContainer] {

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -133,12 +133,8 @@ class PlayApp: BaseApp {
     }
 
     func deleteApp() {
-        do {
-            try FileManager.default.delete(at: URL(fileURLWithPath: url.path))
-            AppsVM.shared.fetchApps()
-        } catch {
-            Log.shared.error(error)
-        }
+        FileManager.default.delete(at: URL(fileURLWithPath: url.path))
+        AppsVM.shared.fetchApps()
     }
 
     func sign() {
@@ -153,7 +149,7 @@ class PlayApp: BaseApp {
             let conf = try Entitlements.composeEntitlements(self)
             try conf.store(tmpEnts)
             shell.signAppWith(executable, entitlements: tmpEnts)
-            try FileManager.default.removeItem(at: tmpEnts)
+            try FileManager.default.removeItem(at: tmpDir)
         } catch {
             print(error)
             Log.shared.error(error)

--- a/PlayCover/Utils/AppIntegrity.swift
+++ b/PlayCover/Utils/AppIntegrity.swift
@@ -15,12 +15,10 @@ class AppIntegrity: ObservableObject {
 
     func moveToApps() {
         do {
-            if FileManager.default.fileExists(atPath: AppIntegrity.expectedUrl.path) {
-                try FileManager.default.delete(at: AppIntegrity.expectedUrl)
-            }
+            FileManager.default.delete(at: AppIntegrity.expectedUrl)
             try FileManager.default.copyItem(at: AppIntegrity.appUrl!, to: AppIntegrity.expectedUrl)
             URL(fileURLWithPath: AppIntegrity.expectedUrl.path).openInFinder()
-            try FileManager.default.delete(at: AppIntegrity.appUrl!)
+            FileManager.default.delete(at: AppIntegrity.appUrl!)
             exit(0)
         } catch {
             Log.shared.error(error)

--- a/PlayCover/Utils/FileExtensions.swift
+++ b/PlayCover/Utils/FileExtensions.swift
@@ -7,7 +7,7 @@ import Foundation
 import UniformTypeIdentifiers
 
 extension FileManager {
-    func delete(at url: URL) throws {
+    func delete(at url: URL) {
         if FileManager.default.fileExists(atPath: url.path) {
             do {
                 try FileManager.default.removeItem(atPath: url.path)

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -56,9 +56,7 @@ class PlayTools {
                 }
 
                 // Check if a version of PlayTools is already installed, if so remove it
-                if FileManager.default.fileExists(atPath: playToolsFramework.path) {
-                    try FileManager.default.delete(at: URL(fileURLWithPath: playToolsFramework.path))
-                }
+                FileManager.default.delete(at: URL(fileURLWithPath: playToolsFramework.path))
 
                 // Install version of PlayTools bundled with PlayCover
                 Log.shared.log("Copying PlayTools to Frameworks")

--- a/PlayCover/Views/Uninstaller.swift
+++ b/PlayCover/Views/Uninstaller.swift
@@ -111,32 +111,24 @@ class Uninstaller {
             app.clearAllCache()
         }
 
-        do {
-            if UninstallPreferences.shared.removeAppKeymap {
-                try FileManager.default.delete(at: app.keymapping.keymapURL)
-            }
+        if UninstallPreferences.shared.removeAppKeymap {
+            FileManager.default.delete(at: app.keymapping.keymapURL)
+        }
 
-            if UninstallPreferences.shared.removeAppSettings {
-                try FileManager.default.delete(at: app.settings.settingsUrl)
-            }
+        if UninstallPreferences.shared.removeAppSettings {
+            FileManager.default.delete(at: app.settings.settingsUrl)
+        }
 
-            if UninstallPreferences.shared.removeAppEntitlements {
-                try FileManager.default.delete(at: app.entitlements)
-            }
-        } catch {
-            Log.shared.error(error)
+        if UninstallPreferences.shared.removeAppEntitlements {
+            FileManager.default.delete(at: app.entitlements)
         }
 
         app.deleteApp()
     }
 
     static func clearExternalCache(_ bundleId: String) {
-        do {
-            for cache in cacheURLs {
-                try FileManager.default.delete(at: cache.appendingPathComponent(bundleId))
-            }
-        } catch {
-            Log.shared.error(error)
+        for cache in cacheURLs {
+            FileManager.default.delete(at: cache.appendingPathComponent(bundleId))
         }
     }
 
@@ -150,7 +142,7 @@ class Uninstaller {
                     if !bundleIds.contains(bundleId) {
                         clearExternalCache(bundleId)
 
-                        try FileManager.default.delete(at: file)
+                        FileManager.default.delete(at: file)
                     }
                 }
             } catch {


### PR DESCRIPTION
Always delete temporary directories when PlayCover is finished using them. When installing an app fails, it leaves behind a directory with the IPA.