### PR TITLE
fix: missing com.apple.developer.applesignin entitlement

### DIFF
--- a/PlayCover/Utils/Entitlements.swift
+++ b/PlayCover/Utils/Entitlements.swift
@@ -51,6 +51,7 @@ class Entitlements {
         base["com.apple.security.personal-information.calendars"] = true
         base["com.apple.security.personal-information.location"] = true
         base["com.apple.security.print"] = true
+        base["com.apple.developer.applesignin"] = "Default"
     }
 
     // swiftlint:disable:next cyclomatic_complexity


### PR DESCRIPTION
Note that I couldn't try this fix because I don't have an Apple Developer License so I can't sign PlayCover after building it.
Reference: https://stackoverflow.com/a/63804071/3634271

**How to reproduce**:

1) Download [`ch.poinz.Poinz_4.1.14_und3fined.ipa`](https://web.archive.org/web/20231219082608/https://36.filelu.com/d/rr3nw7tjjqqnjjtadcm44z53thpxsukqdu2ksshbu3vs7fca2fti74ovm5wbljwzexwzzbp6/ch.poinz.Poinz_4.1.14_und3fined.ipa) and install it in PlayCover.

2) Click on sign-in with Apple:
<img width="400" alt="image" src="https://github.com/PlayCover/PlayCover/assets/2824100/234b2e11-735c-483a-b830-dfcdcb405e96">

3) The following error appears:
<img width="400" alt="image" src="https://github.com/PlayCover/PlayCover/assets/2824100/8b9bfca3-d06b-4142-800f-227d1dbfb5ba">