### PR TITLE
Fix Discord RPC

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		B6603E1128E206A300DEFA3F /* UninstallSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6603E1028E206A300DEFA3F /* UninstallSettings.swift */; };
 		B6603E1328E2257800DEFA3F /* Uninstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6603E1228E2257800DEFA3F /* Uninstaller.swift */; };
 		B6825C3528F3D23600E3015A /* InstallSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6825C3428F3D23600E3015A /* InstallSettings.swift */; };
+		B68FD80D2ACB642100683778 /* PlayAppExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68FD80C2ACB642100683778 /* PlayAppExtensions.swift */; };
 		B6AB53C929232B4F00039B2E /* KeyCodeNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AB53C829232B4F00039B2E /* KeyCodeNames.swift */; };
 		B6ABDA2A2971EEF700A46E80 /* ProgressVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ABDA292971EEF700A46E80 /* ProgressVM.swift */; };
 /* End PBXBuildFile section */
@@ -189,6 +190,7 @@
 		B6603E1028E206A300DEFA3F /* UninstallSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallSettings.swift; sourceTree = "<group>"; };
 		B6603E1228E2257800DEFA3F /* Uninstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Uninstaller.swift; sourceTree = "<group>"; };
 		B6825C3428F3D23600E3015A /* InstallSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSettings.swift; sourceTree = "<group>"; };
+		B68FD80C2ACB642100683778 /* PlayAppExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayAppExtensions.swift; sourceTree = "<group>"; };
 		B6AB53C829232B4F00039B2E /* KeyCodeNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCodeNames.swift; sourceTree = "<group>"; };
 		B6ABDA292971EEF700A46E80 /* ProgressVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressVM.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -358,6 +360,7 @@
 				8783D00A26B8C9E600171041 /* URLExtensions.swift */,
 				6ECB1D0D29798DFA00CD92AA /* DataExtensions.swift */,
 				6E25096E297F5032004D754C /* FileExtensions.swift */,
+				B68FD80C2ACB642100683778 /* PlayAppExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -695,6 +698,7 @@
 				28361D662892800200B35EDB /* DeleteStoredGenshinUserData.swift in Sources */,
 				53D9DAF326C1849D0071959E /* PlayCoverError.swift in Sources */,
 				9286D296273A7E4200958DD3 /* AppSettings.swift in Sources */,
+				B68FD80D2ACB642100683778 /* PlayAppExtensions.swift in Sources */,
 				9272F19E273B74C800DFBEF1 /* AppsVM.swift in Sources */,
 				923421F7275F40300030CD7D /* AppContainer.swift in Sources */,
 			);

--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -60,7 +60,7 @@ class Installer {
                 let app = try ipa.unzip()
                 InstallVM.shared.next(.library, 0.5, 0.55)
                 try saveEntitlements(app)
-                let machos = try resolveValidMachOs(app)
+                let machos = resolveValidMachOs(app)
                 app.validMachOs = machos
 
                 InstallVM.shared.next(.playtools, 0.55, 0.85)
@@ -150,14 +150,14 @@ class Installer {
     }
 
     /// Returns an array of URLs to MachO files within the app
-    static func resolveValidMachOs(_ baseApp: BaseApp) throws -> [URL] {
+    static func resolveValidMachOs(_ baseApp: BaseApp) -> [URL] {
         if let validMachOs = baseApp.validMachOs {
             return validMachOs
         }
 
         var resolved: [URL] = []
 
-        try baseApp.url.enumerateContents { url, attributes in
+        baseApp.url.enumerateContents { url, attributes in
             guard attributes.isRegularFile == true, let fileSize = attributes.fileSize, fileSize > 4 else {
                 return
             }

--- a/PlayCover/Model/AppContainer.swift
+++ b/PlayCover/Model/AppContainer.swift
@@ -33,4 +33,8 @@ struct AppContainer {
     public func clear() {
         FileManager.default.delete(at: containerUrl)
     }
+
+    public func doesExist() -> Bool {
+        FileManager.default.fileExists(atPath: containerUrl.path)
+    }
 }

--- a/PlayCover/Model/AppContainer.swift
+++ b/PlayCover/Model/AppContainer.swift
@@ -9,45 +9,28 @@ import Foundation
 
 struct AppContainer {
 
-    let bundleId: String
-    let containerUrl: URL
     private static let containersURL = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Library")
         .appendingPathComponent("Containers")
 
-    lazy var userPrefsUrl: URL = {
-        return containerUrl
-            .appendingPathComponent("Data")
+    let bundleId: String
+    var containerUrl: URL {
+        AppContainer.containersURL.appendingPathComponent(bundleId)
+    }
+
+    var userPrefsUrl: URL {
+        containerUrl.appendingPathComponent("Data")
             .appendingPathComponent("Library")
             .appendingPathComponent("Preferences")
             .appendingPathComponent(bundleId)
             .appendingPathExtension("plist")
-    }()
+    }
+
+    init(bundleId: String) {
+        self.bundleId = bundleId
+    }
 
     public func clear() {
         FileManager.default.delete(at: containerUrl)
-    }
-
-    public static func containers() throws -> [String: AppContainer] {
-        var found = [String: AppContainer]()
-
-        let directoryContents = try FileManager.default
-            .contentsOfDirectory(at: containersURL, includingPropertiesForKeys: nil, options: [])
-
-        let subdirs = directoryContents.filter { $0.hasDirectoryPath }
-        for sub in subdirs {
-            let metadataPlist = sub.appendingPathComponent(".com.apple.containermanagerd.metadata")
-                                   .appendingPathExtension("plist")
-
-            if FileManager.default.fileExists(atPath: metadataPlist.path) {
-                if let plist = NSDictionary(contentsOfFile: metadataPlist.path) {
-                    if let bundleId = plist["MCMMetadataIdentifier"] as? String {
-                        found[bundleId] = AppContainer(bundleId: bundleId, containerUrl: sub)
-                    }
-                }
-            }
-        }
-
-        return found
     }
 }

--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -92,16 +92,14 @@ class AppSettings {
     let settingsUrl: URL
     var openWithLLDB: Bool = false
     var openLLDBWithTerminal: Bool = true
-    var container: AppContainer?
     var settings: AppSettingsData {
         didSet {
             encode()
         }
     }
 
-    init(_ info: AppInfo, container: AppContainer?) {
+    init(_ info: AppInfo) {
         self.info = info
-        self.container = container
         settingsUrl = AppSettings.appSettingsDir.appendingPathComponent(info.bundleIdentifier)
                                                 .appendingPathExtension("plist")
         settings = AppSettingsData()

--- a/PlayCover/Model/Keymapping.swift
+++ b/PlayCover/Model/Keymapping.swift
@@ -109,7 +109,6 @@ class Keymapping {
 
     let info: AppInfo
     let keymapURL: URL
-    var container: AppContainer?
     var keymap: Keymap {
         get {
             do {
@@ -134,9 +133,8 @@ class Keymapping {
         }
     }
 
-    init(_ info: AppInfo, container: AppContainer?) {
+    init(_ info: AppInfo) {
         self.info = info
-        self.container = container
         keymapURL = Keymapping.keymappingDir.appendingPathComponent("\(info.bundleIdentifier).plist")
     }
 

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -8,7 +8,6 @@ import Foundation
 import IOKit.pwr_mgt
 
 class PlayApp: BaseApp {
-    private static let library = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library")
     var displaySleepAssertionID: IOPMAssertionID?
     public var isStarting = false
 
@@ -16,6 +15,11 @@ class PlayApp: BaseApp {
         info.displayName.lowercased().appending(" ").appending(info.bundleName).lowercased()
     }
     var sessionDisableKeychain: Bool = false
+
+    override init(appUrl: URL) {
+        super.init(appUrl: appUrl)
+        self.loadDiscordIPC()
+    }
 
     func launch() async {
         do {
@@ -65,10 +69,6 @@ class PlayApp: BaseApp {
 
     func runAppExec() {
         let config = NSWorkspace.OpenConfiguration()
-
-        if settings.settings.injectIntrospection {
-            config.environment["DYLD_LIBRARY_PATH"] = "/usr/lib/system/introspection"
-        }
 
         NSWorkspace.shared.openApplication(
             at: url,
@@ -187,11 +187,11 @@ class PlayApp: BaseApp {
 
     lazy var playChainURL = PlayApp.playChainDirectory.appendingPathComponent(info.bundleIdentifier)
 
-    lazy var settings = AppSettings(info, container: container)
+    lazy var settings = AppSettings(info)
 
-    lazy var keymapping = Keymapping(info, container: container)
+    lazy var keymapping = Keymapping(info)
 
-    var container: AppContainer?
+    lazy var container = AppContainer(bundleId: info.bundleIdentifier)
 
     func hasPlayTools() -> Bool {
         do {
@@ -242,7 +242,7 @@ class PlayApp: BaseApp {
     }
 
     func openAppCache() {
-        container?.containerUrl.showInFinderAndSelectLastComponent()
+        container.containerUrl.showInFinderAndSelectLastComponent()
     }
 
     func clearAllCache() {

--- a/PlayCover/Utils/Cacher.swift
+++ b/PlayCover/Utils/Cacher.swift
@@ -28,15 +28,11 @@ class Cacher {
         var bestResImage: NSImage?
         let compareStr = app.info.bundleIdentifier + app.info.bundleVersion
 
-        do {
-            try app.url.enumerateContents { file, _ in
-                if file.lastPathComponent.contains(app.info.primaryIconName), let icon = NSImage(contentsOf: file),
-                    checkImageDimensions(icon, bestResImage) {
-                    bestResImage = icon
-                }
+        app.url.enumerateContents(blocking: false) { file, _ in
+            if file.lastPathComponent.contains(app.info.primaryIconName), let icon = NSImage(contentsOf: file),
+               self.checkImageDimensions(icon, bestResImage) {
+                bestResImage = icon
             }
-        } catch {
-            Log.shared.error(error)
         }
 
         if let assetsExtractor = try? AssetsExtractor(appUrl: app.url) {

--- a/PlayCover/Utils/Extensions/PlayAppExtensions.swift
+++ b/PlayCover/Utils/Extensions/PlayAppExtensions.swift
@@ -9,37 +9,41 @@ import Foundation
 
 extension PlayApp {
     func loadDiscordIPC() {
-        let appTmp = self.container.containerUrl.appendingPathComponent("Data")
-            .appendingPathComponent("tmp")
+        if self.container.doesExist() {
+            let appTmp = self.container.containerUrl.appendingPathComponent("Data")
+                .appendingPathComponent("tmp")
 
-        appTmp.enumerateContents(options: []) { url, type in
-            if url.lastPathComponent.contains("discord-ipc-") && (type.isSymbolicLink ?? true) {
-                FileManager.default.delete(at: url)
-            }
-        }
+            try? FileManager.default.createDirectory(at: appTmp, withIntermediateDirectories: false)
 
-        guard self.settings.settings.discordActivity.enable else {
-            return
-        }
-
-        let userTmp = FileManager.default.temporaryDirectory.path
-
-        for ipcPort in 0..<10 {
-            let socketPath = userTmp + "/discord-ipc-\(ipcPort)"
-            if FileManager.default.fileExists(atPath: socketPath) {
-                do {
-                    try FileManager.default.createSymbolicLink(atPath: appTmp
-                        .appendingPathComponent("discord-ipc-\(ipcPort)").path,
-                                                               withDestinationPath: socketPath)
-                    print("Successfully linked discordipc for \(self.info.bundleIdentifier)")
-                    return
-                } catch {
-                    print(error)
-                    continue
+            appTmp.enumerateContents(options: []) { url, type in
+                if url.lastPathComponent.contains("discord-ipc-") && (type.isSymbolicLink ?? true) {
+                    FileManager.default.delete(at: url)
                 }
             }
-        }
 
-        print("Unable to link discordipc for \(self.info.bundleIdentifier)")
+            guard self.settings.settings.discordActivity.enable else {
+                return
+            }
+
+            let userTmp = FileManager.default.temporaryDirectory.path
+
+            for ipcPort in 0..<10 {
+                let socketPath = userTmp + "/discord-ipc-\(ipcPort)"
+                if FileManager.default.fileExists(atPath: socketPath) {
+                    do {
+                        try FileManager.default.createSymbolicLink(atPath: appTmp
+                            .appendingPathComponent("discord-ipc-\(ipcPort)").path,
+                                                                   withDestinationPath: socketPath)
+                        print("Successfully linked discordipc for \(self.info.bundleIdentifier)")
+                        return
+                    } catch {
+                        print(error)
+                        continue
+                    }
+                }
+            }
+
+            print("Unable to link discordipc for \(self.info.bundleIdentifier)")
+        }
     }
 }

--- a/PlayCover/Utils/Extensions/PlayAppExtensions.swift
+++ b/PlayCover/Utils/Extensions/PlayAppExtensions.swift
@@ -1,0 +1,45 @@
+//
+//  PlayAppExtensions.swift
+//  PlayCover
+//
+//  Created by TheMoonThatRises on 10/2/23.
+//
+
+import Foundation
+
+extension PlayApp {
+    func loadDiscordIPC() {
+        let appTmp = self.container.containerUrl.appendingPathComponent("Data")
+            .appendingPathComponent("tmp")
+
+        appTmp.enumerateContents(options: []) { url, type in
+            if url.lastPathComponent.contains("discord-ipc-") && (type.isSymbolicLink ?? true) {
+                FileManager.default.delete(at: url)
+            }
+        }
+
+        guard self.settings.settings.discordActivity.enable else {
+            return
+        }
+
+        let userTmp = FileManager.default.temporaryDirectory.path
+
+        for ipcPort in 0..<10 {
+            let socketPath = userTmp + "/discord-ipc-\(ipcPort)"
+            if FileManager.default.fileExists(atPath: socketPath) {
+                do {
+                    try FileManager.default.createSymbolicLink(atPath: appTmp
+                        .appendingPathComponent("discord-ipc-\(ipcPort)").path,
+                                                               withDestinationPath: socketPath)
+                    print("Successfully linked discordipc for \(self.info.bundleIdentifier)")
+                    return
+                } catch {
+                    print(error)
+                    continue
+                }
+            }
+        }
+
+        print("Unable to link discordipc for \(self.info.bundleIdentifier)")
+    }
+}

--- a/PlayCover/Utils/Extensions/URLExtensions.swift
+++ b/PlayCover/Utils/Extensions/URLExtensions.swift
@@ -74,18 +74,36 @@ extension URL {
     }
 
     // Wraps NSFileEnumerator since the geniuses at corelibs-foundation decided it should be completely untyped
-    func enumerateContents(_ callback: (URL, URLResourceValues) throws -> Void) throws {
+    func enumerateContents(blocking: Bool = true,
+                           includingPropertiesForKeys keys: [URLResourceKey]? = nil,
+                           options: FileManager.DirectoryEnumerationOptions? = nil,
+                           _ callback: @escaping(URL, URLResourceValues) throws -> Void) {
         guard let enumerator = FileManager.default.enumerator(
             at: self,
-            includingPropertiesForKeys: [.isRegularFileKey],
-            options: [.skipsHiddenFiles, .skipsPackageDescendants]) else {
+            includingPropertiesForKeys: keys ?? [.isRegularFileKey],
+            options: options ?? [.skipsHiddenFiles, .skipsPackageDescendants]) else {
             return
         }
 
+        let queue = OperationQueue()
+        queue.name = "io.playcover.PlayCover.URLExtension"
+        queue.qualityOfService = .userInitiated
+        queue.maxConcurrentOperationCount = 15
+
         for case let fileURL as URL in enumerator {
-            do {
-                try callback(fileURL, fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]))
+            queue.addOperation {
+                do {
+                    try callback(fileURL, fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]))
+                } catch {
+                    // Don't show error, as there could be many files within the folder
+                    // that would fail the callback
+                    print(error)
+                }
             }
+        }
+
+        if blocking {
+            queue.waitUntilAllOperationsAreFinished()
         }
     }
 

--- a/PlayCover/ViewModel/AppsVM.swift
+++ b/PlayCover/ViewModel/AppsVM.swift
@@ -27,7 +27,6 @@ class AppsVM: ObservableObject {
             apps.removeAll()
 
             do {
-                let containers = try AppContainer.containers()
                 let directoryContents = try FileManager.default
                     .contentsOfDirectory(at: PlayTools.playCoverContainer, includingPropertiesForKeys: nil, options: [])
 
@@ -39,10 +38,8 @@ class AppsVM: ObservableObject {
                                                                   .appendingPathExtension("plist")
                                                                   .path) {
                         let app = PlayApp(appUrl: sub)
-                        if let container = containers[app.info.bundleIdentifier] {
-                            app.container = container
-                            print("Application installed under:", sub.path)
-                        }
+                        print("Application installed under:", sub.path)
+
                         apps.append(app)
                         if searchText.isEmpty || app.searchText.contains(searchText.lowercased()) {
                             filteredApps.append(app)

--- a/PlayCover/Views/Uninstaller.swift
+++ b/PlayCover/Views/Uninstaller.swift
@@ -153,27 +153,23 @@ class Uninstaller {
         let bundleIds = AppsVM.shared.apps.map { $0.info.bundleIdentifier }
         let appNames = AppsVM.shared.apps.map { $0.info.displayName }
 
-        do {
-            for url in pruneURLs {
-                try url.enumerateContents { file, _ in
-                    let bundleId = file.deletingPathExtension().lastPathComponent
-                    if !bundleIds.contains(bundleId) {
-                        clearExternalCache(bundleId)
+        for url in pruneURLs {
+            url.enumerateContents(options: []) { file, _ in
+                let bundleId = file.deletingPathExtension().lastPathComponent
+                if !bundleIds.contains(bundleId) {
+                    clearExternalCache(bundleId)
 
-                        FileManager.default.delete(at: file)
-                    }
+                    FileManager.default.delete(at: file)
                 }
             }
-            for url in otherPruneURLs {
-                try url.enumerateContents { file, _ in
-                    let appName = file.deletingPathExtension().lastPathComponent
-                    if !appNames.contains(appName) {
-                        FileManager.default.delete(at: file)
-                    }
+        }
+        for url in otherPruneURLs {
+            url.enumerateContents(options: []) { file, _ in
+                let appName = file.deletingPathExtension().lastPathComponent
+                if !appNames.contains(appName) {
+                    FileManager.default.delete(at: file)
                 }
             }
-        } catch {
-            Log.shared.error(error)
         }
     }
 }


### PR DESCRIPTION
Fixes #1112 and requires https://github.com/PlayCover/PlayTools/pull/126, https://github.com/PlayCover/SwordRPC/pull/1. The fix is to symbolically link the discord-ipc socket "file" to the app's own temporary directory in `~/Library/Containers/[App ID]/Data/tmp` at the initialisation of each app model. In order to accomplish this, some of the functions and models have been changed, such as the `enumerate` function in FileManager and the `AppContainer` model itself. Along with that, the `PlayAppExtensions.swift` file was created to avoid going over the line limit for `PlayApp` with SwiftLint.