### PR TITLE
Fix: Genshin account switcher now works.

### DIFF
--- a/PlayCover/Utils/GenshinUserData/DeleteStoredGenshinUserData.swift
+++ b/PlayCover/Utils/GenshinUserData/DeleteStoredGenshinUserData.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 func deleteStoredAccount(folderName: String) {
-    let folderPath = GenshinUserDataURLs.getStorePath(folderName: folderName)
+  //  let folderPath = NSHomeDirectory() + "/Library/Containers/io.playcover.PlayCover/Storage/" + folderName
+
+    let folderPath = GenshinUserDataURLs.getStorePath().appendingPathComponent(folderName)
 
     do {
         try FileManager.default.removeItem(atPath: folderPath.path)

--- a/PlayCover/Utils/GenshinUserData/GenshinUserDataURLs.swift
+++ b/PlayCover/Utils/GenshinUserData/GenshinUserDataURLs.swift
@@ -31,12 +31,11 @@ class GenshinUserDataURLs {
             .appendingPathComponent("Documents")
     }
 
-    static func getStorePath(folderName: String) -> URL {
+    static func getStorePath() -> URL {
         return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library")
             .appendingPathComponent("Containers")
             .appendingPathComponent("io.playcover.PlayCover")
             .appendingPathComponent("Storage")
-            .appendingPathComponent(folderName)
     }
 }

--- a/PlayCover/Utils/GenshinUserData/RestoreGenshinUserData.swift
+++ b/PlayCover/Utils/GenshinUserData/RestoreGenshinUserData.swift
@@ -12,7 +12,7 @@ func restoreUserData(folderName: String, app: PlayApp) {
     let isGlobalVersion = bundleID == "com.miHoYo.GenshinImpact"
 
     let gameDataPath = GenshinUserDataURLs.getGameDataPath(bundleID: bundleID)
-    let storePath = GenshinUserDataURLs.getStorePath(folderName: folderName)
+    let storePath = GenshinUserDataURLs.getStorePath().appendingPathComponent(folderName)
 
     let accountInfoPlistURL = gameDataPath.appendingPathComponent(GenshinUserDataURLs.accountInfoPlist)
     let kibanaReportArrayKeyURL = gameDataPath.appendingPathComponent(GenshinUserDataURLs.kibanaReportArrayKey)

--- a/PlayCover/Utils/GenshinUserData/SaveGenshinUserData.swift
+++ b/PlayCover/Utils/GenshinUserData/SaveGenshinUserData.swift
@@ -16,7 +16,7 @@ func storeUserData(folderName: String, accountRegion: String, app: PlayApp) {
     let gameDataPath = GenshinUserDataURLs.getGameDataPath(bundleID: bundleID)
 
     // Path to the folder where the data will be stored check if exists and if not create it
-    let store = GenshinUserDataURLs.getStorePath(folderName: folderName)
+    let store = GenshinUserDataURLs.getStorePath()
     let storePath = isGlobalVersion
                     ? store.appendingPathComponent(folderName)
                     : store.appendingPathComponent("Yuanshen \(folderName)")


### PR DESCRIPTION
This was a bug introduced by the refactor of the code, fixed by removing folderName from the path for 'Storage' folder.