### PR TITLE
Fix: Unable to install unsigned IPA

### DIFF
--- a/PlayCover/Utils/PlayTools.swift
+++ b/PlayCover/Utils/PlayTools.swift
@@ -230,6 +230,9 @@ class PlayTools {
             if error.localizedDescription.contains("Document is empty") {
                 // Empty entitlements
                 return ""
+            } else if error.localizedDescription.contains("code object is not signed at all") {
+                // IPA not signed
+                return ""
             } else {
                 throw error
             }


### PR DESCRIPTION
Related issue: https://github.com/PlayCover/PlayCover/issues/1605

Note: Unsigned IPA will works fine, but some IPA files (In my case it had been signed by a revoked enterprise certificate) framework binary may return `internal error in Code Signing subsystem` when executing `/usr/bin/codesign -fs- framework_binary` in `PlayCover/Utils/Shell.swift`. If we ignore error above, app will crash with runtime error `code signature invalid in <XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX>`. I haven't found a solution for this case yet.