### PR TITLE
Support for app location

### DIFF
--- a/PlayCover/Model/AppContainer.swift
+++ b/PlayCover/Model/AppContainer.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct AppContainer {
 
-    private static let containersURL = FileManager.default.homeDirectoryForCurrentUser
+    private static let containersURL = InstallSettings.shared.installPreferences.defaultAppPath
         .appendingPathComponent("Library")
         .appendingPathComponent("Containers")
 

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -188,7 +188,7 @@ class PlayApp: BaseApp {
         }
     }
 
-    static let aliasDirectory = FileManager.default.homeDirectoryForCurrentUser
+    static let aliasDirectory = InstallSettings.shared.installPreferences.defaultAppPath
             .appendingPathComponent("Applications")
             .appendingPathComponent("PlayCover")
 

--- a/PlayCover/Utils/GenshinUserData/GenshinUserDataURLs.swift
+++ b/PlayCover/Utils/GenshinUserData/GenshinUserDataURLs.swift
@@ -12,7 +12,7 @@ class GenshinUserDataURLs {
     static let kibanaReportArrayKey = "MIHOYO_KIBANA_REPORT_ARRAY_KEY_Encryption"
     static let lastAccountModel = "MIHOYO_LAST_ACCOUNT_MODEL_Encryption"
 
-    static let plistPath = FileManager.default.homeDirectoryForCurrentUser
+    static let plistPath = InstallSettings.shared.installPreferences.defaultAppPath
         .appendingPathComponent("Library")
         .appendingPathComponent("Containers")
         .appendingPathComponent("com.miHoYo.GenshinImpact")
@@ -23,7 +23,7 @@ class GenshinUserDataURLs {
         .appendingPathExtension("plist")
 
     static func getGameDataPath(bundleID: String) -> URL {
-        return FileManager.default.homeDirectoryForCurrentUser
+        return InstallSettings.shared.installPreferences.defaultAppPath
             .appendingPathComponent("Library")
             .appendingPathComponent("Containers")
             .appendingPathComponent(bundleID)
@@ -32,7 +32,7 @@ class GenshinUserDataURLs {
     }
 
     static func getStorePath() -> URL {
-        return FileManager.default.homeDirectoryForCurrentUser
+        return InstallSettings.shared.installPreferences.defaultAppPath
             .appendingPathComponent("Library")
             .appendingPathComponent("Containers")
             .appendingPathComponent("io.playcover.PlayCover")

--- a/PlayCover/Utils/GenshinUserData/RestoreGenshinUserData.swift
+++ b/PlayCover/Utils/GenshinUserData/RestoreGenshinUserData.swift
@@ -87,7 +87,7 @@ func modifyPlist(newRegion: String) {
 }
 
 func getAccountList() -> [String] {
-    let storePath = FileManager.default.homeDirectoryForCurrentUser
+    let storePath = InstallSettings.shared.installPreferences.defaultAppPath
         .appendingPathComponent("Library")
         .appendingPathComponent("Containers")
         .appendingPathComponent("io.playcover.PlayCover")

--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -26,7 +26,7 @@ class PlayTools {
         .appendingPathExtension("framework")
 
     public static var playCoverContainer: URL {
-        let playCoverPath = FileManager.default.homeDirectoryForCurrentUser
+        let playCoverPath = InstallSettings.shared.installPreferences.defaultAppPath
             .appendingPathComponent("Library")
             .appendingPathComponent("Containers")
             .appendingPathComponent("io.playcover.PlayCover")

--- a/PlayCover/ViewModel/AppsVM.swift
+++ b/PlayCover/ViewModel/AppsVM.swift
@@ -11,7 +11,7 @@ class AppsVM: ObservableObject {
     public static var currentVersion: String {
         (try? String(contentsOf: AppsVM.versionsFile)) ?? "2"
     }
-    public static let appDirectory = PlayTools.playCoverContainer.appendingPathComponent("Applications")
+    public static let appDirectory = InstallSettings.shared.installPreferences.defaultAppPath.appendingPathComponent("Applications")
 
     static let shared = AppsVM()
 

--- a/PlayCover/Views/App Views/PlayAppView.swift
+++ b/PlayCover/Views/App Views/PlayAppView.swift
@@ -167,7 +167,7 @@ struct PlayAppView: View {
 
     func removeTwitterSessionCookie() {
         do {
-            let cookieURL = FileManager.default.homeDirectoryForCurrentUser
+            let cookieURL = InstallSettings.shared.installPreferences.defaultAppPath
                 .appendingPathComponent("Library")
                 .appendingPathComponent("Containers")
                 .appendingPathComponent("com.miHoYo.GenshinImpact")
@@ -185,7 +185,7 @@ struct PlayAppView: View {
     }
 
     func deletePreferences(app: String) {
-        let plistURL = FileManager.default.homeDirectoryForCurrentUser
+        let plistURL = InstallSettings.shared.installPreferences.defaultAppPath
             .appendingPathComponent("Library")
             .appendingPathComponent("Containers")
             .appendingEscapedPathComponent(app)

--- a/PlayCover/Views/Settings/InstallSettings.swift
+++ b/PlayCover/Views/Settings/InstallSettings.swift
@@ -15,6 +15,8 @@ class InstallPreferences: NSObject, ObservableObject {
     @AppStorage("DefaultAppType") var defaultAppType: LSApplicationCategoryType = .none
 
     @AppStorage("ShowInstallPopup") var showInstallPopup = false
+    
+    @AppStorage("DefaultAppPath") var defaultAppPath = FileManager.default.homeDirectoryForCurrentUser
 }
 
 struct InstallSettings: View {
@@ -58,7 +60,7 @@ struct InstallSettings: View {
             GroupBox {
                 VStack(alignment: .leading) {
                     Text("Cartella selezionata:")
-                    Text(folderPath)
+                    Text(installPreferences.defaultAppPath.absoluteString)
                         .padding(.bottom, 10)
                     Button(action: selectFolder) {
                         Text("Seleziona Cartella")
@@ -74,11 +76,8 @@ struct InstallSettings: View {
         let folderPicker = FolderPicker()
         folderPicker.pickFolder { url in
             if let url = url {
+                installPreferences.defaultAppPath = url
                 folderPath = url.path
-                print(folderPath)
-                print(folderPath)
-                print(folderPath)
-                print(folderPath)
             } else {
                 folderPath = "Nessuna cartella selezionata"
             }

--- a/PlayCover/Views/Settings/InstallSettings.swift
+++ b/PlayCover/Views/Settings/InstallSettings.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-
+import Cocoa
 class InstallPreferences: NSObject, ObservableObject {
     static var shared = InstallPreferences()
 
@@ -21,6 +21,8 @@ struct InstallSettings: View {
     public static var shared = InstallSettings()
 
     @ObservedObject var installPreferences = InstallPreferences.shared
+
+    @State private var folderPath: String = "Nessuna cartella selezionata"
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -51,8 +53,51 @@ struct InstallSettings: View {
                         .frame(height: 20)
                 }
             }.disabled(installPreferences.showInstallPopup)
+            Spacer()
+                .frame(height: 20)
+            GroupBox {
+                VStack(alignment: .leading) {
+                    Text("Cartella selezionata:")
+                    Text(folderPath)
+                        .padding(.bottom, 10)
+                    Button(action: selectFolder) {
+                        Text("Seleziona Cartella")
+                    }
+                }
+            }
         }
         .padding(20)
-        .frame(width: 400, height: 200)
+        .frame(width: 400, height: 300)
+    }
+
+    private func selectFolder() {
+        let folderPicker = FolderPicker()
+        folderPicker.pickFolder { url in
+            if let url = url {
+                folderPath = url.path
+                print(folderPath)
+                print(folderPath)
+                print(folderPath)
+                print(folderPath)
+            } else {
+                folderPath = "Nessuna cartella selezionata"
+            }
+        }
+    }
+}
+
+class FolderPicker {
+    func pickFolder(completion: @escaping (URL?) -> Void) {
+        let openPanel = NSOpenPanel()
+        openPanel.canChooseFiles = false
+        openPanel.canChooseDirectories = true
+        openPanel.allowsMultipleSelection = false
+        openPanel.begin { response in
+            if response == .OK {
+                completion(openPanel.url)
+            } else {
+                completion(nil)
+            }
+        }
     }
 }

--- a/PlayCover/Views/Settings/InstallSettings.swift
+++ b/PlayCover/Views/Settings/InstallSettings.swift
@@ -24,7 +24,7 @@ struct InstallSettings: View {
 
     @ObservedObject var installPreferences = InstallPreferences.shared
 
-    @State private var folderPath: String = "Nessuna cartella selezionata"
+    @State private var folderPath: String = "No Folder Selected"
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -59,11 +59,11 @@ struct InstallSettings: View {
                 .frame(height: 20)
             GroupBox {
                 VStack(alignment: .leading) {
-                    Text("Cartella selezionata:")
+                    Text("Select Folder:")
                     Text(installPreferences.defaultAppPath.absoluteString)
                         .padding(.bottom, 10)
                     Button(action: selectFolder) {
-                        Text("Seleziona Cartella")
+                        Text("Select Folder")
                     }
                 }
             }
@@ -79,7 +79,7 @@ struct InstallSettings: View {
                 installPreferences.defaultAppPath = url
                 folderPath = url.path
             } else {
-                folderPath = "Nessuna cartella selezionata"
+                folderPath = "No Folder selected"
             }
         }
     }

--- a/PlayCover/Views/Uninstaller.swift
+++ b/PlayCover/Views/Uninstaller.swift
@@ -14,7 +14,7 @@ struct CheckBoxHelper {
 }
 
 class Uninstaller {
-    private static let libraryUrl = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library")
+    private static let libraryUrl = InstallSettings.shared.installPreferences.defaultAppPath.appendingPathComponent("Library")
     private static let pruneURLs: [URL] = [
         PlayTools.playCoverContainer.appendingPathComponent("App Settings"),
         PlayTools.playCoverContainer.appendingPathComponent("Entitlements"),


### PR DESCRIPTION
Added setting to change default app location

- [x] Add setting in PlayCover setting
- [x] Change App install location
- [ ] Create empty folder when changing install path
- [ ] Move all Application to new location
- [ ] Move all Container to new location ( since games like Genshin have container of 30gb I think it might be good to move them also)

Help appreciated