### PR TITLE
Fix Crash When Removing/Installing PlayTools

### DIFF
--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -455,8 +455,11 @@ struct MiscView: View {
                             } else {
                                 PlayTools.installInApp(app.executable)
                             }
-                            AppsVM.shared.apps = []
-                            AppsVM.shared.fetchApps()
+
+                            DispatchQueue.main.async {
+                                AppsVM.shared.apps = []
+                                AppsVM.shared.fetchApps()
+                            }
                         }
                     }
                     Spacer()


### PR DESCRIPTION
Push AppsVM changes into main thread.