### PR TITLE
feat: starts app asynchronously

### DIFF
--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -10,6 +10,7 @@ import IOKit.pwr_mgt
 class PlayApp: BaseApp {
     private static let library = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library")
     var displaySleepAssertionID: IOPMAssertionID?
+    public var isStarting = false
 
     var searchText: String {
         info.displayName.lowercased().appending(" ").appending(info.bundleName).lowercased()
@@ -17,6 +18,7 @@ class PlayApp: BaseApp {
 
     func launch() async {
         do {
+            isStarting = true
             if prohibitedToPlay {
                 clearAllCache()
                 throw PlayCoverError.appProhibited
@@ -51,6 +53,7 @@ class PlayApp: BaseApp {
                     runAppExec() // Splitting to reduce complexity
                 }
             }
+            isStarting = false
         } catch {
             Log.shared.error(error)
         }

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -9,12 +9,13 @@ import IOKit.pwr_mgt
 
 class PlayApp: BaseApp {
     private static let library = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library")
+    var displaySleepAssertionID: IOPMAssertionID?
 
     var searchText: String {
         info.displayName.lowercased().appending(" ").appending(info.bundleName).lowercased()
     }
 
-    func launch() {
+    func launch() async {
         do {
             if prohibitedToPlay {
                 clearAllCache()
@@ -73,30 +74,46 @@ class PlayApp: BaseApp {
             configuration: config,
             completionHandler: { runningApp, error in
                 guard error == nil else { return }
-                if self.settings.settings.disableTimeout {
-                    // Yeet into a thread
-                    Task {
-                        debugPrint("Disabling timeout...")
-                        let reason = "PlayCover: " + self.name + " disabled screen timeout" as CFString
-                        var assertionID: IOPMAssertionID = 0
-                        var success = IOPMAssertionCreateWithName(
-                            kIOPMAssertionTypeNoDisplaySleep as CFString,
-                            IOPMAssertionLevel(kIOPMAssertionLevelOn),
-                            reason,
-                            &assertionID)
-                        if success == kIOReturnSuccess {
-                            while true { // Run a loop until the app closes
-                                try await Task.sleep(nanoseconds: 10000000000) // Sleep for 10 seconds
-                                guard
-                                    let isFinish = runningApp?.isTerminated,
-                                    !isFinish else { break }
-                            }
-                            success = IOPMAssertionRelease(assertionID)
-                            debugPrint("Enabling timeout...")
+                // Run a thread loop in the background to handle background tasks
+                Task(priority: .background) {
+                    while !(runningApp?.isTerminated ?? true) {
+                        // Check if the app is in the foreground
+                        if runningApp!.isActive {
+                            // If the app is in the foreground, disable the display sleep
+                            self.disableTimeOut()
+                        } else {
+                            // If the app is not in the foreground, enable the display sleep
+                            self.enableTimeOut()
                         }
+                        sleep(1)
                     }
                 }
             })
+    }
+
+    func disableTimeOut() {
+        if displaySleepAssertionID != nil {
+            return
+        }
+        // Disable display sleep
+        let reason = "PlayCover: \(info.bundleIdentifier) is disabling sleep" as CFString
+        var assertionID: IOPMAssertionID = 0
+        let result = IOPMAssertionCreateWithName(
+            kIOPMAssertionTypeNoDisplaySleep as CFString,
+            IOPMAssertionLevel(kIOPMAssertionLevelOn),
+            reason,
+            &assertionID)
+        if result == kIOReturnSuccess {
+            displaySleepAssertionID = assertionID
+        }
+    }
+
+    func enableTimeOut() {
+        // Enable display sleep
+        if let assertionID = displaySleepAssertionID {
+            IOPMAssertionRelease(assertionID)
+            displaySleepAssertionID = nil
+        }
     }
 
     var name: String {

--- a/PlayCover/Views/App Views/PlayAppView.swift
+++ b/PlayCover/Views/App Views/PlayAppView.swift
@@ -37,7 +37,9 @@ struct PlayAppView: View {
                 if app.info.bundleIdentifier == "com.miHoYo.GenshinImpact" {
                     removeTwitterSessionCookie()
                 }
-                app.launch()
+                Task(priority: .userInitiated){
+                    await app.launch()
+                }
             })
             .simultaneousGesture(TapGesture().onEnded {
                 selected = app

--- a/PlayCover/Views/App Views/PlayAppView.swift
+++ b/PlayCover/Views/App Views/PlayAppView.swift
@@ -37,8 +37,8 @@ struct PlayAppView: View {
                 if app.info.bundleIdentifier == "com.miHoYo.GenshinImpact" {
                     removeTwitterSessionCookie()
                 }
-                Task(priority: .userInitiated){
-                    await app.launch()
+                Task(priority: .userInitiated) {
+                    if !app.isStarting { await app.launch() }
                 }
             })
             .simultaneousGesture(TapGesture().onEnded {


### PR DESCRIPTION
Allowing PlayCover to start apps and apply patches to them asynchronously which makes the user interface more responsive

Originally made for KeyCover but backported, will be useful if we have operation that will take a long time to finish (eg. resigning apps with custom entitlements)