### PR TITLE
Fix excessive CPU usage caused by motion sensor updates

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -43,6 +43,7 @@ struct AppSettingsData: Codable {
     var enableScrollWheel = true
     var hideTitleBar = false
     var checkMicPermissionSync = false
+    var limitMotionUpdateFrequency = false
 
     init() {}
 
@@ -75,6 +76,8 @@ struct AppSettingsData: Codable {
         enableScrollWheel = try container.decodeIfPresent(Bool.self, forKey: .enableScrollWheel) ?? true
         hideTitleBar = try container.decodeIfPresent(Bool.self, forKey: .hideTitleBar) ?? false
         checkMicPermissionSync = try container.decodeIfPresent(Bool.self, forKey: .checkMicPermissionSync) ?? false
+        limitMotionUpdateFrequency = try container.decodeIfPresent(Bool.self,
+                                                                   forKey: .limitMotionUpdateFrequency) ?? false
     }
 }
 

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -684,6 +684,15 @@ struct MiscView: View {
                         .help("settings.toggle.rootWorkDir.help")
                     Spacer()
                 }
+                Spacer()
+                    .frame(height: 20)
+                HStack {
+                    Toggle("settings.toggle.limitMotionUpdateFrequency",
+                           isOn: $settings.settings.limitMotionUpdateFrequency)
+                        .disabled(!(hasPlayTools ?? true))
+                        .help("settings.toggle.limitMotionUpdateFrequency.help")
+                    Spacer()
+                }
             }
             .padding()
         }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -254,6 +254,8 @@
 "settings.toggle.lldbWithTerminal" = "Open in terminal";
 "settings.toggle.rootWorkDir" = "Start app at root directory";
 "settings.toggle.rootWorkDir.help" = "Change the working directory of the app to / just like on iOS. Turn this off if the app misbehave";
+"settings.toggle.limitMotionUpdateFrequency" = "Limit motion sensor update frequency";
+"settings.toggle.limitMotionUpdateFrequency.help" = "Limit the frequency of motion sensor updates to avoid excessive CPU usage (often occurs in Unity games).";
 
 "configSigning.header" = "Configure Package Signing";
 "configSigning.subtext" = "Package Signing helps fixing issues with apps that rely on \ncorrect Team IDs for operations like authorization. \nThere may be security risks associated with enabling this feature.\n\n As such, we recommend disabling it when it's not necessary";


### PR DESCRIPTION
Added an option to limit the frequency of motion sensor updates.

<img width="536" height="402" alt="Screenshot" src="https://github.com/user-attachments/assets/07c1c5d6-c682-4254-8bee-b7aa06a29882" />

<br/>
<br/>

also see: https://github.com/PlayCover/PlayTools/pull/195