### PR TITLE
fix!: Shell escape in entitlement handling

### DIFF
--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -248,7 +248,7 @@ class PlayTools {
 
 	static func fetchEntitlements(_ exec: URL) throws -> String {
         do {
-            return  try shell.sh("codesign --display --entitlements - --xml '\(exec.path)'" +
+            return  try shell.sh("codesign --display --entitlements - --xml '\(exec.path.esc)'" +
                             " | xmllint --format -", pipeStdErr: false)
         } catch {
             if error.localizedDescription.contains("Document is empty") {


### PR DESCRIPTION
A bug was discovered that allows arbitrary command execution when running an app from PlayCover due to the code dealing with parsing entitlements did not escape the app path.

Bug was introduced in 84ce798269, so it may have affected all PlayCover versions past v1.0.7