### PR TITLE
Fix Draggable Button Export

### DIFF
--- a/PlayCover/Model/Keymapping.swift
+++ b/PlayCover/Model/Keymapping.swift
@@ -20,15 +20,16 @@ struct ButtonModel: Codable {
     var keyName: String
     var transform: KeyModelTransform
 
-    init(keyCode: Int, transform: KeyModelTransform) {
+    init(keyCode: Int, keyName: String, transform: KeyModelTransform) {
         self.keyCode = keyCode
-        self.keyName = KeyCodeNames.keyCodes[keyCode] ?? "Btn"
+        self.keyName = keyName.isEmpty ? KeyCodeNames.keyCodes[keyCode] ?? "Btn" : keyName
         self.transform = transform
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.init(keyCode: try container.decode(Int.self, forKey: .keyCode),
+                  keyName: try container.decodeIfPresent(String.self, forKey: .keyName) ?? "",
                   transform: try container.decode(KeyModelTransform.self, forKey: .transform))
     }
 }
@@ -41,12 +42,17 @@ struct JoystickModel: Codable {
     var keyName: String
     var transform: KeyModelTransform
 
-    init(upKeyCode: Int, rightKeyCode: Int, downKeyCode: Int, leftKeyCode: Int, transform: KeyModelTransform) {
+    init(upKeyCode: Int,
+         rightKeyCode: Int,
+         downKeyCode: Int,
+         leftKeyCode: Int,
+         keyName: String,
+         transform: KeyModelTransform) {
         self.upKeyCode = upKeyCode
         self.rightKeyCode = rightKeyCode
         self.downKeyCode = downKeyCode
         self.leftKeyCode = leftKeyCode
-        self.keyName = "Keyboard"
+        self.keyName = keyName
         self.transform = transform
     }
 
@@ -56,6 +62,7 @@ struct JoystickModel: Codable {
                   rightKeyCode: try container.decode(Int.self, forKey: .rightKeyCode),
                   downKeyCode: try container.decode(Int.self, forKey: .downKeyCode),
                   leftKeyCode: try container.decode(Int.self, forKey: .leftKeyCode),
+                  keyName: try container.decodeIfPresent(String.self, forKey: .keyName) ?? "Keyboard",
                   transform: try container.decode(KeyModelTransform.self, forKey: .transform))
     }
 }
@@ -64,14 +71,15 @@ struct MouseAreaModel: Codable {
     var keyName: String
     var transform: KeyModelTransform
 
-    init(transform: KeyModelTransform) {
-        self.keyName = "Mouse"
+    init(keyName: String, transform: KeyModelTransform) {
+        self.keyName = keyName
         self.transform = transform
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.init(transform: try container.decode(KeyModelTransform.self, forKey: .transform))
+        self.init(keyName: try container.decodeIfPresent(String.self, forKey: .keyName) ?? "Mouse",
+                  transform: try container.decode(KeyModelTransform.self, forKey: .transform))
     }
 }
 

--- a/PlayCover/Utils/LegacySettings.swift
+++ b/PlayCover/Utils/LegacySettings.swift
@@ -86,29 +86,26 @@ class LegacySettings {
                     let xCoord = data[1] as? CGFloat ?? 0
                     let yCoord = data[2] as? CGFloat ?? 0
 
-                    let transform = KeyModelTransform(size: size,
-                                                      xCoord: xCoord,
-                                                      yCoord: yCoord)
+                    let transform = KeyModelTransform(size: size, xCoord: xCoord, yCoord: yCoord)
 
                     let keyCode = data[0] as? Int ?? 0
                     keymap.buttonModels.append(ButtonModel(keyCode: keyCode,
+                                                           keyName: KeyCodeNames.keyCodes[keyCode] ?? "Btn",
                                                            transform: transform))
                 } else if data.count == 2 {
                     let xCoord = data[0] as? CGFloat ?? 0
                     let yCoord = data[1] as? CGFloat ?? 0
 
-                    let transform = KeyModelTransform(size: 25,
-                                                      xCoord: xCoord,
-                                                      yCoord: yCoord)
-                    keymap.mouseAreaModel.append(MouseAreaModel(transform: transform))
+                    let transform = KeyModelTransform(size: 25, xCoord: xCoord, yCoord: yCoord)
+
+                    keymap.mouseAreaModel.append(MouseAreaModel(keyName: "Mouse", transform: transform))
                 } else if data.count == 8 {
                     let size = data[6] as? CGFloat ?? 5
                     let xCoord = data[4] as? CGFloat ?? 0
                     let yCoord = data[5] as? CGFloat ?? 0
 
-                    let transform = KeyModelTransform(size: size,
-                                                      xCoord: xCoord,
-                                                      yCoord: yCoord)
+                    let transform = KeyModelTransform(size: size, xCoord: xCoord, yCoord: yCoord)
+
                     let upKeyCode = data[0] as? Int ?? 0
                     let leftKeyCode = data[2] as? Int ?? 0
                     let rightKeyCode = data[3] as? Int ?? 0
@@ -117,18 +114,18 @@ class LegacySettings {
                                                               rightKeyCode: rightKeyCode,
                                                               downKeyCode: downKeyCode,
                                                               leftKeyCode: leftKeyCode,
+                                                              keyName: "Keyboard",
                                                               transform: transform))
                 } else if data.count == 5 {
                     let size = data[3] as? CGFloat ?? 5
                     let xCoord = data[1] as? CGFloat ?? 0
                     let yCoord = data[2] as? CGFloat ?? 0
 
-                    let transform = KeyModelTransform(size: size,
-                                                      xCoord: xCoord,
-                                                      yCoord: yCoord)
+                    let transform = KeyModelTransform(size: size, xCoord: xCoord, yCoord: yCoord)
 
                     let keyCode = data[0] as? Int ?? 0
                     keymap.draggableButtonModels.append(ButtonModel(keyCode: keyCode,
+                                                                    keyName: "Mouse",
                                                                     transform: transform))
                 }
             }


### PR DESCRIPTION
Adds new `init` functions to the different keymapping model structs to handle custom `keyName`s. Fixes #610. (Note: This may affect legacy keymappings and should be tested for backward compatibility).