### PR TITLE
Warn duplicate source url

### DIFF
--- a/PlayCover/ViewModel/StoreVM.swift
+++ b/PlayCover/ViewModel/StoreVM.swift
@@ -100,7 +100,10 @@ class StoreVM: ObservableObject {
                                 let data: [StoreAppData] = try JSONDecoder().decode([StoreAppData].self, from: jsonData)
                                 if data.count > 0 {
                                     Task { @MainActor in
-                                        self.sources[index].status = .valid
+                                        self.sources[index].status =
+                                            sources[0..<index].filter({
+                                                $0.source == sources[index].source && $0.id != sources[index].id
+                                            }).isEmpty ? .valid : .duplicate
                                         self.appendAppData(data)
                                     }
                                     return

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -49,6 +49,7 @@
 "preferences.popover.valid" = "Link Valid";
 "preferences.popover.badurl"  = "URL Invalid!";
 "preferences.popover.badjson" = "JSON Invalid or Not Found!";
+"preferences.popover.duplicate" = "Duplicate Link";
 "preferences.textfield.url" = "Source URL...";
 "preferences.tab.install" = "Install";
 "preferences.toggle.showInstallPopup" = "Show install PlayTools popup";


### PR DESCRIPTION
Informs the user if the url is already in their IPA Library, and shows if a url is a duplicate in settings. This will still allows the user to add the url, and only provides a warning.