### PR TITLE
MacOS detect

### DIFF
--- a/PlayCover/AppInstaller/Downloader.swift
+++ b/PlayCover/AppInstaller/Downloader.swift
@@ -35,6 +35,7 @@ class DownloadApp {
     let installVM = InstallVM.shared
     let downloader = DownloadManager.shared
 
+    @MainActor
     func start() {
         if installVM.inProgress {
             Log.shared.error(PlayCoverError.waitInstallation)

--- a/PlayCover/AppInstaller/Downloader.swift
+++ b/PlayCover/AppInstaller/Downloader.swift
@@ -73,7 +73,7 @@ class DownloadApp {
             if let url = url, let app = app {
                 let ipa = IPA(url: url)
                 Task {
-                    if await ipa.hasMacVersion(app: IPA.Application.store(app)) {
+                    if await ipa.checkOfficialMacOS(app: IPA.Application.store(app)) {
                         cancel()
                     } else {
                         if url.isFileURL {

--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -59,7 +59,7 @@ class Installer {
                 try ipa.allocateTempDir()
 
                 let app = try ipa.unzip()
-                if await ipa.hasMacVersion(app: IPA.Application.base(app)) {
+                if await ipa.checkOfficialMacOS(app: IPA.Application.base(app)) {
                     ipa.releaseTempDir()
                     InstallVM.shared.next(.failed, 0.95, 1.0)
                     returnCompletion(nil)

--- a/PlayCover/Utils/Extensions/PlayAppExtensions.swift
+++ b/PlayCover/Utils/Extensions/PlayAppExtensions.swift
@@ -65,15 +65,4 @@ extension PlayApp {
     func removeAlias() {
         FileManager.default.delete(at: aliasURL)
     }
-
-    var hasMacVersion: Bool {
-        PlayApp.MACOS_APPS.contains(info.bundleIdentifier)
-    }
-
-    static let MACOS_APPS = [
-        "com.innersloth.amongus",
-        "com.devsisters.ck",
-        "com.miHoYo.bh3global"
-    ]
-
 }

--- a/PlayCover/Utils/IPA.swift
+++ b/PlayCover/Utils/IPA.swift
@@ -119,9 +119,8 @@ public class IPA {
             appID = Int(stringArray.last ?? "0") ?? 0
         }
         let supportMacOS: Bool = await checkMacOSCompatibility(appID: appID)
-        let noMacAlert = UserDefaults.standard.bool(forKey: "\(bundleID).noMacAlert")
         let showAlert = InstallPreferences.shared.showAppStorePopup
-        if showAlert && supportMacOS && !noMacAlert {
+        if showAlert && supportMacOS {
             let alert = NSAlert()
             alert.messageText = NSLocalizedString("alert.appstore", comment: "")
             alert.informativeText = String(

--- a/PlayCover/Utils/IPA.swift
+++ b/PlayCover/Utils/IPA.swift
@@ -122,11 +122,10 @@ public class IPA {
         let noMacAlert = UserDefaults.standard.bool(forKey: "\(bundleID).noMacAlert")
         if supportMacOS && !noMacAlert {
             let alert = NSAlert()
-            alert.messageText = NSLocalizedString("alert.error", comment: "")
             alert.informativeText = String(
                 format: NSLocalizedString("macos.version", comment: "")
             )
-            alert.alertStyle = .warning
+            alert.alertStyle = .informational
             alert.addButton(withTitle: NSLocalizedString("alert.install.anyway", comment: ""))
             alert.addButton(withTitle: NSLocalizedString("alert.open.appstore", comment: ""))
             alert.addButton(withTitle: NSLocalizedString("button.Cancel", comment: ""))

--- a/PlayCover/Utils/IPA.swift
+++ b/PlayCover/Utils/IPA.swift
@@ -72,7 +72,7 @@ public class IPA {
         case store(SourceAppsData)
     }
 
-    func checkMacOS(appID: Int) async -> Bool {
+    private func checkMacOSCompatibility(appID: Int) async -> Bool {
         let urlString = "https://apps.apple.com/us/app/id\(appID)"
         guard let url = URL(string: urlString) else {
             return false
@@ -103,7 +103,7 @@ public class IPA {
     }
 
     @MainActor
-    func hasMacVersion(app: Application) async -> Bool {
+    func checkOfficialMacOS(app: Application) async -> Bool {
         let bundleID: String
         let appID: Int
         switch app {
@@ -118,7 +118,7 @@ public class IPA {
             let stringArray = appLookup.components(separatedBy: CharacterSet.decimalDigits.inverted)
             appID = Int(stringArray.last ?? "0") ?? 0
         }
-        let supportMacOS: Bool = await checkMacOS(appID: appID)
+        let supportMacOS: Bool = await checkMacOSCompatibility(appID: appID)
         let noMacAlert = UserDefaults.standard.bool(forKey: "\(bundleID).noMacAlert")
         let showAlert = InstallPreferences.shared.showAppStorePopup
         if showAlert && supportMacOS && !noMacAlert {

--- a/PlayCover/Utils/IPA.swift
+++ b/PlayCover/Utils/IPA.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import SwiftSoup
 
 public class IPA {
     public let url: URL
@@ -71,6 +72,36 @@ public class IPA {
         case store(SourceAppsData)
     }
 
+    func checkMacOS(appID: Int) async -> Bool {
+        let urlString = "https://apps.apple.com/us/app/id\(appID)"
+        guard let url = URL(string: urlString) else {
+            return false
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                return false
+            }
+
+            guard let htmlString = String(data: data, encoding: .utf8) else {
+                return false
+            }
+            let document = try SwiftSoup.parse(htmlString)
+            let elements = try document.getElementsByClass("information-list__item__definition__item__definition")
+            for element in elements {
+                let text = try element.text()
+                if text.contains("macOS") {
+                    return true
+                }
+            }
+        } catch {
+            return false
+        }
+
+        return false
+    }
+
     @MainActor
     func hasMacVersion(app: Application) async -> Bool {
         let bundleID: String
@@ -87,8 +118,9 @@ public class IPA {
             let stringArray = appLookup.components(separatedBy: CharacterSet.decimalDigits.inverted)
             appID = Int(stringArray.last ?? "0") ?? 0
         }
+        let supportMacOS: Bool = await checkMacOS(appID: appID)
         let noMacAlert = UserDefaults.standard.bool(forKey: "\(bundleID).noMacAlert")
-        if PlayApp.MACOS_APPS.contains(bundleID), !noMacAlert {
+        if supportMacOS && !noMacAlert {
             let alert = NSAlert()
             alert.messageText = NSLocalizedString("alert.error", comment: "")
             alert.informativeText = String(

--- a/PlayCover/Utils/IPA.swift
+++ b/PlayCover/Utils/IPA.swift
@@ -120,11 +120,15 @@ public class IPA {
         }
         let supportMacOS: Bool = await checkMacOS(appID: appID)
         let noMacAlert = UserDefaults.standard.bool(forKey: "\(bundleID).noMacAlert")
-        if supportMacOS && !noMacAlert {
+        let showAlert = InstallPreferences.shared.showAppStorePopup
+        if showAlert && supportMacOS && !noMacAlert {
             let alert = NSAlert()
             alert.informativeText = String(
                 format: NSLocalizedString("macos.version", comment: "")
             )
+            alert.icon = nil
+            alert.showsSuppressionButton = true
+            alert.suppressionButton?.toolTip = NSLocalizedString("alert.supression", comment: "String")
             alert.alertStyle = .informational
             alert.addButton(withTitle: NSLocalizedString("alert.install.anyway", comment: ""))
             alert.addButton(withTitle: NSLocalizedString("alert.open.appstore", comment: ""))
@@ -132,7 +136,11 @@ public class IPA {
             let result = alert.runModal()
             switch result {
             case .alertFirstButtonReturn:
-                UserDefaults.standard.set(true, forKey: "\(bundleID).noMacAlert")
+                if let suppressionButton = alert.suppressionButton,
+                   suppressionButton.state == .on {
+                    InstallPreferences.shared.showAppStorePopup = false
+                }
+                return false
             case .alertSecondButtonReturn:
                 if appID != 0 {
                     guard let urlApp = URL(string:

--- a/PlayCover/Utils/IPA.swift
+++ b/PlayCover/Utils/IPA.swift
@@ -123,6 +123,7 @@ public class IPA {
         let showAlert = InstallPreferences.shared.showAppStorePopup
         if showAlert && supportMacOS && !noMacAlert {
             let alert = NSAlert()
+            alert.messageText = NSLocalizedString("alert.appstore", comment: "")
             alert.informativeText = String(
                 format: NSLocalizedString("macos.version", comment: "")
             )

--- a/PlayCover/Views/Settings/InstallSettings.swift
+++ b/PlayCover/Views/Settings/InstallSettings.swift
@@ -15,6 +15,8 @@ class InstallPreferences: NSObject, ObservableObject {
     @AppStorage("DefaultAppType") var defaultAppType: LSApplicationCategoryType = .none
 
     @AppStorage("ShowInstallPopup") var showInstallPopup = false
+
+    @AppStorage("ShowAppStorePopup") var showAppStorePopup = true
 }
 
 struct InstallSettings: View {
@@ -35,6 +37,9 @@ struct InstallSettings: View {
                 }
                 .frame(width: 225)
             }
+            Spacer()
+                .frame(height: 20)
+            Toggle("preferences.toggle.showAppStorePopup", isOn: $installPreferences.showAppStorePopup)
             Spacer()
                 .frame(height: 20)
             Toggle("preferences.toggle.showInstallPopup", isOn: $installPreferences.showInstallPopup)

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -289,4 +289,5 @@
 "macos.version" = "This app can be installed from Mac App Store";
 "alert.install.anyway" = "Install Anyway";
 "alert.open.appstore" = "Open Mac App Store";
+"alert.appstore" = "MacOS version is available";
 "preferences.toggle.showAppStorePopup" = "Show an alert if the application has an official AppStore version";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -289,4 +289,4 @@
 "macos.version" = "This app can be installed from Mac App Store";
 "alert.install.anyway" = "Install Anyway";
 "alert.open.appstore" = "Open Mac App Store";
-
+"preferences.toggle.showAppStorePopup" = "Show an alert if the application has an official AppStore version";


### PR DESCRIPTION
Changed how PlayCover detect if an app has macOS version, in this way is no more necessary to add manually bundleID