### PR TITLE
Set Application Category Type

### DIFF
--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -40,6 +40,7 @@ class Installer {
         // If (the option key is held or the install playtools popup settings is true) and its not an export,
         //    then show the installer dialog
         let installPlayTools: Bool
+        let applicationType = InstallPreferences.shared.defaultAppType
 
         if (Installer.isOptionKeyHeld || InstallPreferences.shared.showInstallPopup) && !export {
             installPlayTools = installPlayToolsPopup()
@@ -80,6 +81,8 @@ class Installer {
                 } else if installPlayTools {
                     try PlayTools.installInIPA(app.executable)
                 }
+
+                app.info.applicationCategoryType = applicationType
 
                 if !export {
                     // -rwxr-xr-x

--- a/PlayCover/Model/AppInfo.swift
+++ b/PlayCover/Model/AppInfo.swift
@@ -5,6 +5,35 @@
 
 import Foundation
 
+enum LSApplicationCategoryType: String, CaseIterable {
+    case business = "public.app-category.business"
+    case developerTools = "public.app-category.developer-tools"
+    case education = "public.app-category.education"
+    case entertainment = "public.app-category.entertainment"
+    case finance = "public.app-category.finance"
+    case games = "public.app-category.games"
+    case graphicsDesign = "public.app-category.graphics-design"
+    case healthcareFitness = "public.app-category.healthcare-fitness"
+    case lifestyle = "public.app-category.lifestyle"
+    case medical = "public.app-category.medical"
+    case music = "public.app-category.music"
+    case news = "public.app-category.news"
+    case photography = "public.app-category.photography"
+    case productivity = "public.app-category.productivity"
+    case reference = "public.app-category.reference"
+    case socialNetworking = "public.app-category.social-networking"
+    case sports = "public.app-category.sports"
+    case travel = "public.app-category.travel"
+    case utilities = "public.app-category.utilities"
+    case video = "public.app-category.video"
+    case weather = "public.app-category.weather"
+    case none = "public.app-category.none" // Note: This is not in an official category type
+
+    var localizedName: String {
+        NSLocalizedString(rawValue, comment: "")
+    }
+}
+
 public class AppInfo {
     public let url: URL
     fileprivate var rawStorage: NSMutableDictionary
@@ -119,6 +148,26 @@ public class AppInfo {
         }
         set {
             rawStorage[index] = newValue
+        }
+    }
+
+    var applicationCategoryType: LSApplicationCategoryType {
+        get {
+            LSApplicationCategoryType(
+                rawValue: self[string: "LSApplicationCategoryType"] ?? ""
+            ) ?? LSApplicationCategoryType.none
+        }
+        set {
+            if newValue == .none {
+                rawStorage.removeObject(forKey: "LSApplicationCategoryType")
+            } else {
+                self[string: "LSApplicationCategoryType"] = newValue.rawValue
+            }
+            do {
+                try write()
+            } catch {
+                Log.shared.error(error)
+            }
         }
     }
 

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -90,7 +90,8 @@ struct AppSettingsView: View {
                          closeView: $closeView,
                          hasPlayTools: $hasPlayTools,
                          hasAlias: $hasAlias,
-                         app: viewModel.app)
+                         app: viewModel.app,
+                         applicationCategoryType: viewModel.app.info.applicationCategoryType)
                     .tabItem {
                         Text("settings.tab.misc")
                     }
@@ -481,9 +482,34 @@ struct MiscView: View {
 
     var app: PlayApp
 
+    @State var applicationCategoryType: LSApplicationCategoryType
+
     var body: some View {
         ScrollView {
             VStack {
+                HStack {
+                    Text("settings.applicationCategoryType")
+                    Spacer()
+                    Picker("", selection: $applicationCategoryType) {
+                        ForEach(LSApplicationCategoryType.allCases, id: \.rawValue) { value in
+                            Text(value.localizedName)
+                                .tag(value)
+                        }
+                    }
+                    .frame(width: 225)
+                    .onChange(of: applicationCategoryType) { _ in
+                        app.info.applicationCategoryType = applicationCategoryType
+                        Task(priority: .userInitiated) {
+                            do {
+                                try Shell.signApp(app.executable)
+                            } catch {
+                                Log.shared.error(error)
+                            }
+                        }
+                    }
+                }
+                Spacer()
+                    .frame(height: 20)
                 HStack {
                     Toggle("settings.toggle.discord", isOn: $settings.settings.discordActivity.enable)
                     Spacer()
@@ -579,6 +605,8 @@ struct MiscView: View {
                         }
                     }
                 }
+                Spacer()
+                    .frame(height: 20)
                 // swiftlint:disable:next todo
                 // TODO: Test and remove before 3.0 release
                 HStack {
@@ -626,6 +654,11 @@ struct InfoView: View {
                 Text("settings.info.bundleVersion")
                 Spacer()
                 Text("\(info.bundleVersion)")
+            }
+            HStack {
+                Text("settings.applicationCategoryType") + Text(":")
+                Spacer()
+                Text("\(info.applicationCategoryType.rawValue)")
             }
             HStack {
                 Text("settings.info.executableName")

--- a/PlayCover/Views/Settings/InstallSettings.swift
+++ b/PlayCover/Views/Settings/InstallSettings.swift
@@ -12,6 +12,8 @@ class InstallPreferences: NSObject, ObservableObject {
 
     @objc @AppStorage("AlwaysInstallPlayTools") var alwaysInstallPlayTools = true
 
+    @AppStorage("DefaultAppType") var defaultAppType: LSApplicationCategoryType = .none
+
     @AppStorage("ShowInstallPopup") var showInstallPopup = false
 }
 
@@ -21,20 +23,36 @@ struct InstallSettings: View {
     @ObservedObject var installPreferences = InstallPreferences.shared
 
     var body: some View {
-        Form {
+        VStack(alignment: .leading) {
+            HStack {
+                Text("settings.applicationCategoryType")
+                Spacer()
+                Picker("", selection: installPreferences.$defaultAppType) {
+                    ForEach(LSApplicationCategoryType.allCases, id: \.rawValue) { value in
+                        Text(value.localizedName)
+                            .tag(value)
+                    }
+                }
+                .frame(width: 225)
+            }
+            Spacer()
+                .frame(height: 20)
             Toggle("preferences.toggle.showInstallPopup", isOn: $installPreferences.showInstallPopup)
             GroupBox {
-                HStack {
-                    VStack(alignment: .leading) {
-                        Toggle("preferences.toggle.alwaysInstallPlayTools",
-                               isOn: $installPreferences.alwaysInstallPlayTools)
+                VStack {
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Toggle("preferences.toggle.alwaysInstallPlayTools",
+                                   isOn: $installPreferences.alwaysInstallPlayTools)
+                        }
+                        Spacer()
                     }
                     Spacer()
+                        .frame(height: 20)
                 }
             }.disabled(installPreferences.showInstallPopup)
-            Spacer()
         }
         .padding(20)
-        .frame(width: 350, height: 100, alignment: .center)
+        .frame(width: 400, height: 200)
     }
 }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -192,6 +192,7 @@
 "settings.toggle.introspection" = "Insert Introspection libraries";
 "settings.toggle.introspection.help" = "Add the system introspection libraries to the app. Known to fix issues with some apps not starting correctly";
 
+"settings.applicationCategoryType" = "Application Type";
 "settings.removePlayTools" = "Remove PlayTools";
 "settings.addToLaunchpad" = "Add to Launchpad";
 "settings.removeFromLaunchpad" = "Remove from Launchpad";


### PR DESCRIPTION
This allows the user to set the category of the app by adding the key `LSApplicationCategoryType` to the `Info.plist` located in the application. This can be changed under Misc in the application's settings.

More specifically, this feature enables and closes #1085 "Game Mode", which can be accomplished by the user setting the application type to `public.app-category.games` for those on MacOS Sonoma.

**This change is tested on MacOS Sonoma Developer Beta 23A5337a**. This should not affect the changes, but should still be tested on a stable version of MacOS.

Other Notes for reviewers:
- Should `LSApplicationCategoryType` be localised? Currently, the code is implemented but was too time consuming to implement it in the localisation files.
- Should the installer popup be updated to a `sheet` or something similar to accommodate for the user to specify the application category type on installation? The setting has been implemented to set all the installing types to the specified value but per installation type setting would be require some major refactoring.
- Should the application inherent the application type from the IPA? Since the application's `Info.plist` does not initially have the key `LSApplicationCategoryType`, it would have to be located elsewhere as iOS apps still have the application category types. I will look into that but since it is not already implemented, I am not too sure it will work.