### PR TITLE
Prevent sandboxed fork from triggering crash reports

### DIFF
--- a/PlayCover/Rules/default.yaml
+++ b/PlayCover/Rules/default.yaml
@@ -74,7 +74,6 @@ allow:
     
 
 bypass:
-    - (deny process-fork)
     - (deny file* file-read* file-read-metadata file-ioctl)
     - (allow file* file-read* file-read-metadata file-ioctl (literal "/usr/lib/libobjc-trampolines.dylib"))
     - (allow file-read-metadata (subpath "/private/var/db/timezone/"))

--- a/PlayCover/Utils/Entitlements.swift
+++ b/PlayCover/Utils/Entitlements.swift
@@ -89,6 +89,7 @@ class Entitlements {
          }
 
         sandboxProfile.append(contentsOf: PlayRules.buildRules(rules: rules.allow ?? [], bundleID: bundleID))
+        sandboxProfile.append("(deny process-fork)")
 
         if app.settings.settings.bypass {
             for file in PlayRules.buildRules(rules: rules.blocklist ?? [], bundleID: bundleID) {


### PR DESCRIPTION
## Summary
- Stop sandboxed PlayCover apps from invoking fork(), which causes SIGABRT on Apple Silicon.
- Remove the redundant bypass rule now enforced directly in entitlements.

## Problem
- PlayCover runs apps inside a multi-threaded sandbox where fork() is unsafe.
- macOS correctly aborts these fork attempts, generating SIGABRT crash reports even though the app keeps running.
- Users see crash dialogs on launch and during application usage without a real failure.

## Solution
- Append `(deny process-fork)` in `composeEntitlements`, making every generated sandbox profile forbid fork() at the OS level.
- Delete the duplicate `(deny process-fork)` entry from `default.yaml` to keep configuration single-sourced.

## Testing
- Built and launched affected titles on an Apple Silicon MacBook Air (M1) and confirmed no SIGABRT crash reports are produced.
- Verified normal gameplay continues to work with the tightened sandbox.

Fixes #1981