### PR TITLE
fixed: a single space

### DIFF
--- a/PlayCover/AppInstaller/Utils/Entitlements.swift
+++ b/PlayCover/AppInstaller/Utils/Entitlements.swift
@@ -225,7 +225,7 @@ class Entitlements {
         """
 }
 
-public func ==<K, L: Hashable, R: Hashable>(lhs: [K: L], rhs: [K: R]) -> Bool {
+public func == <K, L: Hashable, R: Hashable>(lhs: [K: L], rhs: [K: R]) -> Bool {
     (lhs as NSDictionary).isEqual(to: rhs)
 }
 


### PR DESCRIPTION
A. Single. Whitespace.

*I don't know what happened to SwiftLint but it suddenly got angry*