### PR TITLE
High resolution warning

### DIFF
--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -176,6 +176,8 @@ struct GraphicsView: View {
     @State var customWidth = 1920
     @State var customHeight = 1080
 
+    @State var showResolutionWarning = false
+
     static var number: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .none
@@ -198,6 +200,18 @@ struct GraphicsView: View {
                         Text("iPhone 14 Pro Max | A16 | 6GB").tag("iPhone15,3")
                     }
                     .frame(width: 250)
+                }
+                HStack {
+                    if showResolutionWarning {
+                        Spacer()
+                        let highResIcon = Image(systemName: "exclamationmark.triangle")
+                        let warning = NSLocalizedString("settings.highResolution", comment: "")
+
+                        Text("\(highResIcon) \(warning)")
+                            .font(.caption)
+                    } else {
+                        Spacer()
+                    }
                 }
                 HStack {
                     Text("settings.picker.adaptiveRes")
@@ -325,12 +339,14 @@ struct GraphicsView: View {
             height = customHeight
         // Adaptive resolution = Off
         default:
-            width = 1920
             height = 1080
+            width = 1920
         }
 
         settings.settings.windowWidth = width
         settings.settings.windowHeight = height
+
+        showResolutionWarning = width*height >= 2621440 // Tends to crash when the number of pixels exceeds that
     }
 
     func getWidthFromAspectRatio(_ height: Int) -> Int {

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -172,6 +172,7 @@
 "settings.toggle.disableDisplaySleep" = "Disable display sleep";
 "settings.toggle.disableDisplaySleep.help" = "Prevent display from turning off while this app is running";
 "settings.noPlayTools" = "PlayTools is not installed in this app";
+"settings.highResolution" = "High resolution may cause crashing";
 
 "settings.tab.bypasses" = "Bypasses";
 "settings.toggle.jbBypass" = "Enable Jailbreak Bypass (Experimental)";


### PR DESCRIPTION
High app resolution will provide a warning in settings when it is selected. The height and width of the selected resolution are multiplied and compared against 2,621,440 pixels (2048x1280), as it was found that that would cause crashing in certain graphic intensive apps.