### PR TITLE
Fix Github build actions

### DIFF
--- a/.github/workflows/1.build_release.yml
+++ b/.github/workflows/1.build_release.yml
@@ -15,17 +15,7 @@ jobs:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'latest'
+        uses: actions/checkout@v5
 
       - name: Get the version
         id: tag_version
@@ -72,7 +62,7 @@ jobs:
         run: rm apikey.json
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4.3.0
+        uses: actions/upload-artifact@v4
         with:
           name: PlayCover_${{ env.TAG_NAME }}.dmg
           path: output/PlayCover_${{ env.TAG_NAME }}.dmg

--- a/.github/workflows/2.nightly_release.yml
+++ b/.github/workflows/2.nightly_release.yml
@@ -12,17 +12,7 @@ jobs:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'latest'
+        uses: actions/checkout@v5
 
       - name: Install dependencies
         shell: bash
@@ -69,7 +59,7 @@ jobs:
         run: rm apikey.json
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4.3.0
+        uses: actions/upload-artifact@v4
         with:
           name: PlayCover_nightly_${{ github.run_number }}.dmg
           path: output/PlayCover_nightly_${{ github.run_number }}.dmg


### PR DESCRIPTION
- Update `checkout` and `upload-artifact` versions by removing specifying the minor versions.
- Remove unnecessary language setups (see [macOS 15 arm64 image](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md))