### PR TITLE
Improve misc settings format

### DIFF
--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -431,14 +431,15 @@ struct MiscView: View {
                                 }.padding(.bottom)
                             }
                         }
-                    Spacer()
                 }.disabled(!(hasPlayTools ?? true))
+                Spacer()
+                    .frame(height: 20)
                 HStack {
                     HStack {
-                        if #available(macOS 13.0, *) {
-                            Toggle("settings.toggle.hud", isOn: $settings.metalHudEnabled)
-                            Spacer()
-                        }
+                        Toggle("settings.toggle.hud", isOn: $settings.metalHudEnabled)
+                            .disabled(!isVenturaGreater())
+                            .help(!isVenturaGreater() ? "settings.unavailable.hud" : "")
+                        Spacer()
                         HStack {
                             Text("settings.text.debugger")
                             VStack {
@@ -475,6 +476,14 @@ struct MiscView: View {
                 }
             }
             .padding()
+        }
+    }
+
+    func isVenturaGreater() -> Bool {
+        if #available(macOS 13.0, *) {
+            return true
+        } else {
+            return false
         }
     }
 }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -217,6 +217,7 @@
 "settings.text.state.help" = "Second row below title";
 "settings.toggle.discord" = "Enable Discord activity";
 "settings.toggle.hud" = "Metal HUD";
+"settings.unavailable.hud" = "Metal HUD unavailable";
 "settings.text.debugger" = "Debugger:";
 "settings.toggle.lldb" = "Open with LLDB";
 "settings.toggle.lldbWithTerminal" = "Open in terminal";


### PR DESCRIPTION
- Make the `Custom Discord activity` button align with the trailing edge of the LLDB text.
- Keep Metal HUD toggle in MacOS versions below 13.0 to prevent the LLDB toggles from being in the middle of the view. Disables the toggle if MacOS version is below 13.0 and adds a tool tip informing that it is unavailable.