### PR TITLE
Remove CoD:M Garena from Prohibition List

### DIFF
--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -230,7 +230,6 @@ class PlayApp: BaseApp {
     static let PROHIBITED_APPS = [
         "com.activision.callofduty.shooter",
         "com.ea.ios.apexlegendsmobilefps",
-        "com.garena.game.codm",
         "com.tencent.tmgp.cod",
         "com.tencent.ig",
         "com.pubg.newstate",


### PR DESCRIPTION
Since we have reports that CoD:M Garena accounts won't get banned on PlayCover and there is a resolution issue that needs PlayTools to be ran for 1st time from PlayCover, there is no reason to let it still be prohibited.