### PR TITLE
Fix Github builds

### DIFF
--- a/PlayCover/Views/MenuBarView.swift
+++ b/PlayCover/Views/MenuBarView.swift
@@ -73,7 +73,8 @@ struct PlayCoverViewMenuView: Commands {
                     } else if DownloadVM.shared.inProgress {
                         Log.shared.error(PlayCoverError.waitDownload)
                     } else {
-                        NSOpenPanel.selectIPA { result in
+                        // remove await for Swift 6 (no async operation occurs)
+                        await NSOpenPanel.selectIPA { result in
                             if case .success(let url) = result {
                                 Task {
                                     Installer.install(ipaUrl: url,


### PR DESCRIPTION
Add back `await` statement (this `await` gives a warning when compiled with Swift 6 but appears to give a warning when not present in Swift 5.10).