### PR TITLE
Fix microphone permission in certain games

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -42,6 +42,7 @@ struct AppSettingsData: Codable {
     var noKMOnInput = true
     var enableScrollWheel = true
     var hideTitleBar = false
+    var checkMicPermissionSync = false
 
     init() {}
 
@@ -73,6 +74,7 @@ struct AppSettingsData: Codable {
         noKMOnInput = try container.decodeIfPresent(Bool.self, forKey: .noKMOnInput) ?? true
         enableScrollWheel = try container.decodeIfPresent(Bool.self, forKey: .enableScrollWheel) ?? true
         hideTitleBar = try container.decodeIfPresent(Bool.self, forKey: .hideTitleBar) ?? false
+        checkMicPermissionSync = try container.decodeIfPresent(Bool.self, forKey: .checkMicPermissionSync) ?? false
     }
 }
 

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -505,6 +505,12 @@ struct BypassesView: View {
                         .toggleStyle(.async($task, role: .iosFrameworks))
                     Spacer()
                 }
+                Spacer()
+                HStack {
+                    Toggle("settings.toggle.checkMicPermissionSync", isOn: $settings.settings.checkMicPermissionSync)
+                        .help("settings.toggle.checkMicPermissionSync.help")
+                    Spacer()
+                }
             }
             .padding()
         }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -192,6 +192,8 @@
 "settings.toggle.introspection.help" = "Add the system introspection libraries to the app. Known to fix issues with some apps not starting correctly";
 "settings.toggle.iosFrameworks" = "Force Insert iOS Frameworks";
 "settings.toggle.iosFrameworks.help" = "Add the system ios libraries to the app. Known to fix issues with some apps cannot find ios framework";
+"settings.toggle.checkMicPermissionSync" = "Check Microphone Permission Synchronously";
+"settings.toggle.checkMicPermissionSync.help" = "Force microphone permission check to be synchronous. Known to fix issues with some apps complaining about microphone permission not being granted";
 
 "settings.applicationCategoryType" = "Application Type";
 "settings.removePlayTools" = "Remove PlayTools";


### PR DESCRIPTION
Added a option `Check Microphone Permission Synchronously` to fix microphone permission in certain games.

<img width="537" height="358" alt="Screenshot" src="https://github.com/user-attachments/assets/c95b7c71-cea6-4127-b475-6d9844dcdaab" />

<br/>
<br/>

also see https://github.com/PlayCover/PlayTools/pull/193