### PR TITLE
Fix empty async image url string

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		34775E752D493B59001586C2 /* CachedAsyncImageWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34775E742D493B54001586C2 /* CachedAsyncImageWrapper.swift */; };
 		365AFB0628847B2E008B3542 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 365AFB0528847B2E008B3542 /* Sparkle */; };
 		365AFB0828847B75008B3542 /* Sparkle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 365AFB0728847B75008B3542 /* Sparkle.swift */; };
 		3665EF8928832400007CF915 /* PlayCoverSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3665EF8828832400007CF915 /* PlayCoverSettingsView.swift */; };
@@ -91,6 +92,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		34775E742D493B54001586C2 /* CachedAsyncImageWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedAsyncImageWrapper.swift; sourceTree = "<group>"; };
 		365AFB0728847B75008B3542 /* Sparkle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sparkle.swift; sourceTree = "<group>"; };
 		3665EF8828832400007CF915 /* PlayCoverSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayCoverSettingsView.swift; sourceTree = "<group>"; usesTabs = 0; };
 		36B26B96288C724600859EFD /* UpdateSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSettings.swift; sourceTree = "<group>"; };
@@ -230,6 +232,7 @@
 		533F664B26C06A500051CB3E /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				34775E742D493B54001586C2 /* CachedAsyncImageWrapper.swift */,
 				8783CFFA26B8C52D00171041 /* PlayCoverApp.swift */,
 				6E5C68B9289865C8008EC11B /* MainView.swift */,
 				ABED59822887A32F004D782B /* MenuBarView.swift */,
@@ -630,6 +633,7 @@
 				92B4D38F2737CF3D0001D7BB /* PlayTools.swift in Sources */,
 				3665EF8928832400007CF915 /* PlayCoverSettingsView.swift in Sources */,
 				9280871B2824A8D20034C510 /* SoundDeviceService.swift in Sources */,
+				34775E752D493B59001586C2 /* CachedAsyncImageWrapper.swift in Sources */,
 				A25930F42C49E2BC0006C91C /* PlayAppVM.swift in Sources */,
 				92ECD8AE274E787200DB7AC6 /* AppInfo.swift in Sources */,
 				6E250971297F5281004D754C /* SigningSetupView.swift in Sources */,

--- a/PlayCover/Views/App Views/StoreAppView.swift
+++ b/PlayCover/Views/App Views/StoreAppView.swift
@@ -114,8 +114,8 @@ struct StoreAppConditionalView: View {
                         .padding(.leading, 15)
                     ZStack {
                         Group {
-                            CachedAsyncImage(
-                                url: onlineIcon ?? "",
+                            CachedAsyncImageWrapper(
+                                url: onlineIcon,
                                 placeholder: { _ in
                                     if let image = localIcon {
                                         Image(nsImage: image)
@@ -182,8 +182,8 @@ struct StoreAppConditionalView: View {
                 LazyVStack {
                     ZStack {
                         Group {
-                            CachedAsyncImage(
-                                url: onlineIcon ?? "",
+                            CachedAsyncImageWrapper(
+                                url: onlineIcon,
                                 placeholder: { _ in
                                     if let image = localIcon {
                                         Image(nsImage: image)

--- a/PlayCover/Views/CachedAsyncImageWrapper.swift
+++ b/PlayCover/Views/CachedAsyncImageWrapper.swift
@@ -1,0 +1,28 @@
+//
+//  CachedAsyncImageWrapper.swift
+//  PlayCover
+//
+//  Created by TheMoonThatRises on 1/28/25.
+//
+
+import CachedAsyncImage
+import SwiftUI
+
+struct CachedAsyncImageWrapper: View {
+
+    let url: String?
+    let placeholder: ((String) -> any View)?
+    let image: (CPImage) -> any View
+    let error: ((String, @escaping () -> Void) -> any View)?
+
+    var body: some View {
+        if let url = url, !url.isEmpty {
+            CachedAsyncImage(url: url, placeholder: placeholder, image: image, error: error)
+        } else {
+            if let placeholder = placeholder {
+                AnyView(placeholder(""))
+            }
+        }
+    }
+
+}

--- a/PlayCover/Views/Sidebar Views/IPALibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/IPALibraryView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import CachedAsyncImage
 
 struct IPALibraryView: View {
 

--- a/PlayCover/Views/StoreInfoAppView.swift
+++ b/PlayCover/Views/StoreInfoAppView.swift
@@ -31,8 +31,8 @@ struct StoreInfoAppView: View {
             HStack {
                 ZStack {
                     Group {
-                        CachedAsyncImage(
-                            url: onlineIcon ?? "",
+                        CachedAsyncImageWrapper(
+                            url: onlineIcon,
                             placeholder: { _ in
                                 if let image = localIcon {
                                     Image(nsImage: image)
@@ -52,7 +52,8 @@ struct StoreInfoAppView: View {
                                 Image(nsImage: $0)
                                     .resizable()
                                     .aspectRatio(contentMode: .fit)
-                            }
+                            },
+                            error: nil
                         )
                     }
                     .cornerRadius(10)


### PR DESCRIPTION
Provides a layer between `CachedAsyncImage` to check for `nil` and empty input url strings.