### PR TITLE
Remove Xcode CLI Dependancy

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		6E7CA16528B4D02900216CD8 /* ITunesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7CA16428B4D02900216CD8 /* ITunesResponse.swift */; };
 		6E7CA16728B4EEAE00216CD8 /* Keymapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7CA16628B4EEAE00216CD8 /* Keymapping.swift */; };
 		6EB4B57428C93E0600630890 /* LegacySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB4B57328C93E0600630890 /* LegacySettings.swift */; };
+		6ECB1D0E29798DFA00CD92AA /* DataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ECB1D0D29798DFA00CD92AA /* DataExtensions.swift */; };
 		6ED6379D28DAAAC100B506FA /* IPASourceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED6379C28DAAAC100B506FA /* IPASourceSettings.swift */; };
 		6ED6ACA428A949A30040D234 /* AppSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED6ACA328A949A30040D234 /* AppSettingsView.swift */; };
 		6ED6ACA628A96E570040D234 /* DeletePreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED6ACA528A96E570040D234 /* DeletePreferences.swift */; };
@@ -135,6 +136,7 @@
 		6E8001382974FE3400E53461 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6EB4B57328C93E0600630890 /* LegacySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacySettings.swift; sourceTree = "<group>"; };
 		6EC228A028B14A0600D7D73A /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		6ECB1D0D29798DFA00CD92AA /* DataExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtensions.swift; sourceTree = "<group>"; };
 		6ED6379C28DAAAC100B506FA /* IPASourceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPASourceSettings.swift; sourceTree = "<group>"; };
 		6ED6ACA328A949A30040D234 /* AppSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsView.swift; sourceTree = "<group>"; };
 		6ED6ACA528A96E570040D234 /* DeletePreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeletePreferences.swift; sourceTree = "<group>"; };
@@ -315,6 +317,7 @@
 			children = (
 				8783D00A26B8C9E600171041 /* URLExtensions.swift */,
 				53F5E74226C1D37E005AED1D /* FileExtensions.swift */,
+				6ECB1D0D29798DFA00CD92AA /* DataExtensions.swift */,
 				5314D1ED26C402EC00A0A727 /* Shell.swift */,
 				538AAE7A26CD41E60009C7AC /* ProcessExtension.swift */,
 				92B4D38E2737CF3D0001D7BB /* PlayTools.swift */,
@@ -675,6 +678,7 @@
 				6E66B0BF289DE6240099B907 /* StoreVM.swift in Sources */,
 				B6603E1328E2257800DEFA3F /* Uninstaller.swift in Sources */,
 				AA71964B287A0EA800623C15 /* PlayRules.swift in Sources */,
+				6ECB1D0E29798DFA00CD92AA /* DataExtensions.swift in Sources */,
 				6E66B0D928A135360099B907 /* ToastVM.swift in Sources */,
 				53F5E74326C1D37E005AED1D /* FileExtensions.swift in Sources */,
 				92EE06D0274EA433002C907B /* BaseApp.swift in Sources */,

--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -76,7 +76,6 @@ class Installer {
                     }
 
                     if !export {
-                        try PlayTools.replaceLibraries(atURL: macho)
                         try PlayTools.convertMacho(macho)
                         try fakesign(macho)
                     }

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -40,7 +40,7 @@ class PlayApp: BaseApp {
 
             if try !PlayTools.isInstalled() {
                 Log.shared.error("PlayTools are not installed! Please move PlayCover.app into Applications!")
-            } else if try !PlayTools.isValidArch(executable) {
+            } else if try !PlayTools.isMachoValidArch(executable) {
                 Log.shared.error("The app threw an error during conversion.")
             } else if try !isCodesigned() {
                 Log.shared.error("The app is not codesigned! Please open Xcode and accept license agreement.")

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -40,7 +40,7 @@ class PlayApp: BaseApp {
 
             if try !PlayTools.isInstalled() {
                 Log.shared.error("PlayTools are not installed! Please move PlayCover.app into Applications!")
-            } else if try !PlayTools.isValidArch(executable.path) {
+            } else if try !PlayTools.isValidArch(executable) {
                 Log.shared.error("The app threw an error during conversion.")
             } else if try !isCodesigned() {
                 Log.shared.error("The app is not codesigned! Please open Xcode and accept license agreement.")

--- a/PlayCover/PlayCoverError.swift
+++ b/PlayCover/PlayCoverError.swift
@@ -11,6 +11,7 @@ enum PlayCoverError: Error {
     case appProhibited
     case appMaliciousProhibited
     case noGenshinAccount
+    case failedToStripBinary
 }
 
 extension PlayCoverError: LocalizedError {
@@ -32,6 +33,8 @@ extension PlayCoverError: LocalizedError {
             return NSLocalizedString("error.appMaliciousProhibited", comment: "")
         case .noGenshinAccount:
             return NSLocalizedString("error.noGenshinAccount", comment: "")
+        case .failedToStripBinary:
+            return NSLocalizedString("error.failedToStripBinary", comment: "")
         }
     }
 }

--- a/PlayCover/Utils/DataExtensions.swift
+++ b/PlayCover/Utils/DataExtensions.swift
@@ -1,0 +1,29 @@
+//
+//  DataExtensions.swift
+//  PlayCover
+//
+
+import Foundation
+
+extension String {
+    init(data: Data, offset: Int, commandSize: Int, loadCommandString: lc_str) {
+        let loadCommandStringOffset = Int(loadCommandString.offset)
+        let stringOffset = offset + loadCommandStringOffset
+        let length = commandSize - loadCommandStringOffset
+        self = String(data: data[stringOffset..<(stringOffset + length)],
+                      encoding: .utf8)!.trimmingCharacters(in: .controlCharacters)
+    }
+}
+
+extension Data {
+    func extract<T>(_ type: T.Type, offset: Int = 0) -> T {
+        let data = self[offset..<offset + MemoryLayout<T>.size]
+        return data.withUnsafeBytes { dataBytes in
+            dataBytes.baseAddress!
+                .assumingMemoryBound(to: UInt8.self)
+                .withMemoryRebound(to: T.self, capacity: 1) { (pointer) -> T in
+                return pointer.pointee
+            }
+        }
+    }
+}

--- a/PlayCover/Utils/FileExtensions.swift
+++ b/PlayCover/Utils/FileExtensions.swift
@@ -33,7 +33,6 @@ extension FileManager {
 }
 
 extension NSOpenPanel {
-
     static func selectIPA(completion: @escaping (_ result: Result<URL, Error>) -> Void) {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -79,7 +79,7 @@ class PlayTools {
         var header = binary.extract(fat_header.self)
         var offset = MemoryLayout.size(ofValue: header)
         let shouldSwap = header.magic == FAT_CIGAM
-        
+
         if header.magic == FAT_MAGIC || header.magic == FAT_CIGAM {
             // Make sure the endianness is correct
             if shouldSwap {
@@ -247,20 +247,20 @@ class PlayTools {
         var offset = MemoryLayout.size(ofValue: header)
         let shouldSwap = header.magic == MH_CIGAM_64
 
-        if (shouldSwap) {
+        if shouldSwap {
             swap_mach_header_64(&header, NXHostByteOrder())
         }
 
         for _ in 0..<header.ncmds {
             var loadCommand = binary.extract(load_command.self, offset: offset)
-            if (shouldSwap) {
+            if shouldSwap {
                 swap_load_command(&loadCommand, NXHostByteOrder())
             }
 
             switch loadCommand.cmd {
             case UInt32(LC_ENCRYPTION_INFO_64):
                 var infoCommand = binary.extract(encryption_info_command_64.self, offset: offset)
-                if (shouldSwap) {
+                if shouldSwap {
                     swap_encryption_command_64(&infoCommand, NXHostByteOrder())
                 }
 
@@ -282,20 +282,20 @@ class PlayTools {
         var offset = MemoryLayout.size(ofValue: header)
         let shouldSwap = header.magic == MH_CIGAM_64
 
-        if (shouldSwap) {
+        if shouldSwap {
             swap_mach_header_64(&header, NXHostByteOrder())
         }
 
         for _ in 0..<header.ncmds {
             var loadCommand = binary.extract(load_command.self, offset: offset)
-            if (shouldSwap) {
+            if shouldSwap {
                 swap_load_command(&loadCommand, NXHostByteOrder())
             }
 
             switch loadCommand.cmd {
             case UInt32(LC_LOAD_DYLIB):
                 var dylibCommand = binary.extract(dylib_command.self, offset: offset)
-                if (shouldSwap) {
+                if shouldSwap {
                     swap_dylib_command(&dylibCommand, NXHostByteOrder())
                 }
 
@@ -321,26 +321,27 @@ class PlayTools {
             && isValidArch(playToolsPath)
     }
 
+    // TOOD: Fix
     static func isValidArch(_ url: URL) throws -> Bool {
         let binary = try Data(contentsOf: url)
         var header = binary.extract(mach_header_64.self)
         var offset = MemoryLayout.size(ofValue: header)
         let shouldSwap = header.magic == MH_CIGAM_64
 
-        if (shouldSwap) {
+        if shouldSwap {
             swap_mach_header_64(&header, NXHostByteOrder())
         }
 
         for _ in 0..<header.ncmds {
             var loadCommand = binary.extract(load_command.self, offset: offset)
-            if (shouldSwap) {
+            if shouldSwap {
                 swap_load_command(&loadCommand, NXHostByteOrder())
             }
 
             switch loadCommand.cmd {
             case UInt32(LC_BUILD_VERSION):
                 var versionCommand = binary.extract(build_version_command.self, offset: offset)
-                if (shouldSwap) {
+                if shouldSwap {
                     swap_build_version_command(&versionCommand, NXHostByteOrder())
                 }
 

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -538,16 +538,6 @@ class PlayTools {
             }
         }
 	}
-
-    private static func binPath(_ bin: String) throws -> URL {
-        URL(fileURLWithPath: try shell.sh("which \(bin)", print: false).trimmingCharacters(in: .newlines))
-    }
-
-    private static var vtool: URL {
-        get throws {
-            try binPath("vtool")
-        }
-    }
 }
 
 extension URL {

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -8,7 +8,6 @@ import injection
 
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
-// swiftlint:disable function_body_length
 
 class PlayTools {
     private static let frameworksURL = FileManager.default.homeDirectoryForCurrentUser

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -8,6 +8,7 @@ import injection
 
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
+// swiftlint:disable function_body_length
 
 class PlayTools {
     private static let frameworksURL = FileManager.default.homeDirectoryForCurrentUser
@@ -287,7 +288,6 @@ class PlayTools {
                                            reserved: header.reserved)
                 newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header_64>.size)
                 machoRange = Range(NSRange(location: 0, length: MemoryLayout<mach_header_64>.size))!
-                break
             default:
                 break
             }

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -7,6 +7,7 @@ import Foundation
 import injection
 
 // swiftlint:disable type_body_length
+// swiftlint:disable file_length
 
 class PlayTools {
     private static let frameworksURL = FileManager.default.homeDirectoryForCurrentUser

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -339,8 +339,8 @@ class PlayTools {
         var versionCommand = build_version_command(cmd: UInt32(LC_BUILD_VERSION),
                                                    cmdsize: 24,
                                                    platform: UInt32(PLATFORM_MACCATALYST),
-                                                   minos: 11 << 2,
-                                                   sdk: 14 << 2,
+                                                   minos: 0x00000b00,
+                                                   sdk: 0x00000e00,
                                                    ntools: 0)
 
         var zero: UInt = 0

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -81,7 +81,7 @@ class PlayTools {
 
         if header.magic == FAT_MAGIC {
             for _ in 0..<header.nfat_arch {
-                var arch = binary.extract(fat_arch.self, offset: offset)
+                let arch = binary.extract(fat_arch.self, offset: offset)
 
                 if arch.cputype == CPU_TYPE_ARM64 {
                     print("Found ARM64 arch")
@@ -305,9 +305,7 @@ class PlayTools {
         var offset = MemoryLayout.size(ofValue: header)
 
         for _ in 0..<header.ncmds {
-            print(offset)
             let loadCommand = binary.extract(load_command.self, offset: offset)
-            print(loadCommand.cmdsize)
             switch loadCommand.cmd {
             case UInt32(LC_LOAD_DYLIB):
                 let dylibCommand = binary.extract(dylib_command.self, offset: offset)

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -419,6 +419,7 @@ class PlayTools {
     }
 
     static func installedInExec(atURL url: URL) throws -> Bool {
+        try stripBinary(url)
         let binary = try Data(contentsOf: url)
         var header = binary.extract(mach_header_64.self)
         var offset = MemoryLayout.size(ofValue: header)
@@ -464,7 +465,6 @@ class PlayTools {
     }
 
     static func isMachoValidArch(_ url: URL) throws -> Bool {
-        print(url.path)
         let binary = try Data(contentsOf: url)
         var header = binary.extract(fat_header.self)
         let offset = MemoryLayout.size(ofValue: header)

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -339,10 +339,8 @@ class PlayTools {
         var versionCommand = build_version_command(cmd: UInt32(LC_BUILD_VERSION),
                                                    cmdsize: 24,
                                                    platform: UInt32(PLATFORM_MACCATALYST),
-                                                   // 11.0
-                                                   minos: 2816,
-                                                   // 14.0
-                                                   sdk: 234881024,
+                                                   minos: 11 << 2,
+                                                   sdk: 14 << 2,
                                                    ntools: 0)
 
         var zero: UInt = 0

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -77,7 +77,7 @@ class PlayTools {
         let binary = try Data(contentsOf: exec)
         var header = binary.extract(fat_header.self)
         var offset = MemoryLayout.size(ofValue: header)
-        
+
         if header.magic == FAT_MAGIC || header.magic == FAT_MAGIC_64 {
             // Make sure the endianness is correct
             swap_fat_header(&header, NXHostByteOrder())
@@ -99,7 +99,7 @@ class PlayTools {
 
                 offset += Int(MemoryLayout.size(ofValue: arch))
             }
-            
+
             throw PlayCoverError.failedToStripBinary
         } else {
             print("Binary already thin")

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -325,8 +325,8 @@ class PlayTools {
                                                    sdk: 0x000e0000,
                                                    ntools: 0)
 
-        var start = Int(header.sizeofcmds)+Int(MemoryLayout<mach_header_64>.size)
-        var subData = binary[start..<start + Int(versionCommand.cmdsize)]
+        let start = Int(header.sizeofcmds)+Int(MemoryLayout<mach_header_64>.size)
+        let subData = binary[start..<start + Int(versionCommand.cmdsize)]
 
         var newheader = mach_header_64(magic: header.magic,
                                        cputype: header.cputype,
@@ -336,8 +336,8 @@ class PlayTools {
                                        sizeofcmds: header.sizeofcmds + versionCommand.cmdsize,
                                        flags: header.flags,
                                        reserved: header.reserved)
-        var newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header_64>.size)
-        var machoRange = Range(NSRange(location: 0, length: MemoryLayout<mach_header_64>.size))!
+        let newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header_64>.size)
+        let machoRange = Range(NSRange(location: 0, length: MemoryLayout<mach_header_64>.size))!
 
         let testString = String(data: subData, encoding: .utf8)?
             .trimmingCharacters(in: .controlCharacters)

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -273,6 +273,7 @@ class PlayTools {
                 newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header_64>.size)
                 machoRange = Range(NSRange(location: 0, length: MemoryLayout<mach_header_64>.size))!
             case UInt32(LC_BUILD_VERSION):
+                // TODO: Similar thing as other one
                 break
             default:
                 break

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -339,8 +339,8 @@ class PlayTools {
         var versionCommand = build_version_command(cmd: UInt32(LC_BUILD_VERSION),
                                                    cmdsize: 24,
                                                    platform: UInt32(PLATFORM_MACCATALYST),
-                                                   minos: 0x00000b00,
-                                                   sdk: 0x00000e00,
+                                                   minos: 0x000b0000,
+                                                   sdk: 0x000e0000,
                                                    ntools: 0)
 
         var zero: UInt = 0

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -539,32 +539,3 @@ class PlayTools {
         }
 	}
 }
-
-extension URL {
-    func setBinaryPosixPermissions(_ permissions: Int) throws {
-        try FileManager.default.setAttributes([.posixPermissions: permissions], ofItemAtPath: path)
-    }
-}
-
-extension Data {
-    func extract<T>(_ type: T.Type, offset: Int = 0) -> T {
-        let data = self[offset..<offset + MemoryLayout<T>.size]
-        return data.withUnsafeBytes { dataBytes in
-            dataBytes.baseAddress!
-                .assumingMemoryBound(to: UInt8.self)
-                .withMemoryRebound(to: T.self, capacity: 1) { (pointer) -> T in
-                return pointer.pointee
-            }
-        }
-    }
-}
-
-extension String {
-    init(data: Data, offset: Int, commandSize: Int, loadCommandString: lc_str) {
-        let loadCommandStringOffset = Int(loadCommandString.offset)
-        let stringOffset = offset + loadCommandStringOffset
-        let length = commandSize - loadCommandStringOffset
-        self = String(data: data[stringOffset..<(stringOffset + length)],
-                      encoding: .utf8)!.trimmingCharacters(in: .controlCharacters)
-    }
-}

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -234,9 +234,12 @@ class PlayTools {
     }
 
     static func convertMacho(_ macho: URL) throws {
-        print(macho.path)
+        print("Converting MachO at \(macho.path)")
+        print("Stripping MachO")
         try stripBinary(macho)
+        print("Removing old version command from MachO")
         try removeOldCommand(macho)
+        print("Injecting new version command in MachO")
         try injectNewCommand(macho)
     }
 
@@ -293,6 +296,7 @@ class PlayTools {
 
             binary.replaceSubrange(subrangeOld, with: commandData)
             binary.replaceSubrange(machoRange, with: newHeaderData)
+            try FileManager.default.removeItem(at: url)
             try binary.write(to: url)
         }
     }
@@ -335,8 +339,10 @@ class PlayTools {
         var versionCommand = build_version_command(cmd: UInt32(LC_BUILD_VERSION),
                                                    cmdsize: 24,
                                                    platform: UInt32(PLATFORM_MACCATALYST),
-                                                   minos: 11,
-                                                   sdk: 14,
+                                                   // 11.0
+                                                   minos: 2816,
+                                                   // 14.0
+                                                   sdk: 234881024,
                                                    ntools: 0)
 
         var zero: UInt = 0
@@ -348,6 +354,7 @@ class PlayTools {
         binary.replaceSubrange(subrange, with: commandData)
 
         binary.replaceSubrange(machoRange, with: newHeaderData)
+        try FileManager.default.removeItem(at: url)
         try binary.write(to: url)
     }
 

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -273,7 +273,20 @@ class PlayTools {
                 newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header_64>.size)
                 machoRange = Range(NSRange(location: 0, length: MemoryLayout<mach_header_64>.size))!
             case UInt32(LC_BUILD_VERSION):
-                // TODO: Similar thing as other one
+                let versionCommand = binary.extract(build_version_command.self, offset: offset)
+
+                start = offset
+                size = Int(versionCommand.cmdsize)
+                newheader = mach_header_64(magic: header.magic,
+                                           cputype: header.cputype,
+                                           cpusubtype: header.cpusubtype,
+                                           filetype: header.filetype,
+                                           ncmds: header.ncmds - 1,
+                                           sizeofcmds: header.sizeofcmds - UInt32(versionCommand.cmdsize),
+                                           flags: header.flags,
+                                           reserved: header.reserved)
+                newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header_64>.size)
+                machoRange = Range(NSRange(location: 0, length: MemoryLayout<mach_header_64>.size))!
                 break
             default:
                 break
@@ -376,7 +389,7 @@ class PlayTools {
         var offset = offset
         var header = binary.extract(mach_header_64.self, offset: offset)
         offset += MemoryLayout.size(ofValue: header)
-        var shouldSwap = header.magic == MH_CIGAM_64
+        let shouldSwap = header.magic == MH_CIGAM_64
 
         if shouldSwap {
             swap_mach_header_64(&header, NXHostByteOrder())
@@ -454,7 +467,7 @@ class PlayTools {
         print(url.path)
         let binary = try Data(contentsOf: url)
         var header = binary.extract(fat_header.self)
-        var offset = MemoryLayout.size(ofValue: header)
+        let offset = MemoryLayout.size(ofValue: header)
         let shouldSwap = header.magic == FAT_CIGAM
 
         if header.magic == FAT_MAGIC || header.magic == FAT_CIGAM {
@@ -483,7 +496,7 @@ class PlayTools {
         var offset = offset
         var header = binary.extract(mach_header_64.self, offset: offset)
         offset += MemoryLayout.size(ofValue: header)
-        var shouldSwap = header.magic == MH_CIGAM_64
+        let shouldSwap = header.magic == MH_CIGAM_64
 
         if shouldSwap {
             swap_mach_header_64(&header, NXHostByteOrder())

--- a/PlayCover/Utils/URLExtensions.swift
+++ b/PlayCover/Utils/URLExtensions.swift
@@ -1,5 +1,5 @@
 //
-//  Utils.swift
+//  URLExtensions.swift
 //  PlayCover
 //
 
@@ -27,7 +27,6 @@ extension String {
 
 extension URL {
     func subDirectories() throws -> [URL] {
-        // @available(macOS 10.11, iOS 9.0, *)
         guard hasDirectoryPath else { return [] }
         return try FileManager.default
             .contentsOfDirectory(at: self, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
@@ -105,5 +104,9 @@ extension URL {
         }
 
         return self.appendingPathComponent(newPathComponent)
+    }
+
+    func setBinaryPosixPermissions(_ permissions: Int) throws {
+        try FileManager.default.setAttributes([.posixPermissions: permissions], ofItemAtPath: path)
     }
 }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -131,6 +131,7 @@
 "error.appProhibited" = "Using this app through PlayCover will likely result in a ban!";
 "error.appMaliciousProhibited" = "This App behaves maliciously on Macs, and using it can leave your device in an unbootable state, therefore it is blocked from PlayCover. (Uninstalling...)";
 "error.noGenshinAccount" = "We couldn't find a Genshin account! Are you signed into an account in-app?";
+"error.failedToStripBinary" = "Could not find ARM64 arch in fat binary!";
 
 "menubar.exportToSideloady" = "Export to Sideloadly";
 


### PR DESCRIPTION
**Change:**
- Replaces all uses of Xcode CLI with our own implementations, based on `inject`
- Installing Xcode CLI would no longer be required after this PR

`install_name_tool` usage not converted cause it's not necessary afaik

I will leave removing the UI and backend surrounding Xcode CLI to another PR so that the changes from this one can easily be tested in isolation.