### PR TITLE
Feat: add invisible app alias

### DIFF
--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -157,7 +157,7 @@ class PlayApp: BaseApp {
                                                 includingResourceValuesForKeys: nil, relativeTo: nil)
             try URL.writeBookmarkData(data, to: aliasURL)
         } catch {
-            Log.shared.log("\(error)")
+            Log.shared.log(error.localizedDescription)
         }
     }
 

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -107,6 +107,12 @@ class PlayApp: BaseApp {
         }
     }
 
+    static let aliasDirectory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Applications")
+            .appendingPathComponent("PlayCover")
+
+    lazy var aliasURL = PlayApp.aliasDirectory.appendingPathComponent(name)
+
     lazy var settings = AppSettings(info, container: container)
 
     lazy var keymapping = Keymapping(info, container: container)
@@ -120,6 +126,10 @@ class PlayApp: BaseApp {
             Log.shared.error(error)
             return true
         }
+    }
+
+    func hasAlias() -> Bool {
+        return FileManager.default.fileExists(atPath: aliasURL.path)
     }
 
     func isCodesigned() throws -> Bool {
@@ -136,6 +146,28 @@ class PlayApp: BaseApp {
 
     func clearAllCache() {
         Uninstaller.clearExternalCache(info.bundleIdentifier)
+    }
+
+    func createAlias() {
+        do {
+            try FileManager.default.createDirectory(atPath: PlayApp.aliasDirectory.path,
+                                                    withIntermediateDirectories: true,
+                                                    attributes: nil)
+        } catch {
+            Log.shared.log("Error creating app alias directory: \(error)")
+        }
+
+        do {
+            let data = try url.bookmarkData(options: .suitableForBookmarkFile,
+                                                includingResourceValuesForKeys: nil, relativeTo: nil)
+            try URL.writeBookmarkData(data, to: aliasURL)
+        } catch {
+            Log.shared.log("Error creating bookmark data or writing to destination file: \(error)")
+        }
+    }
+
+    func removeAlias() {
+        FileManager.default.delete(at: aliasURL)
     }
 
     func deleteApp() {

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -154,7 +154,7 @@ class PlayApp: BaseApp {
                                                     withIntermediateDirectories: true,
                                                     attributes: nil)
         } catch {
-            Log.shared.log("Error creating app alias directory: \(error)")
+            Log.shared.log("\(error)")
         }
 
         do {
@@ -162,7 +162,7 @@ class PlayApp: BaseApp {
                                                 includingResourceValuesForKeys: nil, relativeTo: nil)
             try URL.writeBookmarkData(data, to: aliasURL)
         } catch {
-            Log.shared.log("Error creating bookmark data or writing to destination file: \(error)")
+            Log.shared.log("\(error)")
         }
     }
 

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -153,11 +153,6 @@ class PlayApp: BaseApp {
             try FileManager.default.createDirectory(atPath: PlayApp.aliasDirectory.path,
                                                     withIntermediateDirectories: true,
                                                     attributes: nil)
-        } catch {
-            Log.shared.log("\(error)")
-        }
-
-        do {
             let data = try url.bookmarkData(options: .suitableForBookmarkFile,
                                                 includingResourceValuesForKeys: nil, relativeTo: nil)
             try URL.writeBookmarkData(data, to: aliasURL)

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -464,7 +464,7 @@ struct MiscView: View {
                         }
                     }
                     Spacer()
-                    Button((hasAlias ?? true) ? "settings.removeAlias" : "settings.createAlias") {
+                    Button((hasAlias ?? true) ? "settings.removeFromLaunchpad" : "settings.addToLaunchpad") {
                         closeView.toggle()
                         if !(hasAlias ?? true) {
                             app.createAlias()

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -18,6 +18,7 @@ struct AppSettingsView: View {
     @State var closeView = false
     @State var iconURL: URL?
     @State var hasPlayTools: Bool?
+    @State var hasAlias: Bool?
 
     var body: some View {
         VStack {
@@ -82,6 +83,7 @@ struct AppSettingsView: View {
                 MiscView(settings: $viewModel.settings,
                          closeView: $closeView,
                          hasPlayTools: $hasPlayTools,
+                         hasAlias: $hasAlias,
                          app: viewModel.app)
                     .tabItem {
                         Text("settings.tab.misc")
@@ -126,6 +128,7 @@ struct AppSettingsView: View {
         }
         .task(priority: .background) {
             hasPlayTools = viewModel.app.hasPlayTools()
+            hasAlias = viewModel.app.hasAlias()
         }
         .padding()
     }
@@ -376,6 +379,7 @@ struct MiscView: View {
     @Binding var settings: AppSettings
     @Binding var closeView: Bool
     @Binding var hasPlayTools: Bool?
+    @Binding var hasAlias: Bool?
 
     @State var showPopover = false
 
@@ -460,6 +464,16 @@ struct MiscView: View {
                         }
                     }
                     Spacer()
+                    Button((hasAlias ?? true) ? "settings.removeAlias" : "settings.createAlias") {
+                        closeView.toggle()
+                        if !(hasAlias ?? true) {
+                            app.createAlias()
+                            hasAlias = true
+                        } else {
+                            app.removeAlias()
+                            hasAlias = false
+                        }
+                    }
                 }
             }
             .padding()

--- a/PlayCover/Views/Uninstaller.swift
+++ b/PlayCover/Views/Uninstaller.swift
@@ -140,8 +140,8 @@ class Uninstaller {
         let bundleIds = AppsVM.shared.apps.map { $0.info.bundleIdentifier }
         let appNames = AppsVM.shared.apps.map { $0.info.displayName }
 
-        for url in pruneURLs {
-            do {
+        do {
+            for url in pruneURLs {
                 try url.enumerateContents { file, _ in
                     let bundleId = file.deletingPathExtension().lastPathComponent
                     if !bundleIds.contains(bundleId) {
@@ -150,22 +150,17 @@ class Uninstaller {
                         FileManager.default.delete(at: file)
                     }
                 }
-            } catch {
-                Log.shared.error(error)
             }
-        }
-
-        for url in otherPruneURLs {
-            do {
+            for url in otherPruneURLs {
                 try url.enumerateContents { file, _ in
                     let appName = file.deletingPathExtension().lastPathComponent
                     if !appNames.contains(appName) {
                         FileManager.default.delete(at: file)
                     }
                 }
-            } catch {
-                Log.shared.error(error)
             }
+        } catch {
+            Log.shared.error(error)
         }
     }
 }

--- a/PlayCover/Views/Uninstaller.swift
+++ b/PlayCover/Views/Uninstaller.swift
@@ -123,6 +123,7 @@ class Uninstaller {
             FileManager.default.delete(at: app.entitlements)
         }
 
+        app.removeAlias()
         app.deleteApp()
     }
 

--- a/PlayCover/Views/Uninstaller.swift
+++ b/PlayCover/Views/Uninstaller.swift
@@ -20,6 +20,9 @@ class Uninstaller {
         PlayTools.playCoverContainer.appendingPathComponent("Entitlements"),
         PlayTools.playCoverContainer.appendingPathComponent("Keymapping")
     ]
+    private static let otherPruneURLs: [URL] = [
+        PlayApp.aliasDirectory
+    ]
     private static let cacheURLs: [URL] = [
         Uninstaller.libraryUrl.appendingPathComponent("Containers"),
         Uninstaller.libraryUrl.appendingPathComponent("Application Scripts"),
@@ -135,6 +138,7 @@ class Uninstaller {
 
     static func pruneFiles() {
         let bundleIds = AppsVM.shared.apps.map { $0.info.bundleIdentifier }
+        let appNames = AppsVM.shared.apps.map { $0.info.displayName }
 
         for url in pruneURLs {
             do {
@@ -143,6 +147,19 @@ class Uninstaller {
                     if !bundleIds.contains(bundleId) {
                         clearExternalCache(bundleId)
 
+                        FileManager.default.delete(at: file)
+                    }
+                }
+            } catch {
+                Log.shared.error(error)
+            }
+        }
+
+        for url in otherPruneURLs {
+            do {
+                try url.enumerateContents { file, _ in
+                    let appName = file.deletingPathExtension().lastPathComponent
+                    if !appNames.contains(appName) {
                         FileManager.default.delete(at: file)
                     }
                 }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -164,8 +164,8 @@
 "settings.toggle.jbBypass.help" = "Attempts to bypass Jailbreak Detection in some games (Not guaranteed to work all the time)";
 
 "settings.removePlayTools" = "Remove PlayTools";
-"settings.createAlias" = "Create alias";
-"settings.removeAlias" = "Remove alias";
+"settings.addToLaunchpad" = "Add to Launchpad";
+"settings.removeFromLaunchpad" = "Remove from Launchpad";
 
 "settings.info.displayName" = "Display name:";
 "settings.info.bundleName" = "Bundle name:";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -164,6 +164,8 @@
 "settings.toggle.jbBypass.help" = "Attempts to bypass Jailbreak Detection in some games (Not guaranteed to work all the time)";
 
 "settings.removePlayTools" = "Remove PlayTools";
+"settings.createAlias" = "Create alias";
+"settings.removeAlias" = "Remove alias";
 
 "settings.info.displayName" = "Display name:";
 "settings.info.bundleName" = "Bundle name:";


### PR DESCRIPTION
A reimplementation of https://github.com/PlayCover/PlayCover/pull/599 with `writeBookmarkData` instead of AppleScript.