### PR TITLE
Fix XCLT-less Installer

### DIFF
--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -244,6 +244,7 @@ class PlayTools {
         print("Replacing instances of @rpath dylibs...")
         try replaceLibraries(&binary)
 
+        print("Writing revised MachO...")
         try FileManager.default.removeItem(at: macho)
         try binary.write(to: macho)
     }

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -95,7 +95,7 @@ class PlayTools {
                 if arch.cputype == CPU_TYPE_ARM64 {
                     print("Found ARM64 arch in fat binary")
 
-                    let thinBinary = binary
+                    binary = binary
                         .subdata(in: Int(arch.offset)..<Int(arch.offset+arch.size))
 
                     return

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -343,7 +343,7 @@ class PlayTools {
         let testString = String(data: subData, encoding: .utf8)?
             .trimmingCharacters(in: .controlCharacters)
         if testString != "" && testString != nil {
-            Log.shared.error("Not enough space in binary!")
+            Log.shared.error("Failed to replace \(rpath) with \(lib). Not enough space in binary!")
             return
         }
 
@@ -430,7 +430,7 @@ class PlayTools {
         let testString = String(data: subData, encoding: .utf8)?
             .trimmingCharacters(in: .controlCharacters)
         if testString != "" && testString != nil {
-            Log.shared.error("Not enough space in binary!")
+            Log.shared.error("Failed to replace version command. Not enough space in binary!")
             return
         }
 

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -248,7 +248,7 @@ class PlayTools {
 
         for dylib in dylibsToReplace {
             let rpathDylib = "@rpath/\(dylib).dylib"
-            let libDylib = "/usr/lib/swift/\(dylib).dylib"
+            let libDylib = "/System/iOSSupport/usr/lib/swift/\(dylib).dylib"
 
             // 1. Check if dylib LC exists
             // 2. If it exists, take note if it is weak or strong and copy version info

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -370,7 +370,7 @@ class PlayTools {
                           timestamp: oldDylibData!.timestamp,
                           current_version: oldDylibData!.current_version,
                           compatibility_version: oldDylibData!.compatibility_version)
-        var command = dylib_command(cmd: UInt32(isWeak ? Int32(LC_LOAD_WEAK_DYLIB) : LC_LOAD_DYLIB),
+        var command = dylib_command(cmd: isWeak ? LC_LOAD_WEAK_DYLIB : UInt32(LC_LOAD_DYLIB),
                                     cmdsize: UInt32(cmdsize),
                                     dylib: dylib)
 

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -309,7 +309,7 @@ class PlayTools {
             // dylib with given rpath was not found in binary
             return
         }
-        
+
         print("Found \(rpath) in binary")
 
         // Perform step 3

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -307,9 +307,10 @@ class PlayTools {
 
         if !dylibExists {
             // dylib with given rpath was not found in binary
-            print("\(rpath) does not exist in this binary")
             return
         }
+        
+        print("Found \(rpath) in binary")
 
         // Perform step 3
         if let start = start,
@@ -342,7 +343,7 @@ class PlayTools {
         let testString = String(data: subData, encoding: .utf8)?
             .trimmingCharacters(in: .controlCharacters)
         if testString != "" && testString != nil {
-            print("Not enough space in binary!")
+            Log.shared.error("Not enough space in binary!")
             return
         }
 
@@ -429,7 +430,7 @@ class PlayTools {
         let testString = String(data: subData, encoding: .utf8)?
             .trimmingCharacters(in: .controlCharacters)
         if testString != "" && testString != nil {
-            print("Not enough space in binary!")
+            Log.shared.error("Not enough space in binary!")
             return
         }
 

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -445,7 +445,7 @@ class PlayTools {
     static func isMachoEncrypted(atURL url: URL) throws -> Bool {
         var binary = try Data(contentsOf: url)
         try stripBinary(&binary)
-        
+
         return try isSlimMachoEncrypted(binary: binary)
     }
 
@@ -481,7 +481,7 @@ class PlayTools {
 
         return false
     }
-    
+
     static func isMachoValidArch(_ url: URL) throws -> Bool {
         var binary = try Data(contentsOf: url)
         try stripBinary(&binary)

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -347,7 +347,7 @@ class PlayTools {
         start = Int(header.ncmds) + Int(MemoryLayout<mach_header_64>.size)
         end! += start!
         subData = binary[start!..<end!]
-        
+
         newHeader = mach_header_64(magic: header.magic,
                                    cputype: header.cputype,
                                    cpusubtype: header.cpusubtype,
@@ -365,7 +365,7 @@ class PlayTools {
             print("cannot inject payload into \(lib) because there is no room")
             return
         }
-        
+
         let dylib = dylib(name: lc_str(offset: UInt32(MemoryLayout<dylib_command>.size)),
                           timestamp: oldDylibData!.timestamp,
                           current_version: oldDylibData!.current_version,
@@ -379,13 +379,12 @@ class PlayTools {
         commandData.append(Data(bytes: &command, count: MemoryLayout<dylib_command>.size))
         commandData.append(lib.data(using: String.Encoding.ascii) ?? Data())
         commandData.append(Data(bytes: &zero, count: padding))
-        
+
         let subrange = Range(NSRange(location: start!, length: commandData.count))!
         binary.replaceSubrange(subrange, with: commandData)
         binary.replaceSubrange(machoRange!, with: newHeaderData!)
         try FileManager.default.removeItem(at: url)
         try binary.write(to: url)
-        
     }
 
     static func removeOldCommand(_ url: URL) throws {

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -239,6 +239,23 @@ class PlayTools {
         try removeOldCommand(macho)
         print("Injecting new version command in MachO")
         try injectNewCommand(macho)
+        print("Replacing instances of @rpath dylibs")
+        try replaceLibraries(macho)
+    }
+    
+    static func replaceLibraries(_ url: URL) throws {
+        let dylibsToReplace = ["libswiftUIKit"]
+
+        for dylib in dylibsToReplace {
+            let rpathDylib = "@rpath/\(dylib).dylib"
+            let libDylib = "/usr/lib/swift/\(dylib).dylib"
+            
+            // 1. Check if dylib LC exists
+            // 2. If it exists, take note if it is weak or strong and copy version info
+            // 3. Remove the existing rpath LC from header
+            // 4. Append a new LC of the same type to the end of the header with
+            //    the same version info (i.e. only difference will be path and number of bytes in command)
+        }
     }
 
     static func removeOldCommand(_ url: URL) throws {

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -239,8 +239,6 @@ class PlayTools {
         try removeOldCommand(macho)
         print("Injecting new version command in MachO")
         try injectNewCommand(macho)
-        print("Replacing instances of @rpath dylibs")
-        try replaceLibraries(macho)
     }
 
     static func removeOldCommand(_ url: URL) throws {
@@ -355,34 +353,6 @@ class PlayTools {
         binary.replaceSubrange(machoRange, with: newHeaderData)
         try FileManager.default.removeItem(at: url)
         try binary.write(to: url)
-    }
-
-    static func replaceLibraries(_ url: URL) throws {
-        let dylibsToReplace = ["libswiftUIKit"]
-
-        for dylib in dylibsToReplace {
-            let rpathDylib = "@rpath/\(dylib).dylib"
-            let libDylib = "/usr/lib/swift/\(dylib).dylib"
-            Inject.removeMachO(machoPath: url.path,
-                               cmdType: LC_Type.LOAD_DYLIB,
-                               backup: false,
-                               injectPath: rpathDylib,
-                               finishHandle: { result in
-                if result {
-                    Inject.injectMachO(machoPath: url.path,
-                                       cmdType: LC_Type.LOAD_DYLIB,
-                                       backup: false,
-                                       injectPath: libDylib,
-                                       finishHandle: { result in
-                        if result {
-                            return
-                        } else {
-                            print("Failed to insert \(dylib).dylib!")
-                        }
-                    })
-                }
-            })
-        }
     }
 
     static func isMachoEncrypted(atURL url: URL) throws -> Bool {

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -285,10 +285,10 @@ class PlayTools {
             switch UInt32(loadCommand.cmd) {
             case LC_LOAD_WEAK_DYLIB, UInt32(LC_LOAD_DYLIB):
                 let dylibCommand = binary.extract(dylib_command.self, offset: offset)
-                if String.init(data: binary,
-                               offset: offset,
-                               commandSize: Int(dylibCommand.cmdsize),
-                               loadCommandString: dylibCommand.dylib.name) == rpath {
+                if String(data: binary,
+                          offset: offset,
+                          commandSize: Int(dylibCommand.cmdsize),
+                          loadCommandString: dylibCommand.dylib.name) == rpath {
 
                     isWeak = LC_LOAD_WEAK_DYLIB == UInt32(loadCommand.cmd)
                     dylibExists = true
@@ -528,10 +528,10 @@ class PlayTools {
                     swap_dylib_command(&dylibCommand, NXHostByteOrder())
                 }
 
-                let dylibName = String.init(data: binary,
-                                            offset: offset,
-                                            commandSize: Int(dylibCommand.cmdsize),
-                                            loadCommandString: dylibCommand.dylib.name)
+                let dylibName = String(data: binary,
+                                       offset: offset,
+                                       commandSize: Int(dylibCommand.cmdsize),
+                                       loadCommandString: dylibCommand.dylib.name)
                 if dylibName == playToolsPath.esc {
                     return true
                 }

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -333,7 +333,7 @@ class PlayTools {
             commandData.append(binary.subdata(in: restOfHeader))
 
             let newHeaderRange = Range(NSRange(location: startOfCmd,
-                                               length: endOfHeader - startOfCmd + cmdsize))!
+                                               length: endOfHeader - endOfCmd + cmdsize))!
 
             binary.replaceSubrange(newHeaderRange, with: commandData)
         }

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -331,7 +331,7 @@ class PlayTools {
         start = Int(header.sizeofcmds) + Int(MemoryLayout<mach_header_64>.size)
         end = cmdsize + start!
         let subData: Data = binary[start!..<end!]
-        
+
         header.sizeofcmds += UInt32(cmdsize)
         newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header_64>.size)
 

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -272,9 +272,9 @@ class PlayTools {
         var oldDylibData: dylib?
         var oldDylibLength: UInt32 = 0
 
-        var header = binary.extract(mach_header_64.self)
-        var offset = MemoryLayout.size(ofValue: header)
+        let header = binary.extract(mach_header_64.self)
         let machoRange = Range(NSRange(location: 0, length: MemoryLayout<mach_header_64>.size))!
+        var offset = MemoryLayout.size(ofValue: header)
 
         // Perform steps 1-2
         for _ in 0..<header.ncmds {
@@ -364,7 +364,9 @@ class PlayTools {
 
         let subrange = Range(NSRange(location: start!, length: commandData.count))!
         binary.replaceSubrange(subrange, with: commandData)
+
         binary.replaceSubrange(machoRange, with: newHeaderData!)
+
         try FileManager.default.removeItem(at: url)
         try binary.write(to: url)
     }


### PR DESCRIPTION
This should fix XCLT-less installer for realsies this time. Sometimes stuff will fail to install the first time, just try it again and it should work (not sure why lol).

What this PR does:
- Reimplements `install_name_tool` replacement this time it can handle weak and strong LCs
- Introduces several major optimisations to clean up code and significantly reduces the number of writes to disk

Thinks to do:
- [x] Cleanup PlayTools.swift code
- [x] Deal with the "Not enough space in binary" issue
- [x] Maybe work to replace the LC at its original index rather than appending
- [x] Fix missing padding at end of header

Apps I've tested:
- Genshin Impact (Works)
- Payback2 (Works)
- Eversoul (Works)
- Geometry Dash (Works)
- Duolingo (Opens, then crashes)
- Netflix (Works)