### PR TITLE
Add support for custom cursors

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		928C01D9272E162C007EB2DF /* InstallVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928C01D8272E162C007EB2DF /* InstallVM.swift */; };
 		92A8AAC9275EFEA800D89B50 /* SystemConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A8AAC8275EFEA800D89B50 /* SystemConfig.swift */; };
 		92B4D38F2737CF3D0001D7BB /* PlayTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B4D38E2737CF3D0001D7BB /* PlayTools.swift */; };
+		92D33C092D5CC65B004FA2C8 /* CursorSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D33C082D5CC656004FA2C8 /* CursorSetting.swift */; };
+		92D33C0B2D5CC680004FA2C8 /* CursorImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D33C0A2D5CC67C004FA2C8 /* CursorImages.swift */; };
 		92ECD8A3274E75CD00DB7AC6 /* Installer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92ECD8A2274E75CD00DB7AC6 /* Installer.swift */; };
 		92ECD8A5274E763700DB7AC6 /* IPA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92ECD8A4274E763700DB7AC6 /* IPA.swift */; };
 		92ECD8AE274E787200DB7AC6 /* AppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92ECD8AD274E787200DB7AC6 /* AppInfo.swift */; };
@@ -155,6 +157,8 @@
 		928C01D8272E162C007EB2DF /* InstallVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallVM.swift; sourceTree = "<group>"; };
 		92A8AAC8275EFEA800D89B50 /* SystemConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemConfig.swift; sourceTree = "<group>"; };
 		92B4D38E2737CF3D0001D7BB /* PlayTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayTools.swift; sourceTree = "<group>"; };
+		92D33C082D5CC656004FA2C8 /* CursorSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorSetting.swift; sourceTree = "<group>"; };
+		92D33C0A2D5CC67C004FA2C8 /* CursorImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorImages.swift; sourceTree = "<group>"; };
 		92D79316273C065A001CC964 /* libsandbox.1.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsandbox.1.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/libsandbox.1.tbd; sourceTree = DEVELOPER_DIR; };
 		92ECD8A2274E75CD00DB7AC6 /* Installer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Installer.swift; sourceTree = "<group>"; };
 		92ECD8A4274E763700DB7AC6 /* IPA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPA.swift; sourceTree = "<group>"; };
@@ -283,6 +287,7 @@
 				6E7CA16428B4D02900216CD8 /* ITunesResponse.swift */,
 				6E7CA16628B4EEAE00216CD8 /* Keymapping.swift */,
 				B6AB53C829232B4F00039B2E /* KeyCodeNames.swift */,
+				92D33C082D5CC656004FA2C8 /* CursorSetting.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -333,6 +338,7 @@
 				AB00EB5129A7BF17006F3225 /* KeyCover.swift */,
 				AB6F21EA299B7FA20078ADEC /* URLHandler.swift */,
 				ABBC85B82B7C5CBA00DCF223 /* ModifierKeyObserver.swift */,
+				92D33C0A2D5CC67C004FA2C8 /* CursorImages.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -646,6 +652,7 @@
 				6ED6ACA428A949A30040D234 /* AppSettingsView.swift in Sources */,
 				92EE06DA274EB009002C907B /* PlayApp.swift in Sources */,
 				53F50C4926E3CA42007AD2D3 /* AppLibraryView.swift in Sources */,
+				92D33C0B2D5CC680004FA2C8 /* CursorImages.swift in Sources */,
 				6E66B0D1289F57B00099B907 /* Documentation.docc in Sources */,
 				53F3802826EB6F6B00D6B525 /* NotifyService.swift in Sources */,
 				6E5C68BA289865C8008EC11B /* MainView.swift in Sources */,
@@ -680,6 +687,7 @@
 				ABDAD80629893CF900DC164F /* KeyCoverSetupViews.swift in Sources */,
 				6888981729F9158700105D9C /* IPASourceView.swift in Sources */,
 				6EE8265028E8AB2B003935BC /* DownloadVM.swift in Sources */,
+				92D33C092D5CC65B004FA2C8 /* CursorSetting.swift in Sources */,
 				AB00EB5229A7BF17006F3225 /* KeyCover.swift in Sources */,
 				68E48B9C295709C000C39879 /* Cacher.swift in Sources */,
 				53D9DAF326C1849D0071959E /* PlayCoverError.swift in Sources */,

--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -41,6 +41,7 @@ struct AppSettingsData: Codable {
     var rootWorkDir = true
     var noKMOnInput = true
     var enableScrollWheel = true
+    var cursorSetting = CursorSetting()
 
     init() {}
 
@@ -71,6 +72,7 @@ struct AppSettingsData: Codable {
         rootWorkDir = try container.decodeIfPresent(Bool.self, forKey: .rootWorkDir) ?? true
         noKMOnInput = try container.decodeIfPresent(Bool.self, forKey: .noKMOnInput) ?? true
         enableScrollWheel = try container.decodeIfPresent(Bool.self, forKey: .enableScrollWheel) ?? true
+        cursorSetting = try container.decodeIfPresent(CursorSetting.self, forKey: .cursorSetting) ?? CursorSetting()
     }
 }
 

--- a/PlayCover/Model/CursorSetting.swift
+++ b/PlayCover/Model/CursorSetting.swift
@@ -1,0 +1,14 @@
+//
+//  CursorSetting.swift
+//  PlayCover
+//
+//  Created by viatearz on 2025/2/12.
+//
+
+struct CursorSetting: Codable {
+    var enable = false
+    var width = 32
+    var height = 32
+    var hotSpotX = 0
+    var hotSpotY = 0
+}

--- a/PlayCover/Utils/CursorImages.swift
+++ b/PlayCover/Utils/CursorImages.swift
@@ -1,0 +1,51 @@
+//
+//  CursorImages.swift
+//  PlayCover
+//  
+//  Created by viatearz on 2025/2/12.
+//
+
+import Foundation
+
+class CursorImages {
+    static let shared = CursorImages()
+    static var cursorImageDir: URL {
+        let cursorImageFolder = PlayTools.playCoverContainer.appendingPathComponent("Cursors")
+
+        if !FileManager.default.fileExists(atPath: cursorImageFolder.path) {
+            do {
+                try FileManager.default.createDirectory(at: cursorImageFolder, withIntermediateDirectories: true)
+            } catch {
+                Log.shared.error(error)
+            }
+        }
+
+        return cursorImageFolder
+    }
+
+    func imageURL(for bundleIdentifier: String) -> URL {
+        return CursorImages.cursorImageDir
+            .appendingPathComponent(bundleIdentifier)
+            .appendingPathExtension("png")
+    }
+
+    func load(bundleId: String) -> NSImage? {
+        let url = imageURL(for: bundleId)
+        return NSImage(contentsOfFile: url.path)
+    }
+
+    func save(srcImageUrl: URL, for bundleId: String) {
+        do {
+            let dstImageUrl = imageURL(for: bundleId)
+            FileManager.default.delete(at: dstImageUrl)
+            try FileManager.default.copyItem(at: srcImageUrl, to: dstImageUrl)
+        } catch {
+            Log.shared.error(error)
+        }
+    }
+
+    func clear(bundleId: String) {
+        let url = imageURL(for: bundleId)
+        FileManager.default.delete(at: url)
+    }
+}

--- a/PlayCover/Utils/Extensions/FileExtensions.swift
+++ b/PlayCover/Utils/Extensions/FileExtensions.swift
@@ -34,4 +34,20 @@ extension NSOpenPanel {
             }
         }
     }
+
+    static func selectImage(completion: @escaping (_ result: Result<URL, Error>) -> Void) {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowedContentTypes = [UTType.png, UTType.jpeg]
+        panel.canChooseFiles = true
+        panel.begin { result in
+            if result == .OK {
+                if let url = panel.urls.first {
+                    completion(.success(url))
+                }
+            }
+        }
+    }
 }

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -179,10 +179,221 @@ struct KeymappingView: View {
                         .frame(width: 250)
                         .disabled(!settings.settings.keymapping)
                 }
+                HStack {
+                    Toggle("settings.toggle.customCursor", isOn: $settings.settings.cursorSetting.enable)
+                    Spacer()
+                }
+                if settings.settings.cursorSetting.enable {
+                    Spacer()
+                        .frame(height: 16)
+                    CursorSettingView(
+                        bundleId: settings.info.bundleIdentifier,
+                        setting: $settings.settings.cursorSetting
+                    )
+                }
                 Spacer()
             }
             .padding()
         }
+    }
+}
+
+struct CursorSettingView: View {
+    let bundleId: String
+    @Binding var setting: CursorSetting
+    @State var cursorImage: NSImage?
+    @State var cursorWidth = 32
+    @State var cursorHeight = 32
+    @State var cursorHotSpotX = 0
+    @State var cursorHotSpotY = 0
+    @State var showClearCursorAlert = false
+
+    let previewMaxWidth: CGFloat = 60
+    let previewMaxHeight: CGFloat = 60
+    @State var previewCursorWidth: CGFloat = 60
+    @State var previewCursorHeight: CGFloat = 60
+    @State var previewHotSpotX: CGFloat = 0
+    @State var previewHotSpotY: CGFloat = 0
+
+    var body: some View {
+        HStack {
+            if let image = cursorImage {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(style: StrokeStyle(lineWidth: 2, dash: [10, 5]))
+                        .frame(width: previewCursorWidth, height: previewCursorHeight)
+                        .foregroundColor(Color(nsColor: .lightGray))
+                    Image(nsImage: image)
+                        .resizable()
+                        .frame(width: previewCursorWidth, height: previewCursorHeight)
+                        .scaledToFill()
+                        .overlay(
+                            Circle()
+                                .fill(Color.red)
+                                .frame(width: 8, height: 8)
+                                .position(x: previewHotSpotX, y: previewHotSpotY),
+                            alignment: .topLeading
+                        )
+                }
+                .frame(width: previewMaxWidth, height: previewMaxHeight)
+                .onTapGesture {
+                    selectCursorImage()
+                }
+
+                Image(systemName: "trash.circle.fill")
+                    .resizable()
+                    .frame(width: 24, height: 24)
+                    .foregroundColor(Color(nsColor: .lightGray))
+                    .onTapGesture {
+                        showClearCursorAlert = true
+                    }
+            } else {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(style: StrokeStyle(lineWidth: 2, dash: [10, 5]))
+                        .foregroundColor(Color(nsColor: .lightGray))
+                    Image(systemName: "plus")
+                        .resizable()
+                        .frame(width: 24, height: 24)
+                        .foregroundColor(Color(nsColor: .lightGray))
+                }
+                .frame(width: previewMaxWidth, height: previewMaxHeight)
+                .onTapGesture {
+                    selectCursorImage()
+                }
+            }
+            Spacer(minLength: 24)
+            VStack {
+                HStack {
+                    Text("settings.text.cursorSize")
+                        .frame(minWidth: 56, alignment: .trailing)
+                    Spacer()
+                    Text("W:")
+                    Stepper(value: $cursorWidth) {
+                        TextField(
+                            "Width",
+                            value: $cursorWidth,
+                            formatter: GraphicsView.number,
+                            onCommit: {
+                                Task { @MainActor in
+                                    NSApp.keyWindow?.makeFirstResponder(nil)
+                                }
+                            })
+                    }
+                    Text("H:")
+                    Stepper(value: $cursorHeight) {
+                        TextField(
+                            "Height",
+                            value: $cursorHeight,
+                            formatter: GraphicsView.number,
+                            onCommit: {
+                                Task { @MainActor in
+                                    NSApp.keyWindow?.makeFirstResponder(nil)
+                                }
+                            })
+                    }
+                }
+                HStack {
+                    Text("settings.text.cursorHotSpot")
+                        .frame(minWidth: 56, alignment: .trailing)
+                    Spacer()
+                    Text("X:")
+                    Stepper(value: $cursorHotSpotX) {
+                        TextField(
+                            "X",
+                            value: $cursorHotSpotX,
+                            formatter: GraphicsView.number,
+                            onCommit: {
+                                Task { @MainActor in
+                                    NSApp.keyWindow?.makeFirstResponder(nil)
+                                }
+                            })
+                    }
+                    Text("Y:")
+                    Stepper(value: $cursorHotSpotY) {
+                        TextField(
+                            "Y",
+                            value: $cursorHotSpotY,
+                            formatter: GraphicsView.number,
+                            onCommit: {
+                                Task { @MainActor in
+                                    NSApp.keyWindow?.makeFirstResponder(nil)
+                                }
+                            })
+                    }
+                }
+            }
+            .disabled(cursorImage == nil)
+        }
+        .task(priority: .userInitiated) {
+            cursorImage = CursorImages.shared.load(bundleId: bundleId)
+            // Since Steppers with nested TextFields don’t work properly with @Binding values,
+            // we store these values in @State variables.
+            cursorWidth = setting.width
+            cursorHeight = setting.height
+            cursorHotSpotX = setting.hotSpotX
+            // Flip the Y-axis so that the hotspot moves in the same direction as the Stepper arrows
+            cursorHotSpotY = -setting.hotSpotY
+        }
+        .onChange(of: cursorWidth) { newValue in
+            setting.width = newValue
+            updatePreviewSize()
+            updatePreviewHotSpot()
+        }
+        .onChange(of: cursorHeight) { newValue in
+            setting.height = newValue
+            updatePreviewSize()
+            updatePreviewHotSpot()
+        }
+        .onChange(of: cursorHotSpotX) { newValue in
+            setting.hotSpotX = newValue
+            updatePreviewHotSpot()
+        }
+        .onChange(of: cursorHotSpotY) { newValue in
+            setting.hotSpotY = -newValue
+            updatePreviewHotSpot()
+        }
+        .alert("alert.cursor.clear", isPresented: $showClearCursorAlert) {
+            Button("button.Proceed", role: .destructive) {
+                clearCursorImage()
+            }
+            Button("button.Cancel", role: .cancel) { }
+        }
+    }
+
+    func updatePreviewSize() {
+        if cursorWidth > cursorHeight {
+            previewCursorWidth = previewMaxWidth
+            previewCursorHeight = cursorWidth > 0 ? previewMaxWidth * CGFloat(cursorHeight) / CGFloat(cursorWidth) : 0
+        } else {
+            previewCursorHeight = previewMaxHeight
+            previewCursorWidth = cursorHeight > 0 ? previewMaxHeight * CGFloat(cursorWidth) / CGFloat(cursorHeight) : 0
+        }
+    }
+
+    func updatePreviewHotSpot() {
+        previewHotSpotX = cursorWidth > 0 ? previewCursorWidth * CGFloat(cursorHotSpotX) / CGFloat(cursorWidth) : 0
+        previewHotSpotY = cursorHeight > 0 ? previewCursorHeight * CGFloat(-cursorHotSpotY) / CGFloat(cursorHeight) : 0
+    }
+
+    func selectCursorImage() {
+        NSOpenPanel.selectImage { result in
+            if case .success(let url) = result {
+                if let image = NSImage(contentsOfFile: url.path) {
+                    CursorImages.shared.save(srcImageUrl: url, for: bundleId)
+                    cursorImage = image
+                    cursorWidth = Int(image.representations[0].pixelsWide)
+                    cursorHeight = Int(image.representations[0].pixelsHigh)
+                    cursorHotSpotX = 0
+                    cursorHotSpotY = 0
+                }
+            }
+        }
+    }
+
+    func clearCursorImage() {
+        CursorImages.shared.clear(bundleId: bundleId)
+        cursorImage = nil
     }
 }
 

--- a/PlayCover/Views/Settings/UninstallSettings.swift
+++ b/PlayCover/Views/Settings/UninstallSettings.swift
@@ -15,6 +15,7 @@ class UninstallPreferences: NSObject, ObservableObject {
     @objc @AppStorage("RemoveAppSettingUninstall") var removeAppSettings = false
     @objc @AppStorage("RemoveAppEntitlementsUninstall") var removeAppEntitlements = false
     @objc @AppStorage("RemovePlayChainUninstall") var removePlayChain = false
+    @objc @AppStorage("RemoveCursorImageUninstall") var removeCursorImage = false
 
     @AppStorage("ShowUninstallPopup") var showUninstallPopup = true
 }
@@ -44,6 +45,8 @@ struct UninstallSettings: View {
                                isOn: $uninstallPreferences.removeAppEntitlements)
                         Toggle("preferences.toggle.removePlayChain",
                                isOn: $uninstallPreferences.removePlayChain)
+                        Toggle("preferences.toggle.removeCursorImage",
+                               isOn: $uninstallPreferences.removeCursorImage)
                     }
                     Spacer()
                 }

--- a/PlayCover/Views/Uninstaller.swift
+++ b/PlayCover/Views/Uninstaller.swift
@@ -19,7 +19,8 @@ class Uninstaller {
         PlayTools.playCoverContainer.appendingPathComponent("App Settings"),
         PlayTools.playCoverContainer.appendingPathComponent("Entitlements"),
         PlayTools.playCoverContainer.appendingPathComponent("Keymapping"),
-        PlayTools.playCoverContainer.appendingPathComponent("PlayChain")
+        PlayTools.playCoverContainer.appendingPathComponent("PlayChain"),
+        PlayTools.playCoverContainer.appendingPathComponent("Cursors")
     ]
     private static let cacheURLs: [URL] = [
         Uninstaller.libraryUrl.appendingPathComponent("Containers"),
@@ -49,6 +50,7 @@ class Uninstaller {
     static func uninstallPopup(_ app: PlayApp) async {
         if UninstallPreferences.shared.showUninstallPopup {
             let boxmakers: [(String, String)] = [
+                ("removeCursorImage", NSLocalizedString("preferences.toggle.removeCursorImage", comment: "")),
                 ("removePlayChain", NSLocalizedString("preferences.toggle.removePlayChain", comment: "")),
                 ("removeAppEntitlements", NSLocalizedString("preferences.toggle.removeEntitlements", comment: "")),
                 ("removeAppSettings", NSLocalizedString("preferences.toggle.removeSetting", comment: "")),
@@ -141,10 +143,15 @@ class Uninstaller {
             uninstallNum += 1
         }
 
+        if UninstallPreferences.shared.removeCursorImage {
+            CursorImages.shared.clear(bundleId: app.info.bundleIdentifier)
+            uninstallNum += 1
+        }
+
         app.removeAlias()
         app.deleteApp()
 
-        if uninstallNum >= 5 {
+        if uninstallNum >= 6 {
             do {
                 let apps = (try PlayApp.bundleIDCache).filter({ $0 != app.info.bundleIdentifier })
                     .joined(separator: "\n") + "\n"

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -48,6 +48,7 @@
 "preferences.toggle.removeSetting" = "Remove settings";
 "preferences.toggle.removeEntitlements" = "Remove entitlements";
 "preferences.toggle.removePlayChain" = "Remove PlayChain";
+"preferences.toggle.removeCursorImage" = "Remove Cursor Image";
 "preferences.button.pruneFiles" = "Prune Files";
 "preferences.prune.alert" = "Are you sure you want to prune all files?";
 "preferences.prune.message" = "This will remove all unused files including settings, keymappings, entitlements, and app data";

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -107,6 +107,7 @@
 "alert.differentBundleIdKeymap.text" = "Are you sure you want to import this keymap?";
 "alert.power.title" = "Low Power Mode Enabled!";
 "alert.power.subtitle" = "Some apps will not work with Low Power Mode enabled. It is recommended to disable it.";
+"alert.cursor.clear" = "Cusror image will be deleted. Do you wish to continue?";
 
 "button.OK" = "OK";
 "button.Proceed" = "Proceed";
@@ -150,6 +151,9 @@
 "settings.toggle.autoKM.help" = "Automatically disable keymapping when text input is sensed";
 "settings.toggle.enableScrollWheel" = "Enable Scroll Wheel";
 "settings.toggle.enableScrollWheel.help" = "Enable scroll wheel in keymapping";
+"settings.toggle.customCursor" = "Custom Cursor";
+"settings.text.cursorSize" = "Size";
+"settings.text.cursorHotSpot" = "Hot Spot";
 
 "settings.tab.graphics" = "Graphics";
 "settings.picker.iosDevice" = "iOS device:";

--- a/PlayCover/zh-Hans.lproj/Localizable.strings
+++ b/PlayCover/zh-Hans.lproj/Localizable.strings
@@ -375,6 +375,9 @@
 "settings.toggle.enableScrollWheel.help" = "在按键映射启用滚轮";
 "settings.toggle.iosFrameworks.help" = "将系统 ios 库添加到应用程序中。已知可修复某些应用程序找不到 ios 框架的问题";
 "settings.toggle.enableScrollWheel" = "启用滚轮";
+"settings.toggle.customCursor" = "自定义鼠标光标";
+"settings.text.cursorSize" = "光标尺寸";
+"settings.text.cursorHotSpot" = "光标热点";
 "ipaLibrary.info.notAvailable" = "此应用链接不可用";
 "ipaLibrary.info" = "应用信息";
 "ipaLibrary.info.checksum.none" = "未提供";
@@ -386,3 +389,4 @@
 "ipaLibrary.AlphabeticalSort" = "按字母顺序排列应用来源";
 "alert.install.anyway" = "仍然安装";
 "alert.open.appstore" = "打开 Mac App Store";
+"alert.cursor.clear" = "鼠标光标图片将被清除。您确定要继续吗？";

--- a/PlayCover/zh-Hans.lproj/Localizable.strings
+++ b/PlayCover/zh-Hans.lproj/Localizable.strings
@@ -262,6 +262,7 @@
 "preferences.toggle.removeKeymap" = "移除键盘映射";
 "preferences.toggle.removeSetting" = "清除设置";
 "preferences.toggle.removeEntitlements" = "移除授权";
+"preferences.toggle.removeCursorImage" = "清除鼠标光标图片";
 "preferences.prune.alert" = "您确定要删除所有未使用的文件吗？";
 "preferences.prune.message" = "这将删除所有未使用的文件，包括设置、按键映射、授权和应用程序数据";
 "preferences.tab.install" = "安装";


### PR DESCRIPTION
### Summary
Allow users to use an image as a custom mouse cursor.
also see: https://github.com/PlayCover/PlayTools/pull/184
<br/>

### Screenshot
<img width="942" alt="Screenshot" src="https://github.com/user-attachments/assets/113e472e-c16f-4944-b951-9f6c15ff7067" />
<img width="942" alt="Screenshot" src="https://github.com/user-attachments/assets/be2a7d3e-2995-42b8-a1ab-ae1fb0ff25f4" />
<br/>

### Cursor Samples
Genshin Impact: <img width="24" alt="toweroffantasy" src="https://github.com/user-attachments/assets/2d85e1fb-d1c5-4d25-b822-7f7eb22e423a" />

Tower of Fantasy: <img width="24" alt="toweroffantasy" src="https://github.com/user-attachments/assets/fa6848eb-dbd1-42da-8f3a-0a48a3197fba" />

Wuthering Waves: <img width="24" alt="wutheringwaves" src="https://github.com/user-attachments/assets/18e5a1be-6857-45cc-9d7b-5e9038078d19" />

Infinity Nikki: <img width="24" alt="infinitynikki" src="https://github.com/user-attachments/assets/c25bea3f-dd32-49c4-9cde-a8a217682d8b" />
<br/>

### Known Issue
- When using macOS’s built-in screen recording tools to capture a portion of the screen, the custom cursor may sometimes not appear. Please retry recording a few times, then  it should work.
<br/>