### PR TITLE
Fix XCLT-less Installer (#830)

### DIFF
--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -400,22 +400,19 @@ class PlayTools {
                                                    ntools: 0)
 
         start = Int(header.sizeofcmds) + Int(MemoryLayout<mach_header_64>.size)
-        let subData = binary[start!..<start! + Int(versionCommand.cmdsize)]
 
         header.sizeofcmds += versionCommand.cmdsize
         let newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header_64>.size)
-
-        let testString = String(data: subData, encoding: .utf8)?
-            .trimmingCharacters(in: .controlCharacters)
-        if testString != "" && testString != nil {
-            Log.shared.error("Failed to replace version command. Not enough space in binary!")
-            return
-        }
 
         var commandData = Data()
         commandData.append(Data(bytes: &versionCommand, count: MemoryLayout<build_version_command>.size))
 
         let subrange = Range(NSRange(location: start!, length: commandData.count))!
+        if binary.subdata(in: subrange).allSatisfy({ $0 == 0 }) {
+            Log.shared.error("Failed to replace version command. Not enough space in binary!")
+            return
+        }
+
         binary.replaceSubrange(subrange, with: commandData)
 
         binary.replaceSubrange(machoRange, with: newHeaderData)

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -325,7 +325,7 @@ class PlayTools {
 
             let restOfHeader = Range(NSRange(location: endOfCmd, length: endOfHeader - endOfCmd))!
 
-            var zero: UInt = 0
+            var zero: UInt64 = 0
             var commandData = Data()
             commandData.append(Data(bytes: &command, count: MemoryLayout<dylib_command>.size))
             commandData.append(lib.data(using: String.Encoding.ascii) ?? Data())
@@ -382,7 +382,7 @@ class PlayTools {
            let size = size {
             let subrangeNew = Range(NSRange(location: start + size, length: end - start - size))!
             let subrangeOld = Range(NSRange(location: start, length: end - start))!
-            var zero: UInt = 0
+            var zero: UInt64 = 0
             var commandData = Data()
             commandData.append(binary.subdata(in: subrangeNew))
             commandData.append(Data(bytes: &zero, count: size))

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -408,10 +408,6 @@ class PlayTools {
         commandData.append(Data(bytes: &versionCommand, count: MemoryLayout<build_version_command>.size))
 
         let subrange = Range(NSRange(location: start!, length: commandData.count))!
-        if binary.subdata(in: subrange).allSatisfy({ $0 == 0 }) {
-            Log.shared.error("Failed to replace version command. Not enough space in binary!")
-            return
-        }
 
         binary.replaceSubrange(subrange, with: commandData)
 


### PR DESCRIPTION
This should fix XCLT-less installer for realsies this time.

What this PR does:
- Reimplements `install_name_tool` replacement this time it can handle weak and strong LCs
- Introduces several major optimisations to clean up code and significantly reduces the number of writes to disk

Thinks to do:
- [x] Cleanup PlayTools.swift code
- [x] Deal with the "Not enough space in binary" issue
- [x] Maybe work to replace the LC at its original index rather than appending
- [x] Fix missing padding at end of header

Apps I've tested:
- Genshin Impact (Works)
- Payback2 (Works)
- Eversoul (Works)
- Geometry Dash (Works)
- Duolingo (Works)
- Netflix (Works)