### PR TITLE
Feature: optional feature to hide titlebar

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,11 +12,6 @@ identifier_name:
 type_name:
   allowed_symbols: ['_']
 
-file_length:
-    ignore_comment_only_lines: true
-    warning: 1000
-    error: 1500
-  
 disabled_rules:
   # see https://github.com/realm/SwiftLint/issues/5263
   - non_optional_string_data_conversion

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,6 +12,11 @@ identifier_name:
 type_name:
   allowed_symbols: ['_']
 
+file_length:
+    ignore_comment_only_lines: true
+    warning: 1000
+    error: 1500
+  
 disabled_rules:
   # see https://github.com/realm/SwiftLint/issues/5263
   - non_optional_string_data_conversion

--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -41,6 +41,7 @@ struct AppSettingsData: Codable {
     var rootWorkDir = true
     var noKMOnInput = true
     var enableScrollWheel = true
+    var hideTitleBar = false
 
     init() {}
 
@@ -71,6 +72,7 @@ struct AppSettingsData: Codable {
         rootWorkDir = try container.decodeIfPresent(Bool.self, forKey: .rootWorkDir) ?? true
         noKMOnInput = try container.decodeIfPresent(Bool.self, forKey: .noKMOnInput) ?? true
         enableScrollWheel = try container.decodeIfPresent(Bool.self, forKey: .enableScrollWheel) ?? true
+        hideTitleBar = try container.decodeIfPresent(Bool.self, forKey: .hideTitleBar) ?? false
     }
 }
 

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -188,13 +188,12 @@ struct KeymappingView: View {
 
 struct GraphicsView: View {
     @Binding var settings: AppSettings
-
     @State var customWidth = 1920
     @State var customHeight = 1080
-
     @State var showResolutionWarning = false
     @AppStorage("settings.settings.inverseScreenValues") private var inverseScreenValues = false
     @AppStorage("settings.settings.disableTimeout") private var disableTimeout = false
+    @AppStorage("settings.toggle.hideTitleBar") private var hideTitleBar = false
     static var number: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .none
@@ -360,6 +359,8 @@ struct GraphicsView: View {
                     }
                     Toggle("settings.toggle.disableDisplaySleep", isOn: $settings.settings.disableTimeout)
                         .help("settings.toggle.disableDisplaySleep.help")
+                    Spacer()
+                    Toggle("settings.toggle.hideTitleBar", isOn: $settings.settings.hideTitleBar)
                     Spacer()
                 }
                 Spacer()

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -271,11 +271,8 @@ struct GraphicsView: View {
                                 })
                                 .frame(width: 125)
                         }
-                        onIncrement: {
-                            customWidth += 1
-                        } onDecrement: {
-                            customWidth -= 1
-                        }
+                        onIncrement: { customWidth += 1 }
+                        onDecrement: { customWidth -= 1 }
                         Spacer()
                         Text(NSLocalizedString("settings.text.customHeight", comment: "") + ":")
                         Stepper {
@@ -323,17 +320,13 @@ struct GraphicsView: View {
                             value: $customScaler,
                             formatter: GraphicsView.fractionFormatter,
                             onCommit: {
-                                Task { @MainActor in
-                                    NSApp.keyWindow?.makeFirstResponder(nil)
-                                }
+                                Task { @MainActor in NSApp.keyWindow?.makeFirstResponder(nil) }
                             })
                             .frame(width: 125)
                     } onIncrement: {
                         customScaler += 0.1
                     } onDecrement: {
-                        if customScaler > 0.5 {
-                            customScaler -= 0.1
-                        }
+                        if customScaler > 0.5 { customScaler -= 0.1 }
                     }
                 }
                 VStack(alignment: .leading) {

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -168,6 +168,7 @@
 "settings.picker.windowFixMethod.1" = "Alternate";
 "settings.toggle.disableDisplaySleep" = "Disable display sleep";
 "settings.toggle.disableDisplaySleep.help" = "Prevent display from turning off while this app is running";
+"settings.toggle.hideTitleBar" = "Hide titlebar";
 "settings.noPlayTools" = "PlayTools is not installed in this app";
 "settings.highResolution" = "High resolution may cause crashing";
 "settings.picker.scaler" = "Resolution Scaler";


### PR DESCRIPTION
This pull request introduces a new feature to hide the title bar in the application settings. The changes span multiple files to implement the feature, update the user interface, and add localization support.

### Feature Implementation:

* [`PlayCover/Model/AppSettings.swift`](diffhunk://#diff-3f57cf6f40ef6e282ae2799f270543767060ac9405adaaf8a2ecc1f89d79d269R44): Added a new property `hideTitleBar` to the `AppSettingsData` struct and updated the decoding logic to handle this property with a default value of `false`. [[1]](diffhunk://#diff-3f57cf6f40ef6e282ae2799f270543767060ac9405adaaf8a2ecc1f89d79d269R44) [[2]](diffhunk://#diff-3f57cf6f40ef6e282ae2799f270543767060ac9405adaaf8a2ecc1f89d79d269R75)

### User Interface Updates:

* `PlayCover/Views/AppSettingsView.swift`: 
  - Introduced a new `@AppStorage` binding for `hideTitleBar` in the `GraphicsView` struct.
  - Added a toggle UI element for `hideTitleBar` in the settings view, allowing users to enable or disable the feature.

### Localization:

* [`PlayCover/en.lproj/Localizable.strings`](diffhunk://#diff-c81219d3648ed083c147833f2b91fee16fa3e375249183f98a8eb8e2080970e4R171): Added a localized string for the new toggle option, "Hide titlebar".

related to: https://github.com/PlayCover/PlayTools/pull/191