### PR TITLE
Fix wrong German translation

### DIFF
--- a/PlayCover/de.lproj/Localizable.strings
+++ b/PlayCover/de.lproj/Localizable.strings
@@ -125,7 +125,7 @@
 "playapp.settings" = "Einstellungen";
 
 /* (No Comment) */
-"playapp.showInFinder" = "Im Sucher anzeigen";
+"playapp.showInFinder" = "Im Finder anzeigen";
 
 /* (No Comment) */
 "playapp.storeCurrentAccount" = "Account speichern";


### PR DESCRIPTION
There is a wrong translation for the word 'Finder'.

Sucher means 'seeker' As Finder is a name, there is no need for translation.