### PR TITLE
Fix sidebar button

### DIFF
--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -44,6 +44,13 @@ struct MainView: View {
                             Label("sidebar.ipaLibrary", systemImage: "arrow.down.circle")
                         }
                     }
+                    .toolbar {
+                        ToolbarItem { // Sits on the left by default
+                            Button(action: toggleSidebar, label: {
+                                Image(systemName: "sidebar.leading")
+                            })
+                        }
+                    }
                     .onChange(of: sidebarGeom.size) { newSize in
                         navWidth = newSize.width
                     }
@@ -87,13 +94,6 @@ struct MainView: View {
             }
             .onAppear {
                 self.selectedView = URLObserved.type == .source ? 2 : 1
-            }
-            .toolbar {
-                ToolbarItem { // Sits on the left by default
-                    Button(action: toggleSidebar, label: {
-                        Image(systemName: "sidebar.leading")
-                    })
-                }
             }
             .overlay {
                 HStack {


### PR DESCRIPTION
Fixes incorrect positioning of sidebar item caused in #1060 and correctly places it (which was the intent of that PR, but not accomplished).

Before:
<img width="961" alt="Screenshot 2023-10-07 at 19 22 08" src="https://github.com/PlayCover/PlayCover/assets/58153205/346b06c5-cf7f-4777-a5c5-aa766155755d">
<img width="961" alt="Screenshot 2023-10-07 at 19 22 16" src="https://github.com/PlayCover/PlayCover/assets/58153205/6cd42a61-e97a-4ca9-93ad-8a300fc78a47">

After:
<img width="961" alt="Screenshot 2023-10-07 at 19 22 40" src="https://github.com/PlayCover/PlayCover/assets/58153205/efbd5ac1-5ff3-4b14-86fc-191b5bea93a3">
<img width="961" alt="Screenshot 2023-10-07 at 19 22 48" src="https://github.com/PlayCover/PlayCover/assets/58153205/3e898c5f-f824-4a03-b492-63f108816c22">
