### PR TITLE
Fix MetalHUD not showing when launching app from alias

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -8,6 +8,8 @@ import Foundation
 import UniformTypeIdentifiers
 
 struct AppSettingsData: Codable {
+    var bundleIdentifier: String = ""
+
     var keymapping = true
     var sensitivity: Float = 50
 
@@ -25,7 +27,15 @@ struct AppSettingsData: Codable {
     var playChain = true
     var playChainDebugging = false
     var inverseScreenValues = false
-    var metalHUD = false
+    var metalHUD = false {
+        didSet {
+            do {
+                try Shell.setMetalHUD(bundleIdentifier, enabled: metalHUD)
+            } catch {
+                Log.shared.error(error)
+            }
+        }
+    }
     var windowFixMethod = 0
     var injectIntrospection = false
     var rootWorkDir = true
@@ -36,6 +46,7 @@ struct AppSettingsData: Codable {
     // handle old 2.x settings where PlayChain did not exist yet
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        bundleIdentifier = try container.decodeIfPresent(String.self, forKey: .bundleIdentifier) ?? ""
         keymapping = try container.decodeIfPresent(Bool.self, forKey: .keymapping) ?? true
         sensitivity = try container.decodeIfPresent(Float.self, forKey: .sensitivity) ?? 50
         disableTimeout = try container.decodeIfPresent(Bool.self, forKey: .disableTimeout) ?? false
@@ -97,6 +108,8 @@ class AppSettings {
         if !decode() {
             encode()
         }
+
+        settings.bundleIdentifier = info.bundleIdentifier
     }
 
     public func sync() {

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -66,12 +66,6 @@ class PlayApp: BaseApp {
     func runAppExec() {
         let config = NSWorkspace.OpenConfiguration()
 
-        if settings.settings.metalHUD {
-            config.environment = ["MTL_HUD_ENABLED": "1"]
-        } else {
-            config.environment = ["MTL_HUD_ENABLED": "0"]
-        }
-
         if settings.settings.injectIntrospection {
             config.environment["DYLD_LIBRARY_PATH"] = "/usr/lib/system/introspection"
         }

--- a/PlayCover/Utils/Shell.swift
+++ b/PlayCover/Utils/Shell.swift
@@ -86,6 +86,11 @@ class Shell: ObservableObject {
                 "--deep", "--preserve-metadata=entitlements")
     }
 
+    static func setMetalHUD(_ bundleID: String, enabled: Bool) throws {
+        try run("/usr/bin/defaults", "write", bundleID,
+                      "MetalForceHudEnabled", "-bool", String(enabled))
+    }
+
     static func lldb(_ url: URL, withTerminalWindow: Bool = false) throws {
         Task(priority: .utility) {
             if withTerminalWindow {


### PR DESCRIPTION
Fixes #961. Writes to the `defaults` key `MetalForceHudEnabled` instead of saving as an environment variable.

Thoughts for reviewer:
- Should MetalHud be removed from the settings file and have it directly linked to `defaults` (similar to PlayTools checking if it is installed in the binary instead of keeping track via the settings file)?
- Should this be merged into #1090, with it being stored in the `Info.plist` instead of `defaults`?