### PR TITLE
Fix mouse click conflicts by disabling built-in mouse support

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -44,6 +44,7 @@ struct AppSettingsData: Codable {
     var hideTitleBar = false
     var checkMicPermissionSync = false
     var limitMotionUpdateFrequency = false
+    var disableBuiltinMouse = false
 
     init() {}
 
@@ -78,6 +79,7 @@ struct AppSettingsData: Codable {
         checkMicPermissionSync = try container.decodeIfPresent(Bool.self, forKey: .checkMicPermissionSync) ?? false
         limitMotionUpdateFrequency = try container.decodeIfPresent(Bool.self,
                                                                    forKey: .limitMotionUpdateFrequency) ?? false
+        disableBuiltinMouse = try container.decodeIfPresent(Bool.self, forKey: .disableBuiltinMouse) ?? false
     }
 }
 

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -166,6 +166,11 @@ struct KeymappingView: View {
                     Spacer()
                 }
                 HStack {
+                    Toggle("settings.toggle.disableBuiltinMouse", isOn: $settings.settings.disableBuiltinMouse)
+                        .help("settings.toggle.disableBuiltinMouse.help")
+                    Spacer()
+                }
+                HStack {
                     Text(String(
                         format: NSLocalizedString("settings.slider.mouseSensitivity", comment: ""),
                         settings.settings.sensitivity))

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -159,6 +159,8 @@
 "settings.toggle.autoKM.help" = "Automatically disable keymapping when text input is sensed";
 "settings.toggle.enableScrollWheel" = "Enable Scroll Wheel";
 "settings.toggle.enableScrollWheel.help" = "Enable scroll wheel in keymapping";
+"settings.toggle.disableBuiltinMouse" = "Disable Built-in Mouse Support";
+"settings.toggle.disableBuiltinMouse.help" = "Disable the app’s built-in mouse support to avoid click conflicts.";
 
 "settings.tab.graphics" = "Graphics";
 "settings.picker.iosDevice" = "iOS device:";


### PR DESCRIPTION
Added an option to disable built-in mouse support.

<img width="532" height="351" alt="Screenshot" src="https://github.com/user-attachments/assets/63a64264-cadf-4961-aecd-0dfe87eabc60" />

<br/>
<br/>

Related Issues: https://github.com/PlayCover/PlayCover/issues/1587 https://github.com/PlayCover/PlayCover/issues/1755
Also see: https://github.com/PlayCover/PlayTools/pull/201