### PR TITLE
Local IPA file link in IPA library

### DIFF
--- a/PlayCover/AppInstaller/Downloader.swift
+++ b/PlayCover/AppInstaller/Downloader.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import CryptoKit
 import DownloadManager
 
 /// DownloaderManager can be configured through this struct, default values are as the same as below
@@ -57,7 +56,11 @@ class DownloadApp {
                 }
             }
 
-            proceedDownload()
+            if let url = url, url.isFileURL {
+                proceedInstall(url, deleteIPA: false)
+            } else {
+                proceedDownload()
+            }
         }
     }
 
@@ -86,18 +89,10 @@ class DownloadApp {
 
     private func verifyChecksum(checksum: String?, file: URL?, completion: @escaping(Bool) -> Void) {
         Task {
-            if let originalSum = self.downloadVM.storeAppData?.checksum, !originalSum.isEmpty, let fileURL = file {
-                do {
-                    let sha256 = SHA256.hash(data: try Data(contentsOf: fileURL))
-                                       .map { String(format: "%02hhx", $0) }
-                                       .joined()
-
-                    if originalSum != sha256 {
-                        checksumAlert(originalSum: originalSum, givenSum: sha256, completion: completion)
-                        return
-                    }
-                } catch {
-                    print("Error in calculating sha256sum: \(error)")
+            if let originalSum = checksum, !originalSum.isEmpty, let fileURL = file {
+                if let sha256 = fileURL.sha256, originalSum != sha256 {
+                    checksumAlert(originalSum: originalSum, givenSum: sha256, completion: completion)
+                    return
                 }
             }
 
@@ -148,12 +143,14 @@ class DownloadApp {
         }
     }
 
-    private func proceedInstall(_ url: URL?) {
+    private func proceedInstall(_ url: URL?, deleteIPA: Bool = true) {
         if let url = url {
             uif.ipaUrl = url
             Installer.install(ipaUrl: uif.ipaUrl!, export: false, returnCompletion: { _ in
                 Task { @MainActor in
-                    FileManager.default.delete(at: url)
+                    if deleteIPA {
+                        FileManager.default.delete(at: url)
+                    }
                     AppsVM.shared.fetchApps()
                     StoreVM.shared.resolveSources()
                     NotifyService.shared.notify(

--- a/PlayCover/Utils/Extensions/URLExtensions.swift
+++ b/PlayCover/Utils/Extensions/URLExtensions.swift
@@ -5,6 +5,7 @@
 
 import AppKit
 import Foundation
+import CryptoKit
 import SwiftUI
 
 extension String {
@@ -32,6 +33,16 @@ extension URL {
 
     var isDirectory: Bool {
         (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+    }
+
+    var sha256: String? {
+        do {
+            return SHA256.hash(data: try Data(contentsOf: self))
+                .map { String(format: "%02hhx", $0) }
+                .joined()
+        } catch {
+            return nil
+        }
     }
 
     func openInFinder() {


### PR DESCRIPTION
Allow IPA Library sources to include local files `file://`. Skips download step and directly installs IPA.