### PR TITLE
Allow user to manually clear PlayChain data from PlayCover

### DIFF
--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -107,7 +107,11 @@ class PlayApp: BaseApp {
             .appendingPathComponent("Applications")
             .appendingPathComponent("PlayCover")
 
+    static let playChainDirectory = PlayTools.playCoverContainer.appendingPathComponent("PlayChain")
+
     lazy var aliasURL = PlayApp.aliasDirectory.appendingPathComponent(name)
+
+    lazy var playChainURL = PlayApp.playChainDirectory.appendingPathComponent(info.bundleIdentifier)
 
     lazy var settings = AppSettings(info, container: container)
 
@@ -142,6 +146,10 @@ class PlayApp: BaseApp {
 
     func clearAllCache() {
         Uninstaller.clearExternalCache(info.bundleIdentifier)
+    }
+
+    func clearPlayChain() {
+        FileManager.default.delete(at: playChainURL)
     }
 
     func createAlias() {
@@ -195,9 +203,11 @@ class PlayApp: BaseApp {
     var prohibitedToPlay: Bool {
         PlayApp.PROHIBITED_APPS.contains(info.bundleIdentifier)
     }
+
     var maliciousProhibited: Bool {
         PlayApp.MALICIOUS_APPS.contains(info.bundleIdentifier)
     }
+
     static let PROHIBITED_APPS = [
         "com.activision.callofduty.shooter",
         "com.ea.ios.apexlegendsmobilefps",
@@ -208,8 +218,9 @@ class PlayApp: BaseApp {
         "com.tencent.tmgp.pubgmhd",
         "com.dts.freefireth",
         "com.dts.freefiremax"
-]
+    ]
+
     static let MALICIOUS_APPS = [
         "com.zhiliaoapp.musically"
-]
+    ]
 }

--- a/PlayCover/Views/App Views/PlayAppView.swift
+++ b/PlayCover/Views/App Views/PlayAppView.swift
@@ -18,6 +18,7 @@ struct PlayAppView: View {
     @State private var showClearCacheAlert = false
     @State private var showClearCacheToast = false
     @State private var showClearPreferencesAlert = false
+    @State private var showClearPlayChainAlert = false
 
     @State var showImportSuccess = false
     @State var showImportFail = false
@@ -98,16 +99,24 @@ struct PlayAppView: View {
                     }
                 }
                 Divider()
-                Button(action: {
-                    showClearCacheAlert.toggle()
-                }, label: {
-                    Text("playapp.clearCache")
-                })
-                Button(action: {
-                    showClearPreferencesAlert.toggle()
-                }, label: {
-                    Text("playapp.clearPreferences")
-                })
+                Group {
+                    Button(action: {
+                        showClearCacheAlert.toggle()
+                    }, label: {
+                        Text("playapp.clearCache")
+                    })
+                    Button(action: {
+                        showClearPreferencesAlert.toggle()
+                    }, label: {
+                        Text("playapp.clearPreferences")
+                    })
+                    Button(action: {
+                        showClearPlayChainAlert.toggle()
+                    }, label: {
+                        Text("playapp.clearPlayChain")
+                    })
+                }
+                Divider()
                 Button(action: {
                     Uninstaller.uninstallPopup(app)
                 }, label: {
@@ -124,16 +133,23 @@ struct PlayAppView: View {
                 DeleteGenshinAccountView()
             }
             .alert("alert.app.delete", isPresented: $showClearCacheAlert) {
-                Button("button.Proceed", role: .cancel) {
+                Button("button.Proceed", role: .destructive) {
                     app.clearAllCache()
                     showClearCacheToast.toggle()
                 }
                 Button("button.Cancel", role: .cancel) { }
             }
             .alert("alert.app.preferences", isPresented: $showClearPreferencesAlert) {
-                Button("button.Proceed", role: .cancel) {
+                Button("button.Proceed", role: .destructive) {
                     deletePreferences(app: app.info.bundleIdentifier)
                     showClearPreferencesAlert.toggle()
+                }
+                Button("button.Cancel", role: .cancel) { }
+            }
+            .alert("alert.app.clearPlayChain", isPresented: $showClearPlayChainAlert) {
+                Button("button.Proceed", role: .destructive) {
+                    app.clearPlayChain()
+                    showClearPlayChainAlert.toggle()
                 }
                 Button("button.Cancel", role: .cancel) { }
             }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -4,6 +4,7 @@
 "playapp.showInFinder" = "Show in Finder";
 "playapp.openCache" = "Open App Data";
 "playapp.clearCache" = "Clear App Data";
+"playapp.clearPlayChain" = "Clear PlayChain Data";
 "playapp.importIPA" = "Import IPA";
 "playapp.importKm" = "Import Keymapping";
 "playapp.exportKm" = "Export Keymapping";
@@ -96,6 +97,7 @@
 "alert.errorImportKm" = "Error occured when importing!";
 "alert.app.delete" = "All app data will be erased. You may need to download app files again. Do you wish to continue?";
 "alert.app.preferences" = "All in-app preferences will be deleted. Do you wish to continue?";
+"alert.app.clearPlayChain" = "All PlayChain data will be erased. You may need to login to the app again. Do you wish to continue?";
 "alert.restart" = "Please restart PlayCover.";
 "alert.error" = "An error occurred!";
 "alert.success" = "Success";


### PR DESCRIPTION
Add a new button that deletes the selected app's PlayChain data.