### PR TITLE
Added Support for iPhone 15 Pro Max in the iOS Device Picker

### DIFF
--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -210,7 +210,7 @@ struct GraphicsView: View {
                         Divider()
                         Text("iPhone 13 Pro Max | A15 | 6GB").tag("iPhone14,3")
                         Text("iPhone 14 Pro Max | A16 | 6GB").tag("iPhone15,3")
-                    }
+                        Text("iPhone 15 Pro Max | A17 Pro | 8GB").tag("iPhone16,2")
                     .frame(width: 250)
                 }
                 HStack {


### PR DESCRIPTION
Based on reputable sources like https://www.screensizes.app/?model=iphone-15-pro-max and https://everymac.com/systems/apple/iphone/specs/apple-iphone-15-pro-max-global-a3106-specs.html It is confirmed that the Device ID for the iPhone 15 Pro max is iPhone16,2.

Using this info i modified the AppSettings View file to include the device.