### PR TITLE
feat: Custom resolution scaler

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -16,6 +16,7 @@ struct AppSettingsData: Codable {
     var iosDeviceModel = "iPad13,8"
     var windowWidth = 1920
     var windowHeight = 1080
+    var customScaler = 2.0
     var resolution = 1
     var aspectRatio = 1
     var notch: Bool = NSScreen.hasNotch()
@@ -41,6 +42,7 @@ struct AppSettingsData: Codable {
         iosDeviceModel = try container.decodeIfPresent(String.self, forKey: .iosDeviceModel) ?? "iPad13,8"
         windowWidth = try container.decodeIfPresent(Int.self, forKey: .windowWidth) ?? 1920
         windowHeight = try container.decodeIfPresent(Int.self, forKey: .windowHeight) ?? 1080
+        customScaler = try container.decodeIfPresent(Double.self, forKey: .customScaler) ?? 2.0
         resolution = try container.decodeIfPresent(Int.self, forKey: .resolution) ?? 1
         aspectRatio = try container.decodeIfPresent(Int.self, forKey: .aspectRatio) ?? 1
         notch = try container.decodeIfPresent(Bool.self, forKey: .notch) ?? NSScreen.hasNotch()

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -76,7 +76,7 @@ class PlayTools {
         try Macho.stripBinary(&binary)
 
         Inject.injectMachO(machoPath: exec.path,
-                           cmdType: .loadDylib,
+                           cmdType: .LOAD_DYLIB,
                            backup: false,
                            injectPath: playToolsPath.path,
                            finishHandle: { result in
@@ -118,7 +118,7 @@ class PlayTools {
         try Macho.stripBinary(&binary)
 
         Inject.injectMachO(machoPath: exec.path,
-                           cmdType: .loadDylib,
+                           cmdType: .LOAD_DYLIB,
                            backup: false,
                            injectPath: "@executable_path/Frameworks/PlayTools.dylib",
                            finishHandle: { result in
@@ -172,7 +172,7 @@ class PlayTools {
 
     static func removeFromApp(_ exec: URL) {
         Inject.removeMachO(machoPath: exec.path,
-                           cmdType: .loadDylib,
+                           cmdType: .LOAD_DYLIB,
                            backup: false,
                            injectPath: playToolsPath.path,
                            finishHandle: { result in

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -183,9 +183,8 @@ struct GraphicsView: View {
         formatter.numberStyle = .none
         return formatter
     }
-    
-    @State var customScaler = 2.0
 
+    @State var customScaler = 2.0
     static var fractionFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
@@ -402,7 +401,8 @@ struct GraphicsView: View {
         settings.settings.windowHeight = height
         settings.settings.customScaler = customScaler
 
-        showResolutionWarning = Double(width * height) * customScaler >= 2621440 * 2.0 // Tends to crash when the number of pixels exceeds that
+        showResolutionWarning = Double(width * height) * customScaler >= 2621440 * 2.0
+        // Tends to crash when the number of pixels exceeds that
     }
 
     func getWidthFromAspectRatio(_ height: Int) -> Int {

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -183,6 +183,17 @@ struct GraphicsView: View {
         formatter.numberStyle = .none
         return formatter
     }
+    
+    @State var customScaler = 2.0
+
+    static var fractionFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 1
+        formatter.minimumFractionDigits = 1
+        formatter.decimalSeparator = "."
+        return formatter
+    }
 
     var body: some View {
         ScrollView {
@@ -285,6 +296,26 @@ struct GraphicsView: View {
                         Spacer()
                     }
                 }
+                HStack {
+                    Text("settings.picker.scaler")
+                    Spacer()
+                    Stepper {
+                        TextField(
+                            "settings.text.scaler",
+                            value: $customScaler,
+                            formatter: GraphicsView.fractionFormatter,
+                            onCommit: {
+                                Task { @MainActor in
+                                    NSApp.keyWindow?.makeFirstResponder(nil)
+                                }
+                            })
+                            .frame(width: 125)
+                    } onIncrement: {
+                        customScaler += 0.1
+                    } onDecrement: {
+                        customScaler -= 0.1
+                    }
+                }
                 VStack(alignment: .leading) {
                     if #available(macOS 13.2, *) {
                         HStack {
@@ -316,6 +347,7 @@ struct GraphicsView: View {
             .onAppear {
                 customWidth = settings.settings.windowWidth
                 customHeight = settings.settings.windowHeight
+                customScaler = settings.settings.customScaler
             }
             .onChange(of: settings.settings.resolution) { _ in
                 setResolution()
@@ -327,6 +359,9 @@ struct GraphicsView: View {
                 setResolution()
             }
             .onChange(of: customHeight) { _ in
+                setResolution()
+            }
+            .onChange(of: customScaler) { _ in
                 setResolution()
             }
         }
@@ -365,8 +400,9 @@ struct GraphicsView: View {
 
         settings.settings.windowWidth = width
         settings.settings.windowHeight = height
+        settings.settings.customScaler = customScaler
 
-        showResolutionWarning = width*height >= 2621440 // Tends to crash when the number of pixels exceeds that
+        showResolutionWarning = Double(width * height) * customScaler >= 2621440 * 2.0 // Tends to crash when the number of pixels exceeds that
     }
 
     func getWidthFromAspectRatio(_ height: Int) -> Int {

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -99,7 +99,7 @@ struct AppSettingsView: View {
                         Text("settings.tab.info")
                     }
             }
-            .frame(minWidth: 450, minHeight: 200)
+            .frame(minWidth: 500, minHeight: 250)
             HStack {
                 Spacer()
                 Button("settings.resetSettings") {

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -312,7 +312,9 @@ struct GraphicsView: View {
                     } onIncrement: {
                         customScaler += 0.1
                     } onDecrement: {
-                        customScaler -= 0.1
+                        if customScaler > 0.5 {
+                            customScaler -= 0.1
+                        }
                     }
                 }
                 VStack(alignment: .leading) {

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -178,6 +178,7 @@
 "settings.toggle.disableDisplaySleep.help" = "Prevent display from turning off while this app is running";
 "settings.noPlayTools" = "PlayTools is not installed in this app";
 "settings.highResolution" = "High resolution may cause crashing";
+"settings.picker.scaler" = "Resolution Scaler";
 
 "settings.tab.bypasses" = "Bypasses";
 "settings.toggle.jbBypass" = "Enable Jailbreak Bypass (Experimental)";


### PR DESCRIPTION
Allow users who want to run at 1440p/4k (I don't know why) to adjust scaling so their games don't instantly die (eg. 1440p @1.5x or 4k @0.7x)

Requires https://github.com/PlayCover/PlayTools/pull/103