### PR TITLE
chore: update MacOS and PlayCover versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/APP-SUPPORT.yml
+++ b/.github/ISSUE_TEMPLATE/APP-SUPPORT.yml
@@ -39,8 +39,8 @@ body:
     attributes:
       label: What version of PlayCover are you using?
       options:
+        - "4.0.0"
         - "3.1.0"
-        - "2.0.5"
         - "Nightly/beta (please specify build number)"
         - "Other (please specify)"
     validations:
@@ -50,9 +50,9 @@ body:
     attributes:
       label: What version of macOS are you using?
       options:
+        - "Tahoe (macOS 26)"
+        - "Sequoia (macOS 15)"
         - "Sonoma (macOS 14)"
-        - "Ventura (macOS 13)"
-        - "Monterey (macOS 12)"
         - "macOS beta (please state the specific version)"
         - "Other (please specify)"
     validations:

--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -35,8 +35,8 @@ body:
     attributes:
       label: What version of PlayCover are you using?
       options:
+        - "4.0.0"
         - "3.1.0"
-        - "2.0.5"
         - "Nightly/beta (please specify build number)"
         - "Other (please specify)"
     validations:
@@ -46,9 +46,9 @@ body:
     attributes:
       label: What version of macOS are you using?
       options:
+        - "Tahoe (macOS 26)"
+        - "Sequoia (macOS 15)"
         - "Sonoma (macOS 14)"
-        - "Ventura (macOS 13)"
-        - "Monterey (macOS 12)"
         - "macOS beta (please state the specific version)"
         - "Other (please specify)"
     validations:

--- a/.github/ISSUE_TEMPLATE/GAME-SUPPORT.yml
+++ b/.github/ISSUE_TEMPLATE/GAME-SUPPORT.yml
@@ -39,8 +39,8 @@ body:
     attributes:
       label: What version of PlayCover are you using?
       options:
+        - "4.0.0"
         - "3.1.0"
-        - "2.0.5"
         - "Nightly/beta (please specify build number)"
         - "Other (please specify)"
     validations:
@@ -50,9 +50,9 @@ body:
     attributes:
       label: What version of macOS are you using?
       options:
+        - "Tahoe (macOS 26)"
+        - "Sequoia (macOS 15)"
         - "Sonoma (macOS 14)"
-        - "Ventura (macOS 13)"
-        - "Monterey (macOS 12)"
         - "macOS beta (please state the specific version)"
         - "Other (please specify)"
     validations:


### PR DESCRIPTION
Add MacOS Tahoe (26) and Sequoia (15) and remove MacOS Monterey (12) and Ventura (13) from Github issue templates. Also add PlayCover 4.0.0 and remove PlayCover 2.0.5.