### PR TITLE
Primary App Icon Default

### DIFF
--- a/PlayCover/Utils/Cacher.swift
+++ b/PlayCover/Utils/Cacher.swift
@@ -27,6 +27,18 @@ class Cacher {
     func resolveLocalIcon(_ app: PlayApp) -> NSImage? {
         var bestResImage: NSImage?
         let compareStr = app.info.bundleIdentifier + app.info.bundleVersion
+
+        do {
+            try app.url.enumerateContents { file, _ in
+                if file.lastPathComponent.contains(app.info.primaryIconName), let icon = NSImage(contentsOf: file),
+                    checkImageDimensions(icon, bestResImage) {
+                    bestResImage = icon
+                }
+            }
+        } catch {
+            Log.shared.error(error)
+        }
+
         if let assetsExtractor = try? AssetsExtractor(appUrl: app.url) {
             for icon in assetsExtractor.extractIcons() where checkImageDimensions(icon, bestResImage) {
                 bestResImage = icon


### PR DESCRIPTION
Always find the primary image icon as a backup in case the icon name is not `AppIcon`.