### PR TITLE
Sidebar toggle position oversight

### DIFF
--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -89,7 +89,7 @@ struct MainView: View {
                 self.selectedView = URLObserved.type == .source ? 2 : 1
             }
             .toolbar {
-                ToolbarItem(placement: .navigation) {
+                ToolbarItem { // Sits on the left by default
                     Button(action: toggleSidebar, label: {
                         Image(systemName: "sidebar.leading")
                     })


### PR DESCRIPTION
I saw a major design oversight regarding the sidebar button.

https://github.com/PlayCover/PlayCover/assets/51266541/f6db7c05-7218-41ba-9113-de200a06894b

The Sidebar button is positioned to `.navigation` which doesn't really make sense since the user needs to chase it if they misclick.

I removed the position so that it sticks to default (left side)

https://github.com/PlayCover/PlayCover/assets/51266541/348e45e3-8004-4393-9ef7-195c69303cc7

The code for this entry can be found [here](https://github.com/404oops/NamecheapDDNS/blob/507021107872c1ffacf3ae7a8c04e75e8e7b5c6e/NamecheapDDNS/ContentView.swift#L38-L45) as "proof" that it works