### PR TITLE
Fix (Temp): Sidebar Navigation Deselection on Sequoia

### DIFF
--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -60,7 +60,7 @@ struct MainView: View {
                         }
                         if showSourceFolders {
                             ForEach(store.sourcesData, id: \.hashValue) { source in
-                                NavigationLink {
+                              NavigationLink(tag: source.hashValue, selection: $selectedView) {
                                     IPASourceView(storeVM: store,
                                                   selectedBackgroundColor: $selectedBackgroundColor,
                                                   selectedTextColor: $selectedTextColor,


### PR DESCRIPTION
This is a temporary fix for showing empty page after switching from a Source view to App/IPA Library in order to find time to refactor the app UI.