### PR TITLE
Fix create-dmg in builds

### DIFF
--- a/.github/workflows/1.build_release.yml
+++ b/.github/workflows/1.build_release.yml
@@ -38,7 +38,7 @@ jobs:
           gem install fastlane
           bundle install
           pip install setuptools
-          npm install --global create-dmg
+          npm install --global https://github.com/PlayCover/create-dmg
 
       - name: Fastlane Release
         shell: bash

--- a/.github/workflows/2.nightly_release.yml
+++ b/.github/workflows/2.nightly_release.yml
@@ -31,7 +31,7 @@ jobs:
           gem install fastlane
           bundle install
           pip install setuptools
-          npm install --global create-dmg
+          npm install --global https://github.com/PlayCover/create-dmg
 
       - name: Set build number
         shell: bash


### PR DESCRIPTION
Uses PlayCover fork of `create-dmg` for better maintenance.