### PR TITLE
Fix: Prevent inheritance of debugging-related variables to installed apps

### DIFF
--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -82,6 +82,13 @@ class PlayApp: BaseApp {
 
     func runAppExec() {
         let config = NSWorkspace.OpenConfiguration()
+        
+        // This is to prevent Xcode from attaching debugging-related variables
+        // that inject macOS-specific libraries such as `libViewDebuggerSupport.dylib`,
+        // which then fail to load inside iOS apps (missing symbols like _OBJC_CLASS_$_AVPlayerView).
+        for (key, _) in ProcessInfo.processInfo.environment where key.hasPrefix("DYLD_") {
+            unsetenv(key)
+        }
 
         NSWorkspace.shared.openApplication(
             at: aliasURL,

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -82,10 +82,11 @@ class PlayApp: BaseApp {
 
     func runAppExec() {
         let config = NSWorkspace.OpenConfiguration()
+
+        // This is to prevent Xcode from attaching debugging-related variables 
+        // so that they are no longer inherited by the child process.
+        // which fail to load inside iOS apps (missing symbols like _OBJC_CLASS_$_AVPlayerView).
         
-        // This is to prevent Xcode from attaching debugging-related variables
-        // that inject macOS-specific libraries such as `libViewDebuggerSupport.dylib`,
-        // which then fail to load inside iOS apps (missing symbols like _OBJC_CLASS_$_AVPlayerView).
         for (key, _) in ProcessInfo.processInfo.environment where key.hasPrefix("DYLD_") {
             unsetenv(key)
         }

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -82,11 +82,9 @@ class PlayApp: BaseApp {
 
     func runAppExec() {
         let config = NSWorkspace.OpenConfiguration()
-
-        // This is to prevent Xcode from attaching debugging-related variables 
+        // This is to prevent Xcode from attaching debugging-related variables
         // so that they are no longer inherited by the child process.
         // which fail to load inside iOS apps (missing symbols like _OBJC_CLASS_$_AVPlayerView).
-        
         for (key, _) in ProcessInfo.processInfo.environment where key.hasPrefix("DYLD_") {
             unsetenv(key)
         }


### PR DESCRIPTION
This pull request introduces a change in the `PlayApp` class to improve compatibility when running iOS apps. The change ensures that macOS-specific debugging-related variables are removed from the environment to prevent issues with missing symbols.

Environment cleanup for compatibility:

* [`PlayCover/Model/PlayApp.swift`](diffhunk://#diff-8c70684d8da2457c4a34d4f5f9bf6124ac596cd5cdee1fc8a04a0ba2bef9d0f7R86-R92): Added code to unset environment variables prefixed with `DYLD_` to prevent macOS-specific libraries from being injected, which can cause failures in iOS apps due to missing symbols.