### PR TITLE
Fix Installing Legacy Keymap Install Message

### DIFF
--- a/PlayCover/Model/Keymapping.swift
+++ b/PlayCover/Model/Keymapping.swift
@@ -178,7 +178,7 @@ class Keymapping {
                         if let keymap = LegacySettings.convertLegacyKeymapFile(selectedPath) {
                             if keymap.bundleIdentifier == self.keymap.bundleIdentifier {
                                 self.keymap = keymap
-                                success(false)
+                                success(true)
                             } else {
                                 if self.differentBundleIdKeymapAlert() {
                                     self.keymap = keymap


### PR DESCRIPTION
Installing legacy keymapping will show a message that the keymap occurred an error when importing, which was first introduced d6ed41965ecfe2e0132e2699fe0d88846af3115a.