### PR TITLE
IPA library app info

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		B17FD04728C7B0D900B1D4CA /* AssetsExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17FD04628C7B0D900B1D4CA /* AssetsExtractor.swift */; };
 		B6603E1128E206A300DEFA3F /* UninstallSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6603E1028E206A300DEFA3F /* UninstallSettings.swift */; };
 		B6603E1328E2257800DEFA3F /* Uninstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6603E1228E2257800DEFA3F /* Uninstaller.swift */; };
+		B67C1A112AE8091F00F396CC /* StoreInfoAppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67C1A102AE8091F00F396CC /* StoreInfoAppView.swift */; };
+		B67C1A132AE80A7400F396CC /* StoreAppVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67C1A122AE80A7400F396CC /* StoreAppVM.swift */; };
 		B6825C3528F3D23600E3015A /* InstallSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6825C3428F3D23600E3015A /* InstallSettings.swift */; };
 		B6AB53C929232B4F00039B2E /* KeyCodeNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AB53C829232B4F00039B2E /* KeyCodeNames.swift */; };
 		B6ABDA2A2971EEF700A46E80 /* ProgressVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ABDA292971EEF700A46E80 /* ProgressVM.swift */; };
@@ -188,6 +190,8 @@
 		B17FD04628C7B0D900B1D4CA /* AssetsExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsExtractor.swift; sourceTree = "<group>"; };
 		B6603E1028E206A300DEFA3F /* UninstallSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UninstallSettings.swift; sourceTree = "<group>"; };
 		B6603E1228E2257800DEFA3F /* Uninstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Uninstaller.swift; sourceTree = "<group>"; };
+		B67C1A102AE8091F00F396CC /* StoreInfoAppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreInfoAppView.swift; sourceTree = "<group>"; };
+		B67C1A122AE80A7400F396CC /* StoreAppVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreAppVM.swift; sourceTree = "<group>"; };
 		B6825C3428F3D23600E3015A /* InstallSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSettings.swift; sourceTree = "<group>"; };
 		B6AB53C829232B4F00039B2E /* KeyCodeNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCodeNames.swift; sourceTree = "<group>"; };
 		B6ABDA292971EEF700A46E80 /* ProgressVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressVM.swift; sourceTree = "<group>"; };
@@ -233,6 +237,7 @@
 				6E66B0D428A0039D0099B907 /* ToastView.swift */,
 				365AFB0728847B75008B3542 /* Sparkle.swift */,
 				6ED6ACA328A949A30040D234 /* AppSettingsView.swift */,
+				B67C1A102AE8091F00F396CC /* StoreInfoAppView.swift */,
 				6E250970297F5281004D754C /* SigningSetupView.swift */,
 				6E06193428B3C3ED0012C771 /* Genshin Account Views */,
 				6E66B0CF289F562A0099B907 /* Sidebar Views */,
@@ -305,6 +310,7 @@
 				6E66B0D828A135360099B907 /* ToastVM.swift */,
 				53F4D29F26C43C690020167C /* Log.swift */,
 				B6ABDA292971EEF700A46E80 /* ProgressVM.swift */,
+				B67C1A122AE80A7400F396CC /* StoreAppVM.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -647,6 +653,7 @@
 				6E550A8B29BA507200EFC15C /* Macho.swift in Sources */,
 				6E25096F297F5032004D754C /* FileExtensions.swift in Sources */,
 				53F4D2A026C43C690020167C /* Log.swift in Sources */,
+				B67C1A132AE80A7400F396CC /* StoreAppVM.swift in Sources */,
 				B6603E1128E206A300DEFA3F /* UninstallSettings.swift in Sources */,
 				92A8AAC9275EFEA800D89B50 /* SystemConfig.swift in Sources */,
 				6E66B0C9289F52800099B907 /* IPALibraryView.swift in Sources */,
@@ -685,6 +692,7 @@
 				ABED59832887A32F004D782B /* MenuBarView.swift in Sources */,
 				B6AB53C929232B4F00039B2E /* KeyCodeNames.swift in Sources */,
 				92EE06D4274EA604002C907B /* PlayAppView.swift in Sources */,
+				B67C1A112AE8091F00F396CC /* StoreInfoAppView.swift in Sources */,
 				6E21233128F65F7600B4D75D /* GenshinUserDataURLs.swift in Sources */,
 				B17FD04728C7B0D900B1D4CA /* AssetsExtractor.swift in Sources */,
 				ABDAD80629893CF900DC164F /* KeyCoverSetupViews.swift in Sources */,

--- a/PlayCover/ViewModel/StoreAppVM.swift
+++ b/PlayCover/ViewModel/StoreAppVM.swift
@@ -1,0 +1,16 @@
+//
+//  StoreAppVM.swift
+//  PlayCover
+//
+//  Created by TheMoonThatRises on 10/24/23.
+//
+
+import Foundation
+
+class StoreAppVM: ObservableObject {
+    @Published var data: StoreAppData
+
+    init(data: StoreAppData) {
+        self.data = data
+    }
+}

--- a/PlayCover/Views/App Views/StoreAppView.swift
+++ b/PlayCover/Views/App Views/StoreAppView.swift
@@ -17,6 +17,7 @@ struct StoreAppView: View {
     @State var app: StoreAppData
     @State var isList: Bool
     @State var observation: NSKeyValueObservation?
+    @State var showInfo = false
 
     @State var warningSymbol: String?
     @State var warningMessage: String?
@@ -42,9 +43,20 @@ struct StoreAppView: View {
                 }
             }
         })
+        .contextMenu {
+            Button(action: {
+                showInfo.toggle()
+            }, label: {
+                Text("ipaLibrary.info")
+            })
+        }
         .simultaneousGesture(TapGesture().onEnded {
             selected = app
         })
+        .sheet(isPresented: $showInfo) {
+            StoreInfoAppView(viewModel: StoreAppVM(data: app))
+                .environmentObject(downloadVM)
+        }
         .environmentObject(downloadVM)
         .task(priority: .background) {
             if let sourceApp = AppsVM.shared.apps.first(where: { $0.info.bundleIdentifier == app.bundleID }) {
@@ -191,7 +203,7 @@ struct StoreAppConditionalView: View {
                 .frame(width: 130, height: 130)
             }
         }
-        .task(priority: .userInitiated) {
+        .task(priority: .background) {
             if !cache.hasData(forKey: app.itunesLookup) {
                 await Cacher().resolveITunesData(app.itunesLookup)
             }

--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -39,7 +39,8 @@ struct MainView: View {
                         }
                         NavigationLink(destination: IPALibraryView(selectedBackgroundColor: $selectedBackgroundColor,
                                                                    selectedTextColor: $selectedTextColor)
-                            .environmentObject(store),
+                            .environmentObject(store)
+                            .environmentObject(DownloadVM.shared),
                                        tag: 2, selection: self.$selectedView) {
                             Label("sidebar.ipaLibrary", systemImage: "arrow.down.circle")
                         }

--- a/PlayCover/Views/Sidebar Views/IPALibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/IPALibraryView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct IPALibraryView: View {
     @EnvironmentObject var storeVM: StoreVM
+    @EnvironmentObject var downloadVM: DownloadVM
 
     @Binding var selectedBackgroundColor: Color
     @Binding var selectedTextColor: Color
@@ -18,6 +19,7 @@ struct IPALibraryView: View {
     @State private var isList = UserDefaults.standard.bool(forKey: "IPALibraryView")
     @State private var selected: StoreAppData?
     @State private var addSourcePresented = false
+    @State private var showInfo = false
 
     @ObservedObject private var URLObserved = URLObservable.shared
 
@@ -91,6 +93,17 @@ struct IPALibraryView: View {
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button(action: {
+                    showInfo.toggle()
+                }, label: {
+                    Image(systemName: "info.circle")
+                })
+                .disabled(selected == nil)
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Spacer()
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Button(action: {
                     storeVM.resolveSources()
                 }, label: {
                     Image(systemName: "arrow.clockwise")
@@ -133,6 +146,12 @@ struct IPALibraryView: View {
         .sheet(isPresented: $addSourcePresented) {
             AddSourceView(addSourceSheet: $addSourcePresented)
                 .environmentObject(storeVM)
+        }
+        .sheet(isPresented: $showInfo) {
+            if let selected = selected {
+                StoreInfoAppView(viewModel: StoreAppVM(data: selected))
+                    .environmentObject(downloadVM)
+            }
         }
         .onChange(of: URLObserved.type) {_ in
             addSourcePresented = URLObserved.type == .source

--- a/PlayCover/Views/StoreInfoAppView.swift
+++ b/PlayCover/Views/StoreInfoAppView.swift
@@ -1,0 +1,176 @@
+//
+//  StoreInfoAppView.swift
+//  PlayCover
+//
+//  Created by TheMoonThatRises on 10/24/23.
+//
+
+import SwiftUI
+import DataCache
+import CachedAsyncImage
+
+struct StoreInfoAppView: View {
+    @Environment(\.dismiss) var dismiss
+
+    @EnvironmentObject var downloadVM: DownloadVM
+
+    @ObservedObject var viewModel: StoreAppVM
+
+    @State var closeView = false
+
+    @State var isAvailable: Bool?
+    @State var onlineIcon: URL?
+    @State var localIcon: NSImage?
+
+    @State var itunesResponse: ITunesResponse?
+
+    @State private var cache = DataCache.instance
+
+    var body: some View {
+        VStack {
+            HStack {
+                ZStack {
+                    Group {
+                        CachedAsyncImage(url: onlineIcon, urlCache: .iconCache) { image in
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                        } placeholder: {
+                            if let image = localIcon {
+                                Image(nsImage: image)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                            } else {
+                                Rectangle()
+                                    .fill(.regularMaterial)
+                                    .overlay {
+                                        ProgressView()
+                                            .progressViewStyle(.circular)
+                                            .controlSize(.small)
+                                    }
+                            }
+                        }
+                    }
+                    .cornerRadius(10)
+                    .shadow(radius: 1)
+                    .frame(width: 33, height: 33)
+                    if downloadVM.inProgress && downloadVM.storeAppData == viewModel.data {
+                        ProgressView(value: downloadVM.progress)
+                            .progressViewStyle(.circular)
+                    }
+                }
+
+                VStack {
+                    HStack {
+                        Text(String(
+                            format:
+                                NSLocalizedString("ipaLibrary.info.title", comment: ""),
+                            viewModel.data.name))
+                        .font(.title2).bold()
+                        .multilineTextAlignment(.leading)
+                        Spacer()
+                    }
+
+                    let notAvailableWarning = Image(systemName: "exclamationmark.triangle")
+                    let warning = NSLocalizedString("ipaLibrary.info.notAvailable", comment: "")
+
+                    if !(isAvailable ?? true) {
+                        HStack {
+                            Text("\(notAvailableWarning) \(warning)")
+                                .font(.caption)
+                                .multilineTextAlignment(.leading)
+                            Spacer()
+                        }
+                    }
+                }
+            }
+
+            TabView {
+                StoreInfoView(data: $viewModel.data)
+                    .tabItem {
+                        Text("ipaLibrary.info.tab.info")
+                    }
+            }
+            .frame(minWidth: 500, minHeight: 250)
+            HStack {
+                Spacer()
+                Button("button.OK") {
+                    closeView.toggle()
+                }
+                .tint(.accentColor)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .onChange(of: closeView) { _ in
+            dismiss()
+        }
+        .task(priority: .background) {
+            if let link = URL(string: viewModel.data.link) {
+                _ = NetworkVM.urlAccessible(url: link, popup: false) { _, available in
+                    isAvailable = available
+                }
+            } else {
+                isAvailable = false
+            }
+
+            if !cache.hasData(forKey: viewModel.data.itunesLookup) {
+                await Cacher().resolveITunesData(viewModel.data.itunesLookup)
+            }
+            itunesResponse = try? cache.readCodable(forKey: viewModel.data.itunesLookup)
+            if let response = itunesResponse {
+                onlineIcon = URL(string: response.results[0].artworkUrl512)
+            } else {
+                localIcon = Cacher().getLocalIcon(bundleId: viewModel.data.bundleID)
+            }
+        }
+        .padding()
+    }
+
+}
+
+struct StoreInfoView: View {
+
+    @Binding var data: StoreAppData
+
+    var body: some View {
+        List {
+            HStack {
+                Text("ipaLibrary.info.appName")
+                Spacer()
+                Text("\(data.name)")
+            }
+            HStack {
+                Text("ipaLibrary.info.bundleIdentifier")
+                Spacer()
+                Text("\(data.bundleID)")
+            }
+            HStack {
+                Text("ipaLibrary.info.bundleVersion")
+                Spacer()
+                Text("\(data.version)")
+            }
+            HStack {
+                Text("ipaLibrary.info.itunes")
+                Spacer()
+                Text(.init("[\(data.itunesLookup)](\(data.itunesLookup))"))
+            }
+            HStack {
+                Text("ipaLibrary.info.directLink")
+                Spacer()
+                Text(.init("[\(data.link)](\(data.link))"))
+            }
+            HStack {
+                Text("ipaLibrary.info.checksum")
+                Spacer()
+                if let checksum = data.checksum {
+                    Text("\(checksum)")
+                } else {
+                    Text("ipaLibrary.info.checksum.none")
+                }
+            }
+        }
+        .listStyle(.bordered(alternatesRowBackgrounds: true))
+        .padding()
+    }
+
+}

--- a/PlayCover/Views/StoreInfoAppView.swift
+++ b/PlayCover/Views/StoreInfoAppView.swift
@@ -88,7 +88,7 @@ struct StoreInfoAppView: View {
             TabView {
                 StoreInfoView(data: $viewModel.data)
                     .tabItem {
-                        Text("ipaLibrary.info.tab.info")
+                        Text("settings.tab.info")
                     }
             }
             .frame(minWidth: 500, minHeight: 250)
@@ -135,17 +135,17 @@ struct StoreInfoView: View {
     var body: some View {
         List {
             HStack {
-                Text("ipaLibrary.info.appName")
+                Text("settings.info.bundleName")
                 Spacer()
                 Text("\(data.name)")
             }
             HStack {
-                Text("ipaLibrary.info.bundleIdentifier")
+                Text("settings.info.bundleIdentifier")
                 Spacer()
                 Text("\(data.bundleID)")
             }
             HStack {
-                Text("ipaLibrary.info.bundleVersion")
+                Text("settings.info.bundleVersion")
                 Spacer()
                 Text("\(data.version)")
             }
@@ -155,7 +155,7 @@ struct StoreInfoView: View {
                 Text(.init("[\(data.itunesLookup)](\(data.itunesLookup))"))
             }
             HStack {
-                Text("ipaLibrary.info.directLink")
+                Text("settings.info.url")
                 Spacer()
                 Text(.init("[\(data.link)](\(data.link))"))
             }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -20,6 +20,18 @@
 "playapp.noSources.title" = "No IPAs Installed";
 "playapp.noSources.subtitle" = "You currently have no IPAs installed. Click the button below to import one.";
 
+"ipaLibrary.info" = "App Info";
+"ipaLibrary.info.title" = "%@ Info";
+"ipaLibrary.info.notAvailable" = "Link not valid for this app";
+"ipaLibrary.info.tab.info" = "Info";
+"ipaLibrary.info.appName" = "App Name:";
+"ipaLibrary.info.bundleIdentifier" = "Bundle Identifier:";
+"ipaLibrary.info.bundleVersion" = "Bundle Version:";
+"ipaLibrary.info.itunes" = "ITunes Lookup:";
+"ipaLibrary.info.directLink" = "Direct Link:";
+"ipaLibrary.info.checksum" = "Checksum:";
+"ipaLibrary.info.checksum.none" = "None provided";
+
 "ipaLibrary.noSources.title" = "No IPA Sources Added";
 "ipaLibrary.noSources.subtitle" = "You currently have no IPA Sources added. Click the button below to add one.";
 "ipaLibrary.noSources.button" = "Add Source";
@@ -28,6 +40,7 @@
 "ipaLibrary.version.older" = "This version is older than the one you have installed";
 "ipaLibrary.version.same" = "App already installed";
 "ipaLibrary.version.newer" = "This version is newer than the version you have installed";
+"ipaLibrary.unavailable" = "The link is unavailable";
 "ipaLibrary.alert.download" = "Are you sure you want to download this version of %@?";
 "ipaLibrary.download" = "Download";
 

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -23,12 +23,7 @@
 "ipaLibrary.info" = "App Info";
 "ipaLibrary.info.title" = "%@ Info";
 "ipaLibrary.info.notAvailable" = "Link not valid for this app";
-"ipaLibrary.info.tab.info" = "Info";
-"ipaLibrary.info.appName" = "App Name:";
-"ipaLibrary.info.bundleIdentifier" = "Bundle Identifier:";
-"ipaLibrary.info.bundleVersion" = "Bundle Version:";
 "ipaLibrary.info.itunes" = "ITunes Lookup:";
-"ipaLibrary.info.directLink" = "Direct Link:";
 "ipaLibrary.info.checksum" = "Checksum:";
 "ipaLibrary.info.checksum.none" = "None provided";
 


### PR DESCRIPTION
This adds more transparency as to the information in each source, allowing the user to view the direct link (and access through the use of hyperlinks), checksum, and the other information provided by the source.
<img width="850" alt="773a023d-c332-45c2-b69e-16fd1dc322ff" src="https://github.com/PlayCover/PlayCover/assets/58153205/63a60361-859c-4bb8-9c30-fa67ae7f9cc1">

This will also show if the link to the app is valid and accessible, in the case of failed downloads.
<img width="850" alt="Screenshot 2023-10-24 at 14 37 00" src="https://github.com/PlayCover/PlayCover/assets/58153205/878d054c-37c2-44d7-8ffc-8107c680b6c8">

This is modelled after the settings view for apps the user already has installed, and can also be accessed through the "ⓘ" icon in the top navigation bar.
<img width="849" alt="Screenshot 2023-10-24 at 14 38 30" src="https://github.com/PlayCover/PlayCover/assets/58153205/ce09aeb1-0282-4e79-84b1-f03b5a14e450">
