### PR TITLE
Fancy: Revert ListView's Icons Size Change + Better Navigation Animation

### DIFF
--- a/PlayCover/Utils/NavigationStack.swift
+++ b/PlayCover/Utils/NavigationStack.swift
@@ -29,7 +29,7 @@ enum StackNavigationTransition: Equatable {
             return AnyTransition.identity
         case .defaultTranisition:
             /// In this case you need to wrap `showingSubview = true` in the
-            /// root of the view view in a `withAnimation(.spring()) { ... }`
+            /// root of the view view in a `withAnimation(.easeOut(duration: 0.3)) { ... }`
             return AnyTransition.move(edge: .trailing)
         case .custom(let transition):
             return transition
@@ -73,7 +73,7 @@ struct StackNavigationView<RootContent>: View where RootContent: View {
                                 currentSubview = AnyView(EmptyView())
                                 switch transition {
                                 case .defaultTranisition:
-                                    withAnimation(.spring()) {
+                                    withAnimation(.easeOut(duration: 0.3)) {
                                         showingSubview = false
                                     }
                                 default:

--- a/PlayCover/Views/App Views/PlayAppView.swift
+++ b/PlayCover/Views/App Views/PlayAppView.swift
@@ -204,10 +204,11 @@ struct PlayAppConditionalView: View {
                                 .overlay {
                                     ProgressView()
                                         .progressViewStyle(.circular)
+                                        .controlSize(.small)
                                 }
                         }
                     }
-                    .frame(width: 40, height: 40)
+                    .frame(width: 30, height: 30)
                     .cornerRadius(7.5)
                     .shadow(radius: 1)
                     .padding(.horizontal, 15)

--- a/PlayCover/Views/App Views/StoreAppView.swift
+++ b/PlayCover/Views/App Views/StoreAppView.swift
@@ -107,11 +107,12 @@ struct StoreAppConditionalView: View {
                                         .overlay {
                                             ProgressView()
                                                 .progressViewStyle(.circular)
+                                                .controlSize(.small)
                                         }
                                 }
                             }
                         }
-                        .frame(width: 40, height: 40)
+                        .frame(width: 30, height: 30)
                         .cornerRadius(7.5)
                         .shadow(radius: 1)
                         .padding(.horizontal, 15)

--- a/PlayCover/Views/Sidebar Views/IPALibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/IPALibraryView.swift
@@ -50,7 +50,7 @@ struct IPALibraryView: View {
                                         currentSubview = AnyView(DetailStoreAppView(app: app,
                                                                                     downloadVM: DownloadVM.shared,
                                                                                     installVM: InstallVM.shared))
-                                        withAnimation(.spring()) {
+                                        withAnimation(.easeOut(duration: 0.3)) {
                                             showingSubview = true
                                         }
                                     } label: {
@@ -74,7 +74,7 @@ struct IPALibraryView: View {
                                         currentSubview = AnyView(DetailStoreAppView(app: app,
                                                                                     downloadVM: DownloadVM.shared,
                                                                                     installVM: InstallVM.shared))
-                                        withAnimation(.spring()) {
+                                        withAnimation(.easeIn(duration: 0.3)) {
                                             showingSubview = true
                                         }
                                     } label: {


### PR DESCRIPTION
Reverts Icon size change in previous PRs for ListViews and makes ProgressView size to match the size of the frame