### PR TITLE
Fix notch detection to work on all machines

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -148,15 +148,11 @@ class AppSettings {
     }
 }
 
-let notchModels = ["MacBookPro18,3", "MacBookPro18,4", "MacBookPro18,1", "MacBookPro18,2", "Mac14,2"]
-
 extension NSScreen {
     public static func hasNotch() -> Bool {
-        if let model = NSScreen.getMacModel() {
-            return notchModels.contains(model)
-        } else {
-            return false
-        }
+        guard #available(macOS 12, *) else { return false }
+        // check if any of the connected screens contains a notch
+        return NSScreen.screens.contains { $0.safeAreaInsets.top != 0 }
     }
 
     private static func getMacModel() -> String? {


### PR DESCRIPTION
This replaces the hard-coded list of Mac models that have a notch with a runtime check.

I'm checking if _any_ connected screen has a notch because that should provide equivalent behavior to the model check.

I left the `NSScreen.getMacModel()` extension method in, but it's not used any more, so I can remove it if desired.

Resolves #1516.