### PR TITLE
feat: (slightly) more robust uri handler

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "PlayCover/PlayTools" "3.0.0-staging"
+github "PlayCover/PlayTools" "51ab649983e977fd378706e0037866851ba538b8"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "PlayCover/PlayTools" "51ab649983e977fd378706e0037866851ba538b8"
+github "PlayCover/PlayTools" "3.0.0-staging"

--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		AA71964B287A0EA800623C15 /* PlayRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA71964A287A0EA800623C15 /* PlayRules.swift */; };
 		AA71964D287A35F400623C15 /* com.nexon.bluearchive.yaml in Resources */ = {isa = PBXBuildFile; fileRef = AA71964C287A35F400623C15 /* com.nexon.bluearchive.yaml */; };
 		AA818CB5287ABEC3000BEE9D /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = AA818CB4287ABEC3000BEE9D /* Yams */; };
+		AB6F21EB299B7FA20078ADEC /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6F21EA299B7FA20078ADEC /* URLHandler.swift */; };
 		ABED59832887A32F004D782B /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABED59822887A32F004D782B /* MenuBarView.swift */; };
 		B1084E1F28AA80F400E399FA /* AppSettingsVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1084E1E28AA80F400E399FA /* AppSettingsVM.swift */; };
 		B1419FB628BA82EE000CB69F /* DiscordActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1419FB528BA82EE000CB69F /* DiscordActivity.swift */; };
@@ -169,6 +170,7 @@
 		AA71964A287A0EA800623C15 /* PlayRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayRules.swift; sourceTree = "<group>"; };
 		AA71964C287A35F400623C15 /* com.nexon.bluearchive.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = com.nexon.bluearchive.yaml; sourceTree = "<group>"; };
 		AA970FD228793A310099A5D0 /* PlayCoverRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PlayCoverRelease.entitlements; sourceTree = "<group>"; };
+		AB6F21EA299B7FA20078ADEC /* URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHandler.swift; sourceTree = "<group>"; };
 		ABED59822887A32F004D782B /* MenuBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		ABF0BA1A285F9ED200FC5259 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B1084E1E28AA80F400E399FA /* AppSettingsVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsVM.swift; sourceTree = "<group>"; };
@@ -319,6 +321,7 @@
 				B17FD04628C7B0D900B1D4CA /* AssetsExtractor.swift */,
 				6EB4B57328C93E0600630890 /* LegacySettings.swift */,
 				B17FD03F28C70C7300B1D4CA /* CoreUI.h */,
+				AB6F21EA299B7FA20078ADEC /* URLHandler.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -666,6 +669,7 @@
 				28361D5E2892781200B35EDB /* RestoreGenshinUserData.swift in Sources */,
 				36B26B97288C724600859EFD /* UpdateSettings.swift in Sources */,
 				8783CFFB26B8C52D00171041 /* PlayCoverApp.swift in Sources */,
+				AB6F21EB299B7FA20078ADEC /* URLHandler.swift in Sources */,
 				6ED6379D28DAAAC100B506FA /* IPASourceSettings.swift in Sources */,
 				5314D1EE26C402EC00A0A727 /* Shell.swift in Sources */,
 				6E7CA16528B4D02900216CD8 /* ITunesResponse.swift in Sources */,

--- a/PlayCover/Utils/URLHandler.swift
+++ b/PlayCover/Utils/URLHandler.swift
@@ -38,7 +38,7 @@ struct URLHandler {
             let params = urlComponenents.queryItems else {
                 // Fall back to old url handler (for files)
                 if url.pathExtension == "ipa" {
-                    Installer.install(ipaUrl: uif.ipaUrl!, export: false, returnCompletion: { _ in
+                    Installer.install(ipaUrl: url, export: false, returnCompletion: { _ in
                     Task { @MainActor in
                         AppsVM.shared.fetchApps()
                         NotifyService.shared.notify(

--- a/PlayCover/Utils/URLHandler.swift
+++ b/PlayCover/Utils/URLHandler.swift
@@ -34,8 +34,8 @@ struct URLHandler {
 
     func processURL(url: URL) {
         guard let urlComponenents = NSURLComponents(url: url, resolvingAgainstBaseURL: false),
-            let uriPath = urlComponenents.path,
-            let params = urlComponenents.queryItems else {
+              let uriHost = urlComponenents.host,
+              let params = urlComponenents.queryItems else {
                 // Fall back to old url handler (for files)
                 if url.pathExtension == "ipa" {
                     Installer.install(ipaUrl: url, export: false, returnCompletion: { _ in
@@ -52,9 +52,10 @@ struct URLHandler {
         // URI format: playcoverapp://<object>?action=<action>&<param>=<value>
         // Example: playcoverapp://source?action=add&url=https://homebrew.playcover.io
 
+        debugPrint(urlComponenents)
         // Switch case for main uri path
-        switch uriPath {
-        case "/source":
+        switch uriHost {
+        case "source":
             processSourceURL(params: params)
         default:
             // Print URL to console and break
@@ -63,31 +64,31 @@ struct URLHandler {
     }
 
     func processSourceURL(params: [URLQueryItem]) {
-        switch params[0].value {
-        case "add":
-            // Add source
-            if let url = params[1].value {
-                URLObservable.shared.url = url
-                URLObservable.shared.type = .source
-                URLObservable.shared.action = .add
+        if let actionParam = params[0].value {
+            URLObservable.shared.type = .source
+            switch actionParam {
+            case "add":
+                // Add source
+                if let url = params[1].value {
+                    URLObservable.shared.url = url
+                    URLObservable.shared.action = .add
+                }
+            case "remove":
+                // Remove source
+                if let url = params[1].value {
+                    URLObservable.shared.url = url
+                    URLObservable.shared.action = .remove
+                }
+            case "update":
+                // Update source
+                if let url = params[1].value {
+                    URLObservable.shared.url = url
+                    URLObservable.shared.action = .update
+                }
+            default:
+                // Print params to console and break
+                print("Unknown source URL params: \(params)")
             }
-        case "remove":
-            // Remove source
-            if let url = params[1].value {
-                URLObservable.shared.url = url
-                URLObservable.shared.type = .source
-                URLObservable.shared.action = .remove
-            }
-        case "update":
-            // Update source
-            if let url = params[1].value {
-                URLObservable.shared.url = url
-                URLObservable.shared.type = .source
-                URLObservable.shared.action = .update
-            }
-        default:
-            // Print params to console and break
-            print("Unknown source URL params: \(params)")
         }
     }
 }

--- a/PlayCover/Utils/URLHandler.swift
+++ b/PlayCover/Utils/URLHandler.swift
@@ -56,12 +56,21 @@ struct URLHandler {
         case "source":
             processSourceURL(params: params)
         default:
-            // Print URL to console and break
-            print("Unknown URL: \(url)")
+            // Print URL to log and break
+            NSLog("Unknown URL: \(url)")
         }
     }
 
     func processSourceURL(params: [URLQueryItem]) {
+        // Make dang sure we have the params we need and they match expected query items
+        guard params.count == 2,
+              params[0].name == "action",
+              params[1].name == "url" else {
+            // Print params to logs and break
+            NSLog("Unknown source URL params: \(params)")
+            return
+        }
+
         if let actionParam = params[0].value {
             URLObservable.shared.type = .source
             switch actionParam {

--- a/PlayCover/Utils/URLHandler.swift
+++ b/PlayCover/Utils/URLHandler.swift
@@ -51,8 +51,6 @@ struct URLHandler {
             }
         // URI format: playcoverapp://<object>?action=<action>&<param>=<value>
         // Example: playcoverapp://source?action=add&url=https://homebrew.playcover.io
-
-        debugPrint(urlComponenents)
         // Switch case for main uri path
         switch uriHost {
         case "source":

--- a/PlayCover/Utils/URLHandler.swift
+++ b/PlayCover/Utils/URLHandler.swift
@@ -1,0 +1,93 @@
+//
+//  URIHandler.swift
+//  PlayCover
+//
+//  Created by Venti on 14/02/2023.
+//
+
+import Foundation
+
+enum URLTypes: Int, Equatable {
+    case source
+    case keymap
+    case app
+}
+
+enum URLAction: Int, Equatable {
+    case add
+    case remove
+    case update
+    case install
+    case open
+}
+
+class URLObservable: ObservableObject {
+    @Published var url: String?
+    @Published var type: URLTypes?
+    @Published var action: URLAction?
+
+    public static var shared = URLObservable()
+}
+
+struct URLHandler {
+    public static var shared = URLHandler()
+
+    func processURL(url: URL) {
+        guard let urlComponenents = NSURLComponents(url: url, resolvingAgainstBaseURL: false),
+            let uriPath = urlComponenents.path,
+            let params = urlComponenents.queryItems else {
+                // Fall back to old url handler (for files)
+                if url.pathExtension == "ipa" {
+                    Installer.install(ipaUrl: uif.ipaUrl!, export: false, returnCompletion: { _ in
+                    Task { @MainActor in
+                        AppsVM.shared.fetchApps()
+                        NotifyService.shared.notify(
+                            NSLocalizedString("notification.appInstalled", comment: ""),
+                            NSLocalizedString("notification.appInstalled.message", comment: "")
+                        )
+                    }})
+                }
+                return
+            }
+        // URI format: playcoverapp://<object>?action=<action>&<param>=<value>
+        // Example: playcoverapp://source?action=add&url=https://homebrew.playcover.io
+
+        // Switch case for main uri path
+        switch uriPath {
+        case "/source":
+            processSourceURL(params: params)
+        default:
+            // Print URL to console and break
+            print("Unknown URL: \(url)")
+        }
+    }
+
+    func processSourceURL(params: [URLQueryItem]) {
+        switch params[0].value {
+        case "add":
+            // Add source
+            if let url = params[1].value {
+                URLObservable.shared.url = url
+                URLObservable.shared.type = .source
+                URLObservable.shared.action = .add
+            }
+        case "remove":
+            // Remove source
+            if let url = params[1].value {
+                URLObservable.shared.url = url
+                URLObservable.shared.type = .source
+                URLObservable.shared.action = .remove
+            }
+        case "update":
+            // Update source
+            if let url = params[1].value {
+                URLObservable.shared.url = url
+                URLObservable.shared.type = .source
+                URLObservable.shared.action = .update
+            }
+        default:
+            // Print params to console and break
+            print("Unknown source URL params: \(params)")
+        }
+    }
+}

--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -22,6 +22,9 @@ struct MainView: View {
     @State private var collapsed: Bool = false
     @State private var selectedBackgroundColor: Color = Color.accentColor
     @State private var selectedTextColor: Color = Color.black
+
+    @ObservedObject private var URLObserved = URLObservable.shared
+
     var body: some View {
         GeometryReader { viewGeom in
             NavigationView {
@@ -81,7 +84,7 @@ struct MainView: View {
                 .background(SplitViewAccessor(sideCollapsed: $collapsed))
             }
             .onAppear {
-                self.selectedView = 1
+                self.selectedView = URLObserved.type == .source ? 2 : 1
             }
             .toolbar {
                 ToolbarItem(placement: .navigation) {
@@ -119,6 +122,9 @@ struct MainView: View {
             }
             .sheet(isPresented: $isSigningSetupShown) {
                 SignSetupView(isSigningSetupShown: $isSigningSetupShown)
+            }
+            .onChange(of: URLObserved.action) { _ in
+                self.selectedView = URLObserved.type == .source ? 2 : 1
             }
         }
         .frame(minWidth: 675, minHeight: 330)

--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -124,7 +124,7 @@ struct MainView: View {
                 SignSetupView(isSigningSetupShown: $isSigningSetupShown)
             }
             .onChange(of: URLObserved.action) { _ in
-                self.selectedView = URLObserved.type == .source ? 2 : 1
+                self.selectedView = URLObserved.type == .source ? 2 : self.selectedView
             }
         }
         .frame(minWidth: 675, minHeight: 330)

--- a/PlayCover/Views/PlayCoverApp.swift
+++ b/PlayCover/Views/PlayCoverApp.swift
@@ -8,17 +8,7 @@ import SwiftUI
 class AppDelegate: NSObject, NSApplicationDelegate {
     func application(_ application: NSApplication, open urls: [URL]) {
         if let url = urls.first {
-            if url.pathExtension == "ipa" {
-                uif.ipaUrl = url
-                Installer.install(ipaUrl: uif.ipaUrl!, export: false, returnCompletion: { _ in
-                    Task { @MainActor in
-                        AppsVM.shared.fetchApps()
-                        NotifyService.shared.notify(
-                            NSLocalizedString("notification.appInstalled", comment: ""),
-                            NSLocalizedString("notification.appInstalled.message", comment: ""))
-                    }
-                })
-            }
+            URLHandler.shared.processURL(url: url)
         }
     }
 

--- a/PlayCover/Views/Settings/IPASourceSettings.swift
+++ b/PlayCover/Views/Settings/IPASourceSettings.swift
@@ -230,6 +230,16 @@ struct AddSourceView: View {
         .onChange(of: newSource) { source in
             validateSource(source)
         }
+        .onAppear {
+            if URLObservable.shared.type == .source {
+                newSource = URLObservable.shared.url ?? ""
+            }
+        }
+        .onDisappear {
+            URLObservable.shared.url = nil
+            URLObservable.shared.type = nil
+            URLObservable.shared.action = nil
+        }
     }
 
     func validateSource(_ source: String) {

--- a/PlayCover/Views/Sidebar Views/IPALibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/IPALibraryView.swift
@@ -19,6 +19,8 @@ struct IPALibraryView: View {
     @State private var selected: StoreAppData?
     @State private var addSourcePresented = false
 
+    @ObservedObject private var URLObserved = URLObservable.shared
+
     var body: some View {
         Group {
             if !NetworkVM.isConnectedToNetwork() {
@@ -127,6 +129,12 @@ struct IPALibraryView: View {
         .sheet(isPresented: $addSourcePresented) {
             AddSourceView(addSourceSheet: $addSourcePresented)
                 .environmentObject(storeVM)
+        }
+        .onChange(of: URLObserved.type) {_ in
+            addSourcePresented = URLObserved.type == .source
+        }
+        .onAppear {
+            addSourcePresented = URLObserved.type == .source
         }
     }
 }


### PR DESCRIPTION
This PR proposes a new, (slightly) more robust URI handler for the `playcover:` URI scheme, with support for adding sources directly from other applications

Also includes RuntimeVM, which is like StoreVM, but is not persistent, which can be useful for passing around temp data later.

Example: `playcover://source?action=add&url=<source_url>`