### PR TITLE
fix: settings file path

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -56,7 +56,7 @@ class AppSettings {
         self.info = info
         self.container = container
         settingsUrl = AppSettings.appSettingsDir.appendingPathComponent(info.bundleIdentifier)
-                                                .appendingPathExtension(".plist")
+                                                .appendingPathExtension("plist")
         settings = AppSettingsData()
         if !decode() {
             encode()


### PR DESCRIPTION
The dot shouldn't be here as it is added automatically. This will cause settings files to have two dots which won't be read by PlayTools