### PR TITLE
Add support for some iOS Apps that cannot find iOS Frameworks.

### DIFF
--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -202,17 +202,18 @@ class PlayApp: BaseApp {
         }
     }
 
-    func introspection(set: Bool? = nil) -> Bool {
-        if info.lsEnvironment["DYLD_LIBRARY_PATH"] == nil {
-            info.lsEnvironment["DYLD_LIBRARY_PATH"] = ""
-        }
+    static let introspection: String = "/usr/lib/system/introspection"
+    static let iosFrameworks: String = "/System/iOSSupport/System/Library/Frameworks"
+
+    func changeDyldLibraryPath(set: Bool? = nil, path: String) -> Bool {
+        info.lsEnvironment["DYLD_LIBRARY_PATH"] = info.lsEnvironment["DYLD_LIBRARY_PATH"] ?? ""
 
         if let set = set {
             if set {
-                info.lsEnvironment["DYLD_LIBRARY_PATH"]? += "/usr/lib/system/introspection:"
+                info.lsEnvironment["DYLD_LIBRARY_PATH"]? += "\(path):"
             } else {
                 info.lsEnvironment["DYLD_LIBRARY_PATH"] = info.lsEnvironment["DYLD_LIBRARY_PATH"]?
-                    .replacingOccurrences(of: "/usr/lib/system/introspection:", with: "")
+                    .replacingOccurrences(of: "\(path):", with: "")
             }
 
             do {
@@ -222,11 +223,11 @@ class PlayApp: BaseApp {
             }
         }
 
-        guard let introspection = info.lsEnvironment["DYLD_LIBRARY_PATH"] else {
+        guard let result = info.lsEnvironment["DYLD_LIBRARY_PATH"] else {
             return false
         }
 
-        return introspection.contains("/usr/lib/system/introspection")
+        return result.contains(path)
     }
 
     func hasAlias() -> Bool {

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -82,7 +82,8 @@ struct AppSettingsView: View {
                     .disabled(!(hasPlayTools ?? true))
                 BypassesView(settings: $viewModel.settings,
                              hasPlayTools: $hasPlayTools,
-                             hasIntrospection: viewModel.app.introspection(),
+                             hasIntrospection: viewModel.app.changeDyldLibraryPath(path: PlayApp.introspection),
+                             hasIosFrameworks: viewModel.app.changeDyldLibraryPath(path: PlayApp.iosFrameworks),
                              app: viewModel.app)
                     .tabItem {
                         Text("settings.tab.bypasses")
@@ -445,6 +446,7 @@ struct BypassesView: View {
     @Binding var hasPlayTools: Bool?
 
     @State var hasIntrospection: Bool
+    @State var hasIosFrameworks: Bool
 
     var app: PlayApp
 
@@ -472,11 +474,20 @@ struct BypassesView: View {
                         .help("settings.toggle.introspection.help")
                     Spacer()
                 }
+                Spacer()
+                HStack {
+                    Toggle("settings.toggle.iosFrameworks", isOn: $hasIosFrameworks)
+                        .help("settings.toggle.iosFrameworks.help")
+                    Spacer()
+                }
             }
             .padding()
         }
         .onChange(of: hasIntrospection) {_ in
-            _ = app.introspection(set: hasIntrospection)
+            _ = app.changeDyldLibraryPath(set: hasIntrospection, path: PlayApp.introspection)
+        }
+        .onChange(of: hasIosFrameworks) {_ in
+            _ = app.changeDyldLibraryPath(set: hasIosFrameworks, path: PlayApp.iosFrameworks)
         }
     }
 }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -191,6 +191,8 @@
 "settings.playChain.debugging" = "PlayChain debugging";
 "settings.toggle.introspection" = "Insert Introspection libraries";
 "settings.toggle.introspection.help" = "Add the system introspection libraries to the app. Known to fix issues with some apps not starting correctly";
+"settings.toggle.iosFrameworks" = "Force Insert iOS Frameworks";
+"settings.toggle.iosFrameworks.help" = "Add the system ios libraries to the app. Known to fix issues with some apps cannot find ios framework";
 
 "settings.applicationCategoryType" = "Application Type";
 "settings.removePlayTools" = "Remove PlayTools";


### PR DESCRIPTION
Add some apps that cannot find iOS Frameworks due to weird dynamic linking via FileSystem.

"Curse of Aros", The app actually doesn't catch dyld environment variables on Mac-catalyst.

2023-11-01 03:49:49.140009+0900 IOSLauncher[3583:64154] PC-DEBUG: PlayShadow is now loading
java.lang.UnsatisfiedLinkError: Library 'UIKit' not found
at org. robovm.rt.bro.Runtime.getHandle(Runtime.java :317)
at org. robovm.rt.bro.Runtime. loadLibrary (Runtime. java:191)
at org. robovm.rt.bro.Bro.bind (Bro.java: 60)
at org. robovm.objc.ObjCRuntime.bind(ObjCRuntime.java:92)
at org.robovm.apple.uikit.UIResponder.(UIResponder.java:53)
at com.bitgate.curseofaros.IOSLauncher.main (IOSLauncher.java:67)

This is a log of the app, and it didn't crash but always quit due to DYLD env variables.

Pure iOS SwiftUI App

import SwiftUI

struct ContentView: View {
    var body: some View {
        Text("Test")
            .onAppear {
                if let dyld = ProcessInfo.processInfo.environment["DYLD_LIBRARY_PATH"] {
                    print("DYLD_LIBRARY_PATH env var: \(dyld)")
//DYLD_LIBRARY_PATH env var: /Users/[name]/Library/Developer/Xcode/DerivedData/Test-bfkvkgqricwfawdjxreioirkncqq/Build/Products/Debug-iphoneos:/usr/lib/system/introspection
                }
            }
    }
}
It print DYLD_LIBRARY_PATH like this. I guess Mac-Catalyst does not give DYLD env variables.