### PR TITLE
fix: swiftLint warning Fix

### DIFF
--- a/PlayCover/Utils/Extensions/FileExtensions.swift
+++ b/PlayCover/Utils/Extensions/FileExtensions.swift
@@ -19,10 +19,9 @@ extension FileManager {
 }
 
 extension NSOpenPanel {
-    static func selectIPA(completion: @escaping (_ result: Result<URL, Error>) -> Void) {
+    static func selectIPA(completion: @escaping (_ result: Result<URL, Error>) -> Void) async {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
-        panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowedContentTypes = [UTType(importedAs: "com.apple.itunes.ipa")]
         panel.canChooseFiles = true

--- a/PlayCover/Views/MenuBarView.swift
+++ b/PlayCover/Views/MenuBarView.swift
@@ -73,7 +73,6 @@ struct PlayCoverViewMenuView: Commands {
                     } else if DownloadVM.shared.inProgress {
                         Log.shared.error(PlayCoverError.waitDownload)
                     } else {
-                        // remove await for Swift 6 (no async operation occurs)
                         await NSOpenPanel.selectIPA { result in
                             if case .success(let url) = result {
                                 Task {

--- a/PlayCover/Views/Sidebar Views/AppLibraryView.swift
+++ b/PlayCover/Views/Sidebar Views/AppLibraryView.swift
@@ -181,9 +181,11 @@ struct AppLibraryView: View {
     }
 
     private func selectFile() {
-        NSOpenPanel.selectIPA { result in
-            if case .success(let url) = result {
-                installApp(url)
+        Task {
+            await NSOpenPanel.selectIPA { result in
+                if case .success(let url) = result {
+                    installApp(url)
+                }
             }
         }
     }


### PR DESCRIPTION
- Fix SwiftLint warning on `await NSOpenPanel.selectIPA` , need test to be sure this not brake retro compatibility
- Remove double `panel.canChooseFiles = true`