### PR TITLE
Properly deselect app when uninstalling

### DIFF
--- a/PlayCover/Views/App Views/PlayAppView.swift
+++ b/PlayCover/Views/App Views/PlayAppView.swift
@@ -109,6 +109,7 @@ struct PlayAppView: View {
                     Text("playapp.clearPreferences")
                 })
                 Button(action: {
+                    selected = nil
                     Uninstaller.uninstallPopup(app)
                 }, label: {
                     Text("playapp.delete")


### PR DESCRIPTION
Sets selected app to `nil` when the uninstall button has been pressed. Fixes #786.