### PR TITLE
Update Discord Invites

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-https://discord.gg/rMv5qxGTGC.
+https://discord.com/invite/PlayCover.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
     <br />
     <a href="https://playcover.github.io/PlayBook">Documentation</a>
     ·
-    <a href="https://discord.gg/rMv5qxGTGC">Discord</a>
+    <a href="https://discord.com/invite/PlayCover">Discord</a>
     ·
     <a href="https://playcover.io/">Website</a>
   </p>


### PR DESCRIPTION
Readme and Code of Conduct have broken Discord invite links. This PR updates them to https://discord.com/invite/PlayCover.