### PR TITLE
Change phase to remove quarantine

### DIFF
--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -107,6 +107,7 @@ class Installer {
                 }
 
                 ipa.releaseTempDir()
+                try ipa.removeQuarantine(finalURL)
                 InstallVM.shared.next(.finish, 0.95, 1.0)
                 returnCompletion(finalURL)
             } catch {

--- a/PlayCover/Utils/IPA.swift
+++ b/PlayCover/Utils/IPA.swift
@@ -30,7 +30,7 @@ public class IPA {
         tmpDir = nil
     }
 
-    func removeQuarantine(_ execUrl: URL) throws {
+    public func removeQuarantine(_ execUrl: URL) throws {
         try Shell.run("/usr/bin/xattr", "-r", "-d", "com.apple.quarantine", execUrl.relativePath)
     }
 
@@ -38,7 +38,6 @@ public class IPA {
         if let workDir = tmpDir {
             if try Shell.run("/usr/bin/unzip",
                              "-oq", url.path, "-d", workDir.path) == "" {
-                try removeQuarantine(workDir)
                 return try Installer.fromIPA(detectingAppNameInFolder: workDir.appendingPathComponent("Payload"))
             } else {
                 throw PlayCoverError.appCorrupted


### PR DESCRIPTION
There are some issues about IPA deployment(something changed?)

1. [https://github.com/PlayCover/PlayCover/issues/1360]
2. [https://github.com/PlayCover/PlayCover/issues/1349]

Removal of quarantine using `xattr` in workdir(or tmp folders) is not allowed due to permission.
How about removing it in App file structure.