### PR TITLE
Fix: solve nightly release warning in Action

### DIFF
--- a/.github/workflows/1.build_release.yml
+++ b/.github/workflows/1.build_release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.0
 
       - name: Get the version
         id: tag_version
@@ -61,7 +61,7 @@ jobs:
         run: rm apikey.json
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.0
         with:
           name: PlayCover_${{ env.TAG_NAME }}.dmg
           path: output/PlayCover_${{ env.TAG_NAME }}.dmg

--- a/.github/workflows/2.nightly_release.yml
+++ b/.github/workflows/2.nightly_release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.0
 
       - name: Install dependencies
         shell: bash
@@ -57,7 +57,7 @@ jobs:
         run: rm apikey.json
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.0
         with:
           name: PlayCover_nightly_${{ github.run_number }}.dmg
           path: output/PlayCover_nightly_${{ github.run_number }}.dmg

--- a/.github/workflows/SwiftLint.yml
+++ b/.github/workflows/SwiftLint.yml
@@ -12,7 +12,7 @@ jobs:
   SwiftLint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.0
       
       - name: SwiftLint
         uses: norio-nomura/action-swiftlint@3.2.1


### PR DESCRIPTION
use `actions/checkout@v4.1.0` and `actions/upload-artifact@v4.3.0` to solve Node 16 are deprecated problem.

Ref: [more info](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.)