### PR TITLE
xclt less installer macho converter code cleanup

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		6E21233128F65F7600B4D75D /* GenshinUserDataURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E21233028F65F7600B4D75D /* GenshinUserDataURLs.swift */; };
 		6E25096F297F5032004D754C /* FileExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E25096E297F5032004D754C /* FileExtensions.swift */; };
 		6E250971297F5281004D754C /* SigningSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E250970297F5281004D754C /* SigningSetupView.swift */; };
+		6E550A8B29BA507200EFC15C /* Macho.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E550A8A29BA507200EFC15C /* Macho.swift */; };
 		6E5C68BA289865C8008EC11B /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5C68B9289865C8008EC11B /* MainView.swift */; };
 		6E66B0BF289DE6240099B907 /* StoreVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E66B0BE289DE6240099B907 /* StoreVM.swift */; };
 		6E66B0C9289F52800099B907 /* IPALibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E66B0C8289F52800099B907 /* IPALibraryView.swift */; };
@@ -120,6 +121,7 @@
 		6E21233028F65F7600B4D75D /* GenshinUserDataURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenshinUserDataURLs.swift; sourceTree = "<group>"; };
 		6E25096E297F5032004D754C /* FileExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExtensions.swift; sourceTree = "<group>"; };
 		6E250970297F5281004D754C /* SigningSetupView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SigningSetupView.swift; sourceTree = "<group>"; };
+		6E550A8A29BA507200EFC15C /* Macho.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Macho.swift; sourceTree = "<group>"; };
 		6E5C68B9289865C8008EC11B /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		6E66B0BE289DE6240099B907 /* StoreVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreVM.swift; sourceTree = "<group>"; };
 		6E66B0C8289F52800099B907 /* IPALibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPALibraryView.swift; sourceTree = "<group>"; };
@@ -315,6 +317,7 @@
 				92EE06DD274EC09F002C907B /* Entitlements.swift */,
 				5314D1ED26C402EC00A0A727 /* Shell.swift */,
 				92B4D38E2737CF3D0001D7BB /* PlayTools.swift */,
+				6E550A8A29BA507200EFC15C /* Macho.swift */,
 				68E48B9B295709BF00C39879 /* Cacher.swift */,
 				92A8AAC8275EFEA800D89B50 /* SystemConfig.swift */,
 				92F8500927675124005CE6BE /* AppIntegrity.swift */,
@@ -640,6 +643,7 @@
 				6E250971297F5281004D754C /* SigningSetupView.swift in Sources */,
 				928C01D9272E162C007EB2DF /* InstallVM.swift in Sources */,
 				6E06193628B3C4090012C771 /* StoreGenshinAccountView.swift in Sources */,
+				6E550A8B29BA507200EFC15C /* Macho.swift in Sources */,
 				6E25096F297F5032004D754C /* FileExtensions.swift in Sources */,
 				53F4D2A026C43C690020167C /* Log.swift in Sources */,
 				B6603E1128E206A300DEFA3F /* UninstallSettings.swift in Sources */,

--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -71,12 +71,12 @@ class Installer {
                 }
 
                 for macho in machos {
-                    if try PlayTools.isMachoEncrypted(atURL: macho) {
+                    if try Macho.isMachoEncrypted(atURL: macho) {
                         throw PlayCoverError.appEncrypted
                     }
 
                     if !export {
-                        try PlayTools.convertMacho(macho)
+                        try Macho.convertMacho(macho)
                         try fakesign(macho)
                     }
                 }

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -39,7 +39,7 @@ class PlayApp: BaseApp {
 
             if try !PlayTools.isInstalled() {
                 Log.shared.error("PlayTools are not installed! Please move PlayCover.app into Applications!")
-            } else if try !PlayTools.isMachoValidArch(executable) {
+            } else if try !Macho.isMachoValidArch(executable) {
                 Log.shared.error("The app threw an error during conversion.")
             } else if try !isCodesigned() {
                 Log.shared.error("The app is not codesigned! Please open Xcode and accept license agreement.")

--- a/PlayCover/Utils/Extensions/DataExtensions.swift
+++ b/PlayCover/Utils/Extensions/DataExtensions.swift
@@ -16,14 +16,17 @@ extension String {
 }
 
 extension Data {
-    func extract<T>(_ type: T.Type, offset: Int = 0) -> T {
+    func extract<T>(_ type: T.Type, offset: Int = 0,
+                    swap: ((UnsafeMutablePointer<T>, NXByteOrder) -> Void)? = nil) -> T {
         let data = self[offset..<offset + MemoryLayout<T>.size]
-        return data.withUnsafeBytes { dataBytes in
+        var result = data.withUnsafeBytes { dataBytes in
             dataBytes.baseAddress!
                 .assumingMemoryBound(to: UInt8.self)
                 .withMemoryRebound(to: T.self, capacity: 1) { (pointer) -> T in
                 return pointer.pointee
             }
         }
+        swap?(&result, NXHostByteOrder())
+        return result
     }
 }

--- a/PlayCover/Utils/Macho.swift
+++ b/PlayCover/Utils/Macho.swift
@@ -192,9 +192,14 @@ class Macho {
         }
 
         let injectionEnd = movedCommandsEnd - Int(oldCommandSize) + Int(newCommandSize)
-        // may check for space availability in loadCommandsEnd..<injectionEnd
-        binary.replaceSubrange(movedCommandsEnd-Int(oldCommandSize) ..< movedCommandsEnd,
-                               with: Data(count: Int(oldCommandSize)))
+        if injectionEnd > movedCommandsEnd {
+            if let nonZero = binary[movedCommandsEnd ..< injectionEnd].first(where: {$0 != 0}) {
+                print("Non zero value \(nonZero) found after load commands. Injection may overlap data section")
+            }
+        } else {
+            binary.replaceSubrange(injectionEnd ..< movedCommandsEnd,
+                                   with: Data(count: movedCommandsEnd - injectionEnd))
+        }
         binary.replaceSubrange(oldCommandStart..<injectionEnd, with: resultingCommandsData)
 
         // Write new header data

--- a/PlayCover/Utils/Macho.swift
+++ b/PlayCover/Utils/Macho.swift
@@ -2,8 +2,6 @@
 //  Macho.swift
 //  PlayCover
 //
-//  Created by 许沂聪 on 2023/3/8.
-//
 
 import Foundation
 

--- a/PlayCover/Utils/Macho.swift
+++ b/PlayCover/Utils/Macho.swift
@@ -1,0 +1,274 @@
+//
+//  Macho.swift
+//  PlayCover
+//
+//  Created by 许沂聪 on 2023/3/8.
+//
+
+import Foundation
+
+class Macho {
+    static func stripBinary(_ binary: inout Data) throws {
+        var header = binary.extract(fat_header.self)
+        var offset = MemoryLayout.size(ofValue: header)
+        let shouldSwap = header.magic == FAT_CIGAM
+
+        if header.magic == FAT_MAGIC || header.magic == FAT_CIGAM {
+            // Make sure the endianness is correct
+            if shouldSwap {
+                swap_fat_header(&header, NXHostByteOrder())
+            }
+
+            for _ in 0..<header.nfat_arch {
+                var arch = binary.extract(fat_arch.self, offset: offset)
+                if shouldSwap {
+                    swap_fat_arch(&arch, 1, NXHostByteOrder())
+                }
+
+                if arch.cputype == CPU_TYPE_ARM64 {
+                    print("Found ARM64 arch in fat binary")
+
+                    binary = binary
+                        .subdata(in: Int(arch.offset)..<Int(arch.offset+arch.size))
+
+                    return
+                }
+
+                offset += Int(MemoryLayout.size(ofValue: arch))
+            }
+
+            throw PlayCoverError.failedToStripBinary
+        }
+    }
+
+    static func convertMacho(_ macho: URL) throws {
+        print("Converting MachO at \(macho.path)")
+
+        var binary = try Data(contentsOf: macho)
+
+        print("Stripping MachO...")
+        try stripBinary(&binary)
+        print("Replacing version command...")
+        try replaceVersionCommand(&binary)
+        print("Replacing instances of @rpath dylibs...")
+        try replaceLibraries(&binary)
+
+        print("Writing revised MachO...")
+        try FileManager.default.removeItem(at: macho)
+        try binary.write(to: macho)
+    }
+
+    static func replaceLibraries(_ binary: inout Data) throws {
+        let dylibsToReplace = ["libswiftUIKit"]
+
+        for dylib in dylibsToReplace {
+            let rpathDylib = "@rpath/\(dylib).dylib"
+            let libDylib = "/System/iOSSupport/usr/lib/swift/\(dylib).dylib"
+
+            // 1. Check if dylib LC exists
+            // 2. If it exists, take notes of its command type and dylib struct
+            // 3. Replace existing LC with new dylib path
+
+            try replaceLibrary(&binary, rpathDylib, libDylib)
+        }
+    }
+
+    static func replaceLibrary(_ binary: inout Data, _ rpath: String, _ lib: String) throws {
+        var dylibCommandType: UInt32 = 0
+        var oldDylib: dylib?
+
+        try replaceLastCommand(&binary, satisfy: {commandData, shouldSwap in
+            // Perform steps 1-2
+            let loadCommand = commandData.extract(load_command.self, offset: commandData.startIndex,
+                                                  swap: shouldSwap ? swap_load_command:nil)
+            if ![LC_LOAD_WEAK_DYLIB, UInt32(LC_LOAD_DYLIB)].contains(loadCommand.cmd) {
+                return false
+            }
+            let dylibCommand = commandData.extract(dylib_command.self, offset: commandData.startIndex,
+                                                   swap: shouldSwap ? swap_dylib_command:nil)
+            if String(data: commandData,
+                      offset: commandData.startIndex,
+                      commandSize: Int(dylibCommand.cmdsize),
+                      loadCommandString: dylibCommand.dylib.name) != rpath {
+                return false
+            }
+            dylibCommandType = dylibCommand.cmd
+            oldDylib = dylibCommand.dylib
+            return true
+
+        }, with: {shouldSwap in
+            guard var newDylib = oldDylib else {
+                // dylib with given rpath was not found in binary
+                return nil
+            }
+
+            print("Found \(rpath) in binary")
+
+            // Perform step 3
+            let dylibCommandFixedSize = MemoryLayout<dylib_command>.size
+            let stringLength = lib.lengthOfBytes(using: String.Encoding.utf8)
+            // Align to 8 bytes, leave at least 1 zero for C-style string ending
+            let padding = 8 - (stringLength % 8)
+            let newDylibCommandSize = dylibCommandFixedSize + stringLength + padding
+
+            newDylib.name = lc_str(offset: UInt32(dylibCommandFixedSize))
+            var command = dylib_command(cmd: dylibCommandType,
+                                        cmdsize: UInt32(newDylibCommandSize),
+                                        dylib: newDylib)
+            guard let stringData = lib.data(using: String.Encoding.utf8) else {
+                print("Failed to replace dylib command: unrecognized character in target path")
+                return nil
+            }
+            if shouldSwap {
+                swap_dylib_command(&command, NX_BigEndian)
+            }
+            var commandData = Data(bytes: &command, count: dylibCommandFixedSize)
+            commandData.append(stringData)
+            commandData.append(Data(count: padding))
+            return commandData
+        }, atEnd: false)
+    }
+
+    static func replaceVersionCommand(_ binary: inout Data) throws {
+
+        var macCatalystCommand = build_version_command(cmd: UInt32(LC_BUILD_VERSION),
+                                                   cmdsize: 24,
+                                                   platform: UInt32(PLATFORM_MACCATALYST),
+                                                   minos: 0x000b0000,
+                                                   sdk: 0x000e0000,
+                                                   ntools: 0)
+
+        try replaceLastCommand(&binary, satisfy: {data, shouldSwap in
+            let loadCommand = data.extract(load_command.self, offset: data.startIndex,
+                                           swap: shouldSwap ? swap_load_command:nil)
+            return [UInt32(LC_VERSION_MIN_IPHONEOS),
+                UInt32(LC_VERSION_MIN_MACOSX),
+                UInt32(LC_BUILD_VERSION)]
+                .contains(loadCommand.cmd)
+
+        }, with: {shouldSwap in
+            if shouldSwap {
+                swap_build_version_command(&macCatalystCommand, NX_BigEndian)
+            }
+            return Data(bytes: &macCatalystCommand, count: MemoryLayout<build_version_command>.size)
+        }, atEnd: true)
+    }
+
+    static func replaceLastCommand(_ binary: inout Data, satisfy isTargetCommand: (Data, Bool) -> Bool,
+                                   with getNewCommandData: (Bool) -> Data?, atEnd shouldAppend: Bool) throws {
+        let headerSize = MemoryLayout<mach_header_64>.size
+        var header = binary.extract(mach_header_64.self)
+        var shouldSwap = false
+
+        var oldCommandStart = headerSize
+        var oldCommandSize: UInt32 = 0
+
+        let movedCommandsEnd = try iterateLoadCommands(binary: binary) { offset, needSwap in
+            let loadCommand = binary.extract(load_command.self, offset: offset,
+                                             swap: needSwap ? swap_load_command:nil)
+            if isTargetCommand(binary[offset ..< offset+Int(loadCommand.cmdsize)], needSwap) {
+                oldCommandStart = offset
+                oldCommandSize = loadCommand.cmdsize
+                shouldSwap = needSwap
+            }
+            return false
+        }
+        if movedCommandsEnd != headerSize + Int(header.sizeofcmds) {
+            print("Error while replacing load command: end of commands mismatch")
+        }
+
+        let oldCommandEnd = oldCommandStart + Int(oldCommandSize)
+        guard let newCommandData = getNewCommandData(shouldSwap) else {
+            return
+        }
+        let newCommandSize = UInt32(newCommandData.count)
+
+        var resultingCommandsData = binary[oldCommandEnd..<movedCommandsEnd]
+        if shouldAppend {
+            resultingCommandsData.append(newCommandData)
+        } else {
+            resultingCommandsData.insert(contentsOf: newCommandData,
+                                         at: resultingCommandsData.startIndex)
+        }
+
+        let injectionEnd = movedCommandsEnd - Int(oldCommandSize) + Int(newCommandSize)
+        // may check for space availability in loadCommandsEnd..<injectionEnd
+        binary.replaceSubrange(movedCommandsEnd-Int(oldCommandSize) ..< movedCommandsEnd,
+                               with: Data(count: Int(oldCommandSize)))
+        binary.replaceSubrange(oldCommandStart..<injectionEnd, with: resultingCommandsData)
+
+        // Write new header data
+        header.sizeofcmds -= oldCommandSize
+        header.sizeofcmds += newCommandSize
+        let newHeaderData = Data(bytes: &header, count: headerSize)
+        binary.replaceSubrange(0..<headerSize, with: newHeaderData)
+    }
+
+    static func iterateLoadCommands(binary: Data, _ evaluate: (Int, Bool) -> Bool) throws -> Int {
+        let headerSize = MemoryLayout<mach_header_64>.size
+        var header = binary.extract(mach_header_64.self)
+        var offset = headerSize
+        let shouldSwap = header.magic == MH_CIGAM_64
+        if  shouldSwap {
+            swap_mach_header_64(&header, NXHostByteOrder())
+            print("Slim Mach-O has reversed byte order")
+        }
+
+        let allCommandsEnd = headerSize + Int(header.sizeofcmds)
+        if allCommandsEnd >= binary.count || allCommandsEnd <= headerSize {
+            print("Cannot iterate load commands: Mach-O file is corrupted(-1)")
+            throw PlayCoverError.appCorrupted
+        }
+        for index in 0..<header.ncmds {
+            let loadCommand = binary.extract(load_command.self, offset: offset,
+                                             swap: shouldSwap ? swap_load_command:nil)
+            let commandEnd = offset + Int(loadCommand.cmdsize)
+            if commandEnd > allCommandsEnd || commandEnd <= offset {
+                print("Cannot iterate load commands: Mach-O file is corrupted(\(index))")
+                throw PlayCoverError.appCorrupted
+            }
+            let terminated = evaluate(offset, shouldSwap)
+            offset = commandEnd
+            if terminated {
+                break
+            }
+        }
+        return offset
+    }
+
+    static func isMachoEncrypted(atURL url: URL) throws -> Bool {
+        var binary = try Data(contentsOf: url)
+        try stripBinary(&binary)
+        var result = false
+        _ = try iterateLoadCommands(binary: binary) { offset, shouldSwap in
+            let loadCommand = binary.extract(load_command.self, offset: offset,
+                                                  swap: shouldSwap ? swap_load_command:nil)
+            if loadCommand.cmd == UInt32(LC_ENCRYPTION_INFO_64) {
+                let infoCommand = binary.extract(encryption_info_command_64.self, offset: offset,
+                                                      swap: shouldSwap ? swap_encryption_command_64:nil)
+                result = infoCommand.cryptid != 0
+                return true
+            }
+            return false
+        }
+        return result
+    }
+
+    static func isMachoValidArch(_ url: URL) throws -> Bool {
+        var binary = try Data(contentsOf: url)
+        try stripBinary(&binary)
+        var result = false
+        _ = try iterateLoadCommands(binary: binary) { offset, shouldSwap in
+            let loadCommand = binary.extract(load_command.self, offset: offset,
+                                                  swap: shouldSwap ? swap_load_command:nil)
+            if loadCommand.cmd == UInt32(LC_BUILD_VERSION) {
+                let versionCommand = binary.extract(build_version_command.self, offset: offset,
+                                                         swap: shouldSwap ? swap_build_version_command:nil)
+                result = versionCommand.platform == PLATFORM_MACCATALYST
+                return true
+            }
+            return false
+        }
+        return result
+    }
+}

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -6,10 +6,6 @@
 import Foundation
 import injection
 
-// swiftlint:disable type_body_length
-// swiftlint:disable file_length
-// swiftlint:disable function_body_length
-
 class PlayTools {
     private static let frameworksURL = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Library")
@@ -75,42 +71,9 @@ class PlayTools {
         }
     }
 
-    static func stripBinary(_ binary: inout Data) throws {
-        var header = binary.extract(fat_header.self)
-        var offset = MemoryLayout.size(ofValue: header)
-        let shouldSwap = header.magic == FAT_CIGAM
-
-        if header.magic == FAT_MAGIC || header.magic == FAT_CIGAM {
-            // Make sure the endianness is correct
-            if shouldSwap {
-                swap_fat_header(&header, NXHostByteOrder())
-            }
-
-            for _ in 0..<header.nfat_arch {
-                var arch = binary.extract(fat_arch.self, offset: offset)
-                if shouldSwap {
-                    swap_fat_arch(&arch, 1, NXHostByteOrder())
-                }
-
-                if arch.cputype == CPU_TYPE_ARM64 {
-                    print("Found ARM64 arch in fat binary")
-
-                    binary = binary
-                        .subdata(in: Int(arch.offset)..<Int(arch.offset+arch.size))
-
-                    return
-                }
-
-                offset += Int(MemoryLayout.size(ofValue: arch))
-            }
-
-            throw PlayCoverError.failedToStripBinary
-        }
-    }
-
     static func installInIPA(_ exec: URL) throws {
         var binary = try Data(contentsOf: exec)
-        try stripBinary(&binary)
+        try Macho.stripBinary(&binary)
 
         Inject.injectMachO(machoPath: exec.path,
                            cmdType: LC_Type.LOAD_DYLIB,
@@ -152,7 +115,7 @@ class PlayTools {
 
     static func injectInIPA(_ exec: URL, payload: URL) throws {
         var binary = try Data(contentsOf: exec)
-        try stripBinary(&binary)
+        try Macho.stripBinary(&binary)
 
         Inject.injectMachO(machoPath: exec.path,
                            cmdType: LC_Type.LOAD_DYLIB,
@@ -232,313 +195,35 @@ class PlayTools {
         })
     }
 
-    static func convertMacho(_ macho: URL) throws {
-        print("Converting MachO at \(macho.path)")
-
-        var binary = try Data(contentsOf: macho)
-
-        print("Stripping MachO...")
-        try stripBinary(&binary)
-        print("Replacing version command...")
-        try replaceVersionCommand(&binary)
-        print("Replacing instances of @rpath dylibs...")
-        try replaceLibraries(&binary)
-
-        print("Writing revised MachO...")
-        try FileManager.default.removeItem(at: macho)
-        try binary.write(to: macho)
-    }
-
-    static func replaceLibraries(_ binary: inout Data) throws {
-        let dylibsToReplace = ["libswiftUIKit"]
-
-        for dylib in dylibsToReplace {
-            let rpathDylib = "@rpath/\(dylib).dylib"
-            let libDylib = "/System/iOSSupport/usr/lib/swift/\(dylib).dylib"
-
-            // 1. Check if dylib LC exists
-            // 2. If it exists, take note if it is weak or strong and copy version info
-            // 3. Replace existing LC
-
-            try replaceLibrary(&binary, rpathDylib, libDylib)
-        }
-    }
-
-    static func replaceLibrary(_ binary: inout Data, _ rpath: String, _ lib: String) throws {
-        var start: Int?
-        var size: Int?
-        var isWeak: Bool = false
-        var dylibExists: Bool = false
-        var dylib: dylib?
-        var oldDylibLength: UInt32 = 0
-
-        let machoRange = Range(NSRange(location: 0, length: MemoryLayout<mach_header_64>.size))!
-        var header = binary.extract(mach_header_64.self)
-        var offset = MemoryLayout.size(ofValue: header)
-
-        // Perform steps 1-2
-        for _ in 0..<header.ncmds {
-            let loadCommand = binary.extract(load_command.self, offset: offset)
-            switch UInt32(loadCommand.cmd) {
-            case LC_LOAD_WEAK_DYLIB, UInt32(LC_LOAD_DYLIB):
-                let dylibCommand = binary.extract(dylib_command.self, offset: offset)
-                if String(data: binary,
-                          offset: offset,
-                          commandSize: Int(dylibCommand.cmdsize),
-                          loadCommandString: dylibCommand.dylib.name) == rpath {
-
-                    isWeak = LC_LOAD_WEAK_DYLIB == UInt32(loadCommand.cmd)
-                    dylibExists = true
-                    dylib = dylibCommand.dylib
-                    oldDylibLength = UInt32(dylibCommand.cmdsize)
-
-                    start = offset
-                    size = Int(dylibCommand.cmdsize)
-                }
-            default:
-                break
-            }
-            offset += Int(loadCommand.cmdsize)
-        }
-
-        if !dylibExists {
-            // dylib with given rpath was not found in binary
-            return
-        }
-
-        print("Found \(rpath) in binary")
-
-        // Perform step 3
-        let endOfHeader = offset
-        let length = MemoryLayout<dylib_command>.size + lib.lengthOfBytes(using: String.Encoding.utf8)
-        let padding = (8 - (length % 8))
-        let cmdsize = length + padding
-
-        dylib!.name = lc_str(offset: UInt32(MemoryLayout<dylib_command>.size))
-        var command = dylib_command(cmd: isWeak ? LC_LOAD_WEAK_DYLIB : UInt32(LC_LOAD_DYLIB),
-                                    cmdsize: UInt32(cmdsize),
-                                    dylib: dylib!)
-
-        if let startOfCmd = start,
-           let sizeOfCmd = size {
-            let endOfCmd = startOfCmd + sizeOfCmd
-
-            let restOfHeader = Range(NSRange(location: endOfCmd, length: endOfHeader - endOfCmd))!
-
-            var zero: UInt64 = 0
-            var commandData = Data()
-            commandData.append(Data(bytes: &command, count: MemoryLayout<dylib_command>.size))
-            commandData.append(lib.data(using: String.Encoding.ascii) ?? Data())
-            commandData.append(Data(bytes: &zero, count: padding))
-            commandData.append(binary.subdata(in: restOfHeader))
-
-            let newHeaderRange = Range(NSRange(location: startOfCmd,
-                                               length: endOfHeader - endOfCmd + cmdsize))!
-
-            binary.replaceSubrange(newHeaderRange, with: commandData)
-        }
-
-        // Write new header data
-        header.sizeofcmds -= oldDylibLength
-        header.sizeofcmds += UInt32(cmdsize)
-        let newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header_64>.size)
-        binary.replaceSubrange(machoRange, with: newHeaderData)
-    }
-
-    static func replaceVersionCommand(_ binary: inout Data) throws {
-        var start: Int?
-        var size: Int?
-        var end: Int?
-        var oldDylibLength: UInt32 = 0
-
-        var header = binary.extract(mach_header_64.self)
-        var offset = MemoryLayout.size(ofValue: header)
-        let machoRange = Range(NSRange(location: 0, length: MemoryLayout<mach_header_64>.size))!
-
-        for _ in 0..<header.ncmds {
-            let loadCommand = binary.extract(load_command.self, offset: offset)
-            switch UInt32(loadCommand.cmd) {
-            case UInt32(LC_VERSION_MIN_IPHONEOS), UInt32(LC_VERSION_MIN_MACOSX):
-                let versionCommand = binary.extract(version_min_command.self, offset: offset)
-
-                start = offset
-                size = Int(versionCommand.cmdsize)
-                oldDylibLength = UInt32(versionCommand.cmdsize)
-            case UInt32(LC_BUILD_VERSION):
-                let versionCommand = binary.extract(build_version_command.self, offset: offset)
-
-                start = offset
-                size = Int(versionCommand.cmdsize)
-                oldDylibLength = UInt32(versionCommand.cmdsize)
-            default:
-                break
-            }
-            offset += Int(loadCommand.cmdsize)
-        }
-        end = offset
-
-        if let start = start,
-           let end = end,
-           let size = size {
-            let subrangeNew = Range(NSRange(location: start + size, length: end - start - size))!
-            let subrangeOld = Range(NSRange(location: start, length: end - start))!
-            var zero: UInt64 = 0
-            var commandData = Data()
-            commandData.append(binary.subdata(in: subrangeNew))
-            commandData.append(Data(bytes: &zero, count: size))
-
-            binary.replaceSubrange(subrangeOld, with: commandData)
-        }
-
-        header.sizeofcmds -= oldDylibLength
-
-        var versionCommand = build_version_command(cmd: UInt32(LC_BUILD_VERSION),
-                                                   cmdsize: 24,
-                                                   platform: UInt32(PLATFORM_MACCATALYST),
-                                                   minos: 0x000b0000,
-                                                   sdk: 0x000e0000,
-                                                   ntools: 0)
-
-        start = Int(header.sizeofcmds) + Int(MemoryLayout<mach_header_64>.size)
-
-        header.sizeofcmds += versionCommand.cmdsize
-        let newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header_64>.size)
-
-        var commandData = Data()
-        commandData.append(Data(bytes: &versionCommand, count: MemoryLayout<build_version_command>.size))
-
-        let subrange = Range(NSRange(location: start!, length: commandData.count))!
-
-        binary.replaceSubrange(subrange, with: commandData)
-
-        binary.replaceSubrange(machoRange, with: newHeaderData)
-    }
-
-    static func isMachoEncrypted(atURL url: URL) throws -> Bool {
-        var binary = try Data(contentsOf: url)
-        try stripBinary(&binary)
-
-        return try isSlimMachoEncrypted(binary: binary)
-    }
-
-    static func isSlimMachoEncrypted(binary: Data) throws -> Bool {
-        var offset = 0
-        var header = binary.extract(mach_header_64.self, offset: offset)
-        offset += MemoryLayout.size(ofValue: header)
-        let shouldSwap = header.magic == MH_CIGAM_64
-
-        if shouldSwap {
-            swap_mach_header_64(&header, NXHostByteOrder())
-        }
-
-        for _ in 0..<header.ncmds {
-            var loadCommand = binary.extract(load_command.self, offset: offset)
-            if shouldSwap {
-                swap_load_command(&loadCommand, NXHostByteOrder())
-            }
-
-            switch loadCommand.cmd {
-            case UInt32(LC_ENCRYPTION_INFO_64):
-                var infoCommand = binary.extract(encryption_info_command_64.self, offset: offset)
-                if shouldSwap {
-                    swap_encryption_command_64(&infoCommand, NXHostByteOrder())
-                }
-
-                return infoCommand.cryptid != 0
-            default:
-                break
-            }
-            offset += Int(loadCommand.cmdsize)
-        }
-
-        return false
-    }
-
-    static func isMachoValidArch(_ url: URL) throws -> Bool {
-        var binary = try Data(contentsOf: url)
-        try stripBinary(&binary)
-
-        return try isSlimMachoValidArch(binary: binary)
-    }
-
-    static func isSlimMachoValidArch(binary: Data) throws -> Bool {
-        var offset = 0
-        var header = binary.extract(mach_header_64.self, offset: offset)
-        offset += MemoryLayout.size(ofValue: header)
-        let shouldSwap = header.magic == MH_CIGAM_64
-
-        if shouldSwap {
-            swap_mach_header_64(&header, NXHostByteOrder())
-        }
-
-        for _ in 0..<header.ncmds {
-            var loadCommand = binary.extract(load_command.self, offset: offset)
-            if shouldSwap {
-                swap_load_command(&loadCommand, NXHostByteOrder())
-            }
-
-            switch loadCommand.cmd {
-            case UInt32(LC_BUILD_VERSION):
-                var versionCommand = binary.extract(build_version_command.self, offset: offset)
-                if shouldSwap {
-                    swap_build_version_command(&versionCommand, NXHostByteOrder())
-                }
-
-                return versionCommand.platform == PLATFORM_MACCATALYST
-            default:
-                break
-            }
-            offset += Int(loadCommand.cmdsize)
-        }
-
-        return false
-    }
-
     static func installedInExec(atURL url: URL) throws -> Bool {
         var binary = try Data(contentsOf: url)
-        try stripBinary(&binary)
-
-        var header = binary.extract(mach_header_64.self)
-        var offset = MemoryLayout.size(ofValue: header)
-        let shouldSwap = header.magic == MH_CIGAM_64
-
-        if shouldSwap {
-            swap_mach_header_64(&header, NXHostByteOrder())
-        }
-
-        for _ in 0..<header.ncmds {
-            var loadCommand = binary.extract(load_command.self, offset: offset)
-            if shouldSwap {
-                swap_load_command(&loadCommand, NXHostByteOrder())
-            }
-
-            switch loadCommand.cmd {
-            case UInt32(LC_LOAD_DYLIB):
-                var dylibCommand = binary.extract(dylib_command.self, offset: offset)
-                if shouldSwap {
-                    swap_dylib_command(&dylibCommand, NXHostByteOrder())
-                }
-
+        try Macho.stripBinary(&binary)
+        var result = false
+        try _ = Macho.iterateLoadCommands(binary: binary) { offset, shouldSwap in
+            var loadCommand = binary.extract(load_command.self, offset: offset,
+                                             swap: shouldSwap ? swap_load_command:nil)
+            if(loadCommand.cmd == UInt32(LC_LOAD_DYLIB)) {
+                var dylibCommand = binary.extract(dylib_command.self, offset: offset,
+                                                  swap: shouldSwap ? swap_dylib_command:nil)
+                
                 let dylibName = String(data: binary,
                                        offset: offset,
                                        commandSize: Int(dylibCommand.cmdsize),
                                        loadCommandString: dylibCommand.dylib.name)
                 if dylibName == playToolsPath.esc {
+                    result = true
                     return true
                 }
-            default:
-                break
             }
-            offset += Int(loadCommand.cmdsize)
+            return false
         }
-
-        return false
+        return result
     }
 
     static func isInstalled() throws -> Bool {
         try FileManager.default.fileExists(atPath: playToolsPath.path)
             && FileManager.default.fileExists(atPath: akInterfacePath.path)
-            && isMachoValidArch(playToolsPath)
+            && Macho.isMachoValidArch(playToolsPath)
     }
 
 	static func fetchEntitlements(_ exec: URL) throws -> String {

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -200,12 +200,12 @@ class PlayTools {
         try Macho.stripBinary(&binary)
         var result = false
         try _ = Macho.iterateLoadCommands(binary: binary) { offset, shouldSwap in
-            var loadCommand = binary.extract(load_command.self, offset: offset,
+            let loadCommand = binary.extract(load_command.self, offset: offset,
                                              swap: shouldSwap ? swap_load_command:nil)
-            if(loadCommand.cmd == UInt32(LC_LOAD_DYLIB)) {
-                var dylibCommand = binary.extract(dylib_command.self, offset: offset,
+            if loadCommand.cmd == UInt32(LC_LOAD_DYLIB) {
+                let dylibCommand = binary.extract(dylib_command.self, offset: offset,
                                                   swap: shouldSwap ? swap_dylib_command:nil)
-                
+
                 let dylibName = String(data: binary,
                                        offset: offset,
                                        commandSize: Int(dylibCommand.cmdsize),


### PR DESCRIPTION
Created a new file `Macho.swift` to put macho-related code, so that `PlayTools` has less lines than `swiftlint`'s upper bound

Added sanity checks while iterating load commands.

Added byte order checks while replacing load commands.

Variable names changed to more meaningful ones.