### PR TITLE
fix!: Remove quotations in fetchEntitlements completely

### DIFF
--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -248,7 +248,7 @@ class PlayTools {
 
 	static func fetchEntitlements(_ exec: URL) throws -> String {
         do {
-            return  try shell.sh("codesign --display --entitlements - --xml '\(exec.path.esc)'" +
+            return  try shell.sh("codesign --display --entitlements - --xml \(exec.path.esc)" +
                             " | xmllint --format -", pipeStdErr: false)
         } catch {
             if error.localizedDescription.contains("Document is empty") {


### PR DESCRIPTION
Since we already escape strings in #600 it would probably be better to simply remove the single quotes completely as the string is already escaped. This also helps if the app name legitimately has the `'` character (eg. Hide 'n Seek)