### PR TITLE
Escape forwards slash

### DIFF
--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -128,7 +128,7 @@ class Installer {
                 continue
             }
 
-            let entryURL = folderURL.appendingPathComponent(entry)
+            let entryURL = folderURL.appendingEscapedPathComponent(entry)
             var isDirectory: ObjCBool = false
 
             guard FileManager.default.fileExists(atPath: entryURL.path, isDirectory: &isDirectory),
@@ -206,7 +206,7 @@ class Installer {
             .appendingPathComponent("Info")
             .appendingPathExtension("plist"))
         let location = PlayTools.playCoverContainer
-            .appendingPathComponent(info.displayName)
+            .appendingEscapedPathComponent(info.displayName)
             .appendingPathExtension("app")
         if FileManager.default.fileExists(atPath: location.path) {
             try FileManager.default.removeItem(at: location)

--- a/PlayCover/AppInstaller/Utils/IPA.swift
+++ b/PlayCover/AppInstaller/Utils/IPA.swift
@@ -50,7 +50,7 @@ public class IPA {
 
     func packIPABack(app: URL) throws -> URL {
         let newIpa = getDocumentsDirectory()
-            .appendingPathComponent(app.deletingPathExtension().lastPathComponent).appendingPathExtension("ipa")
+            .appendingEscapedPathComponent(app.deletingPathExtension().lastPathComponent).appendingPathExtension("ipa")
         try Shell.zip(
             ipa: newIpa,
             name: app.deletingPathExtension().lastPathComponent,

--- a/PlayCover/Model/AppContainer.swift
+++ b/PlayCover/Model/AppContainer.swift
@@ -1,5 +1,5 @@
 //
-//  ContainersParser.swift
+//  AppContainer.swift
 //  PlayCover
 //
 //  Created by Александр Дорофеев on 07.12.2021.

--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -55,7 +55,8 @@ class AppSettings {
     init(_ info: AppInfo, container: AppContainer?) {
         self.info = info
         self.container = container
-        settingsUrl = AppSettings.appSettingsDir.appendingPathComponent("\(info.bundleIdentifier).plist")
+        settingsUrl = AppSettings.appSettingsDir.appendingPathComponent(info.bundleIdentifier)
+                                                .appendingPathExtension(".plist")
         settings = AppSettingsData()
         if !decode() {
             encode()

--- a/PlayCover/Model/BaseApp.swift
+++ b/PlayCover/Model/BaseApp.swift
@@ -14,7 +14,7 @@ public class BaseApp {
     public var url: URL
 
     public var executable: URL {
-        url.appendingPathComponent(info.executableName)
+        url.appendingEscapedPathComponent(info.executableName)
     }
 
     public var entitlements: URL {

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -115,7 +115,7 @@ class PlayApp: BaseApp {
 
     func hasPlayTools() -> Bool {
         do {
-            return try PlayTools.installedInExec(atURL: url.appendingPathComponent(info.executableName))
+            return try PlayTools.installedInExec(atURL: url.appendingEscapedPathComponent(info.executableName))
         } catch {
             Log.shared.error(error)
             return true
@@ -150,7 +150,7 @@ class PlayApp: BaseApp {
                                                   appropriateFor: URL(fileURLWithPath: "/Users"),
                                                   create: true)
             let tmpEnts = tmpDir
-                .appendingPathComponent(ProcessInfo().globallyUniqueString)
+                .appendingEscapedPathComponent(ProcessInfo().globallyUniqueString)
                 .appendingPathExtension("plist")
             let conf = try Entitlements.composeEntitlements(self)
             try conf.store(tmpEnts)

--- a/PlayCover/Utils/DeletePreferences.swift
+++ b/PlayCover/Utils/DeletePreferences.swift
@@ -11,11 +11,11 @@ func deletePreferences(app: String) {
     let plistURL = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Library")
         .appendingPathComponent("Containers")
-        .appendingPathComponent(app)
+        .appendingEscapedPathComponent(app)
         .appendingPathComponent("Data")
         .appendingPathComponent("Library")
         .appendingPathComponent("Preferences")
-        .appendingPathComponent(app)
+        .appendingEscapedPathComponent(app)
         .appendingPathExtension("plist")
 
     guard FileManager.default.fileExists(atPath: plistURL.path) else { return }

--- a/PlayCover/Utils/GenshinUserData/DeleteStoredGenshinUserData.swift
+++ b/PlayCover/Utils/GenshinUserData/DeleteStoredGenshinUserData.swift
@@ -10,7 +10,7 @@ import Foundation
 func deleteStoredAccount(folderName: String) {
   //  let folderPath = NSHomeDirectory() + "/Library/Containers/io.playcover.PlayCover/Storage/" + folderName
 
-    let folderPath = GenshinUserDataURLs.getStorePath().appendingPathComponent(folderName)
+    let folderPath = GenshinUserDataURLs.getStorePath().appendingEscapedPathComponent(folderName)
 
     do {
         try FileManager.default.removeItem(atPath: folderPath.path)

--- a/PlayCover/Utils/GenshinUserData/RestoreGenshinUserData.swift
+++ b/PlayCover/Utils/GenshinUserData/RestoreGenshinUserData.swift
@@ -12,7 +12,7 @@ func restoreUserData(folderName: String, app: PlayApp) {
     let isGlobalVersion = bundleID == "com.miHoYo.GenshinImpact"
 
     let gameDataPath = GenshinUserDataURLs.getGameDataPath(bundleID: bundleID)
-    let storePath = GenshinUserDataURLs.getStorePath().appendingPathComponent(folderName)
+    let storePath = GenshinUserDataURLs.getStorePath().appendingEscapedPathComponent(folderName)
 
     let accountInfoPlistURL = gameDataPath.appendingPathComponent(GenshinUserDataURLs.accountInfoPlist)
     let kibanaReportArrayKeyURL = gameDataPath.appendingPathComponent(GenshinUserDataURLs.kibanaReportArrayKey)

--- a/PlayCover/Utils/GenshinUserData/SaveGenshinUserData.swift
+++ b/PlayCover/Utils/GenshinUserData/SaveGenshinUserData.swift
@@ -18,8 +18,8 @@ func storeUserData(folderName: String, accountRegion: String, app: PlayApp) {
     // Path to the folder where the data will be stored check if exists and if not create it
     let store = GenshinUserDataURLs.getStorePath()
     let storePath = isGlobalVersion
-                    ? store.appendingPathComponent(folderName)
-                    : store.appendingPathComponent("Yuanshen \(folderName)")
+                    ? store.appendingEscapedPathComponent(folderName)
+                    : store.appendingEscapedPathComponent("Yuanshen \(folderName)")
 
     // Data to move from GameDataPath to StorePath
     let accountInfoPlistURL = gameDataPath.appendingPathComponent(GenshinUserDataURLs.accountInfoPlist)

--- a/PlayCover/Utils/Shell.swift
+++ b/PlayCover/Utils/Shell.swift
@@ -106,7 +106,7 @@ class Shell: ObservableObject {
     static func zip(ipa: URL, name: String, payload: URL) throws {
         shell("cd \(payload.esc) && zip -r \(name.esc).ipa Payload")
         try FileManager.default
-            .moveItem(at: payload.appendingPathComponent(name).appendingPathExtension("ipa"), to: ipa)
+            .moveItem(at: payload.appendingEscapedPathComponent(name).appendingPathExtension("ipa"), to: ipa)
     }
 
     static func signAppWith(_ exec: URL, entitlements: URL) {

--- a/PlayCover/Utils/URLExtensions.swift
+++ b/PlayCover/Utils/URLExtensions.swift
@@ -94,4 +94,16 @@ extension URL {
             }
         }
     }
+
+    func appendingEscapedPathComponent(_ pathComponent: String) -> URL {
+        let esc = [("/", ":")]
+
+        var newPathComponent = pathComponent
+
+        for (find, replace) in esc {
+            newPathComponent = newPathComponent.replacingOccurrences(of: find, with: replace)
+        }
+
+        return self.appendingPathComponent(newPathComponent)
+    }
 }


### PR DESCRIPTION
Adds a new extension function that escapes certain characters when appending a path component. The only time this function needs to be used is when an inputted name can potentially contain a forward slash. Fixes an issue where apps with a forward slash in their display name are unable to be installed.