### PR TITLE
Revert "Add `install_name_tool` replacement"

### DIFF
--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -239,8 +239,6 @@ class PlayTools {
         try removeOldCommand(macho)
         print("Injecting new version command in MachO")
         try injectNewCommand(macho)
-        print("Replacing instances of @rpath dylibs")
-        try replaceLibraries(macho)
     }
 
     static func removeOldCommand(_ url: URL) throws {
@@ -355,34 +353,6 @@ class PlayTools {
         binary.replaceSubrange(machoRange, with: newHeaderData)
         try FileManager.default.removeItem(at: url)
         try binary.write(to: url)
-    }
-
-    static func replaceLibraries(_ url: URL) throws {
-        let dylibsToReplace = ["libswiftUIKit"]
-
-        for dylib in dylibsToReplace {
-            let rpathDylib = "@rpath/\(dylib).dylib"
-            let libDylib = "/usr/lib/swift/\(dylib).dylib"
-            Inject.removeMachO(machoPath: url.path,
-                               cmdType: LC_Type.LOAD_DYLIB,
-                               backup: false,
-                               injectPath: rpathDylib,
-                               finishHandle: { result in
-                if result {
-                    Inject.injectMachO(machoPath: url.path,
-                                       cmdType: LC_Type.LOAD_DYLIB,
-                                       backup: false,
-                                       injectPath: libDylib,
-                                       finishHandle: { result in
-                        if result {
-                            return
-                        } else {
-                            print("Failed to insert \(dylib).dylib!")
-                        }
-                    })
-                }
-            })
-        }
     }
 
     static func isMachoEncrypted(atURL url: URL) throws -> Bool {


### PR DESCRIPTION
Reverts PlayCover/PlayCover#794

I made several mistakes in implementing this, and it has proven more problematic than lacking `install_name_tool` functionality altogether. I will fix this functionality later, but for now I think it's best if this naive implementation is removed.