### PR TITLE
feat: Migrated ToastView visual style to the new design system

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		AA719649287A0E2500623C15 /* default.yaml in Resources */ = {isa = PBXBuildFile; fileRef = AA719647287A0E2500623C15 /* default.yaml */; };
 		AA71964B287A0EA800623C15 /* PlayRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA71964A287A0EA800623C15 /* PlayRules.swift */; };
 		AA818CB5287ABEC3000BEE9D /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = AA818CB4287ABEC3000BEE9D /* Yams */; };
+		AAE2F78F2F725632001336C9 /* ViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE2F78E2F72562E001336C9 /* ViewExtensions.swift */; };
 		AB00EB5229A7BF17006F3225 /* KeyCover.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00EB5129A7BF17006F3225 /* KeyCover.swift */; };
 		AB6F21EB299B7FA20078ADEC /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6F21EA299B7FA20078ADEC /* URLHandler.swift */; };
 		ABBC85B92B7C5CBA00DCF223 /* ModifierKeyObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABBC85B82B7C5CBA00DCF223 /* ModifierKeyObserver.swift */; };
@@ -175,6 +176,7 @@
 		AA719647287A0E2500623C15 /* default.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = default.yaml; sourceTree = "<group>"; };
 		AA71964A287A0EA800623C15 /* PlayRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayRules.swift; sourceTree = "<group>"; };
 		AA970FD228793A310099A5D0 /* PlayCoverRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PlayCoverRelease.entitlements; sourceTree = "<group>"; };
+		AAE2F78E2F72562E001336C9 /* ViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtensions.swift; sourceTree = "<group>"; };
 		AB00EB5129A7BF17006F3225 /* KeyCover.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyCover.swift; sourceTree = "<group>"; };
 		AB6F21EA299B7FA20078ADEC /* URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHandler.swift; sourceTree = "<group>"; };
 		ABBC85B82B7C5CBA00DCF223 /* ModifierKeyObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifierKeyObserver.swift; sourceTree = "<group>"; };
@@ -354,6 +356,7 @@
 		6E25096D297F4E95004D754C /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				AAE2F78E2F72562E001336C9 /* ViewExtensions.swift */,
 				8783D00A26B8C9E600171041 /* URLExtensions.swift */,
 				6ECB1D0D29798DFA00CD92AA /* DataExtensions.swift */,
 				6E25096E297F5032004D754C /* FileExtensions.swift */,
@@ -674,6 +677,7 @@
 				B67BC7122C39354C00315011 /* UpdateScheme.swift in Sources */,
 				ABBC85B92B7C5CBA00DCF223 /* ModifierKeyObserver.swift in Sources */,
 				92F8500A27675124005CE6BE /* AppIntegrity.swift in Sources */,
+				AAE2F78F2F725632001336C9 /* ViewExtensions.swift in Sources */,
 				342787552E787EBB003A3C2F /* Keymapping.swift in Sources */,
 				B44B40372C1E315600CE2A3E /* GoogleDrive.swift in Sources */,
 				68E48B97295704A600C39879 /* Downloader.swift in Sources */,

--- a/PlayCover/Utils/Extensions/ViewExtensions.swift
+++ b/PlayCover/Utils/Extensions/ViewExtensions.swift
@@ -1,5 +1,5 @@
 //
-//  URLExtensions.swift
+//  ViewExtensions.swift
 //  PlayCover
 //
 

--- a/PlayCover/Utils/Extensions/ViewExtensions.swift
+++ b/PlayCover/Utils/Extensions/ViewExtensions.swift
@@ -16,11 +16,20 @@ extension View {
     }
 
     func toastBackground() -> some View {
+        let view = self
+            .padding()
+            .frame(maxWidth: .infinity)
+
+        // provide default padding for older systems, but for those with liquid glass available, add proper padding to
+        // left, right, and bottom to ensure that the distance from the edges of the app are consistent and equal
         #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
-            return self.glassEffect(.regular, in: .containerRelative)
+            return view.glassEffect(.regular, in: .containerRelative)
+                .padding(ToastView.toastGlassPadding)
+                .padding(.top)
         }
         #endif
-        return self.background(.regularMaterial, in: .containerRelative)
+        return view.background(.regularMaterial, in: .containerRelative)
+            .padding()
     }
 }

--- a/PlayCover/Utils/Extensions/ViewExtensions.swift
+++ b/PlayCover/Utils/Extensions/ViewExtensions.swift
@@ -1,0 +1,34 @@
+//
+//  URLExtensions.swift
+//  PlayCover
+//
+
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func toastOverlay<Content: View>(
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        if #available(macOS 26.0, *) {
+            self.safeAreaBar(edge: .bottom) {
+                content()
+            }
+        } else {
+            self.overlay {
+                content()
+            }
+        }
+    }
+
+    @ViewBuilder
+    func toastBackground() -> some View {
+        if #available(macOS 26.0, *) {
+            self.glassEffect(.regular, in:
+                                ContainerRelativeShape())
+        } else {
+            self.background(.regularMaterial, in:
+                                ContainerRelativeShape())
+        }
+    }
+}

--- a/PlayCover/Utils/Extensions/ViewExtensions.swift
+++ b/PlayCover/Utils/Extensions/ViewExtensions.swift
@@ -6,29 +6,21 @@
 import SwiftUI
 
 extension View {
-    @ViewBuilder
-    func toastOverlay<Content: View>(
-        @ViewBuilder content: () -> Content
-    ) -> some View {
+    func toastOverlay<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
-            self.safeAreaBar(edge: .bottom) {
-                content()
-            }
-        } else {
-            self.overlay {
-                content()
-            }
+            return self.safeAreaBar(edge: .bottom, content: content)
         }
+        #endif
+        return self.overlay(content: content)
     }
 
-    @ViewBuilder
     func toastBackground() -> some View {
+        #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
-            self.glassEffect(.regular, in:
-                                ContainerRelativeShape())
-        } else {
-            self.background(.regularMaterial, in:
-                                ContainerRelativeShape())
+            return self.glassEffect(.regular, in: .containerRelative)
         }
+        #endif
+        return self.background(.regularMaterial, in: .containerRelative)
     }
 }

--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -133,8 +133,14 @@ struct MainView: View {
             .toastOverlay {
                 HStack {
                     if !collapsed {
+                        var spacerWidth: CGFloat {
+                            if #available(macOS 26.0, *) {
+                                return navWidth + 8
+                            }
+                            return navWidth
+                        }
                         Spacer()
-                            .frame(width: navWidth + 8)
+                            .frame(width: spacerWidth)
                     }
                     ToastView()
                         .environmentObject(ToastVM.shared)

--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -134,9 +134,11 @@ struct MainView: View {
                 HStack {
                     if !collapsed {
                         var spacerWidth: CGFloat {
+                            #if compiler(>=6.2)
                             if #available(macOS 26.0, *) {
                                 return navWidth + 8
                             }
+                            #endif
                             return navWidth
                         }
                         Spacer()

--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -130,11 +130,11 @@ struct MainView: View {
             .onAppear {
                 self.selectedView = URLObserved.type == .source ? 2 : 1
             }
-            .overlay {
+            .toastOverlay {
                 HStack {
                     if !collapsed {
                         Spacer()
-                            .frame(width: navWidth)
+                            .frame(width: navWidth + 8)
                     }
                     ToastView()
                         .environmentObject(ToastVM.shared)
@@ -172,6 +172,23 @@ struct MainView: View {
 
     private func toggleSidebar() {
         NSApp.keyWindow?.firstResponder?.tryToPerform(#selector(NSSplitViewController.toggleSidebar(_:)), with: nil)
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func toastOverlay<Content: View>(
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        if #available(macOS 26.0, *) {
+            self.safeAreaBar(edge: .bottom) {
+                content()
+            }
+        } else {
+            self.overlay {
+                content()
+            }
+        }
     }
 }
 

--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -181,23 +181,6 @@ struct MainView: View {
     }
 }
 
-extension View {
-    @ViewBuilder
-    func toastOverlay<Content: View>(
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        if #available(macOS 26.0, *) {
-            self.safeAreaBar(edge: .bottom) {
-                content()
-            }
-        } else {
-            self.overlay {
-                content()
-            }
-        }
-    }
-}
-
 struct SplitViewAccessor: NSViewRepresentable {
     @Binding var sideCollapsed: Bool
 

--- a/PlayCover/Views/MainView.swift
+++ b/PlayCover/Views/MainView.swift
@@ -132,15 +132,17 @@ struct MainView: View {
             }
             .toastOverlay {
                 HStack {
-                    if !collapsed {
-                        var spacerWidth: CGFloat {
-                            #if compiler(>=6.2)
-                            if #available(macOS 26.0, *) {
-                                return navWidth + 8
-                            }
-                            #endif
-                            return navWidth
+                    var spacerWidth: CGFloat {
+                        // space width changes depending on if it is liquid glass and its accompanying custom padding
+                        #if compiler(>=6.2)
+                        if #available(macOS 26.0, *) {
+                            return navWidth + ToastView.toastGlassPadding
                         }
+                        #endif
+                        return navWidth
+                    }
+
+                    if !collapsed {
                         Spacer()
                             .frame(width: spacerWidth)
                     }
@@ -148,7 +150,8 @@ struct MainView: View {
                         .environmentObject(ToastVM.shared)
                         .environmentObject(InstallVM.shared)
                         .environmentObject(DownloadVM.shared)
-                        .frame(width: collapsed || viewWidth < navWidth ? viewWidth : (viewWidth - navWidth))
+                        // add a max statement here to ensure that the width will never be negative
+                        .frame(width: max(0, collapsed || viewWidth < navWidth ? viewWidth : (viewWidth - spacerWidth)))
                         .animation(.spring(), value: collapsed)
                 }
             }

--- a/PlayCover/Views/ToastView.swift
+++ b/PlayCover/Views/ToastView.swift
@@ -15,7 +15,9 @@ struct ToastView: View {
     var body: some View {
         if toastVM.isShown {
             VStack(spacing: -20) {
-                Spacer()
+                if #unavailable(macOS 26.0) {
+                    Spacer()
+                }
                 ForEach(toastVM.toasts, id: \.self) { toast in
                     HStack {
                         switch toast.toastType {
@@ -30,8 +32,8 @@ struct ToastView: View {
                     }
                     .padding()
                     .frame(maxWidth: .infinity)
-                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
-                    .padding()
+                    .toastBackground()
+                    .padding(8)
                     .onAppear {
                         Task { @MainActor in
                             try await Task.sleep(nanoseconds: toast.timeRemaining * 1000000000)
@@ -47,8 +49,8 @@ struct ToastView: View {
                     }
                     .padding()
                     .frame(maxWidth: .infinity)
-                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
-                    .padding()
+                    .toastBackground()
+                    .padding(8)
                 }
                 if downloadVM.inProgress {
                     VStack {
@@ -69,14 +71,26 @@ struct ToastView: View {
                     }
                     .padding()
                     .frame(maxWidth: .infinity)
-                    .background(.regularMaterial, in:
-                                    RoundedRectangle(cornerRadius: 10))
-                    .padding()
+                    .toastBackground()
+                    .padding(8)
                 }
             }
             .animation(.easeInOut(duration: 0.25), value: toastVM.toasts.count)
             .animation(.easeInOut(duration: 0.25), value: installVM.inProgress)
             .animation(.easeInOut(duration: 0.25), value: downloadVM.inProgress)
+        }
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func toastBackground() -> some View {
+        if #available(macOS 26.0, *) {
+            self.glassEffect(.regular, in:
+                                ContainerRelativeShape())
+        } else {
+            self.background(.regularMaterial, in:
+                                ContainerRelativeShape())
         }
     }
 }

--- a/PlayCover/Views/ToastView.swift
+++ b/PlayCover/Views/ToastView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ToastView: View {
+    public static let toastGlassPadding: CGFloat = 8
+
     @EnvironmentObject var toastVM: ToastVM
     @EnvironmentObject var installVM: InstallVM
     @EnvironmentObject var downloadVM: DownloadVM
@@ -15,6 +17,8 @@ struct ToastView: View {
     var body: some View {
         if toastVM.isShown {
             VStack(spacing: -20) {
+                // remove spacing for liquid glass toast to prevent the background blur that accompanies the toast when
+                // scrolling down in either of the library views
                 #if compiler(>=6.2)
                 if #unavailable(macOS 26.0) {
                     Spacer()
@@ -34,10 +38,7 @@ struct ToastView: View {
                         }
                         Text(toast.toastDetails)
                     }
-                    .padding()
-                    .frame(maxWidth: .infinity)
                     .toastBackground()
-                    .padding(8)
                     .onAppear {
                         Task { @MainActor in
                             try await Task.sleep(nanoseconds: toast.timeRemaining * 1000000000)
@@ -51,10 +52,7 @@ struct ToastView: View {
                         Text(NSLocalizedString(installVM.status.rawValue, comment: ""))
                         ProgressView(value: installVM.progress)
                     }
-                    .padding()
-                    .frame(maxWidth: .infinity)
                     .toastBackground()
-                    .padding(8)
                 }
                 if downloadVM.inProgress {
                     VStack {
@@ -73,10 +71,7 @@ struct ToastView: View {
                             }
                         }
                     }
-                    .padding()
-                    .frame(maxWidth: .infinity)
                     .toastBackground()
-                    .padding(8)
                 }
             }
             .animation(.easeInOut(duration: 0.25), value: toastVM.toasts.count)

--- a/PlayCover/Views/ToastView.swift
+++ b/PlayCover/Views/ToastView.swift
@@ -82,19 +82,6 @@ struct ToastView: View {
     }
 }
 
-extension View {
-    @ViewBuilder
-    func toastBackground() -> some View {
-        if #available(macOS 26.0, *) {
-            self.glassEffect(.regular, in:
-                                ContainerRelativeShape())
-        } else {
-            self.background(.regularMaterial, in:
-                                ContainerRelativeShape())
-        }
-    }
-}
-
 struct ToastView_Preview: PreviewProvider {
     static var previews: some View {
         ToastView()

--- a/PlayCover/Views/ToastView.swift
+++ b/PlayCover/Views/ToastView.swift
@@ -15,9 +15,13 @@ struct ToastView: View {
     var body: some View {
         if toastVM.isShown {
             VStack(spacing: -20) {
+                #if compiler(>=6.2)
                 if #unavailable(macOS 26.0) {
                     Spacer()
                 }
+                #else
+                Spacer()
+                #endif
                 ForEach(toastVM.toasts, id: \.self) { toast in
                     HStack {
                         switch toast.toastType {


### PR DESCRIPTION
Pleased to notice that this project has begun building against the macOS 26 SDK, allowing most visual styles to automatically benefit from the new design system. This Pull Request provides supplementary updates specifically for the custom `ToastView`.

1. **Adoption of Liquid Glass:** For macOS 26 and later, `ToastView` now utilizes [`Glass`](https://developer.apple.com/documentation/swiftui/glass) to better align with macOS's [Liquid Glass](https://developer.apple.com/documentation/swiftui/applying-liquid-glass-to-custom-views) design system. On earlier versions, the original [`Material`](https://developer.apple.com/documentation/SwiftUI/Material) style is preserved.

<img width="100%" alt="compare" src="https://github.com/user-attachments/assets/ef825102-73b1-4c57-9b44-cc00ee4e2931" />

2. **Safe Area Bar:** For macOS 26 and later, the `overlay` modifier used for displaying the `ToastView` in `MainView` has been replaced with the new [`safeAreaBar`](https://developer.apple.com/documentation/swiftui/view/safeareabar(edge:alignment:spacing:content:)), which provides an elegant progressive blur effect at the edges of the scroll view.

<img width="100%" alt="SafeAreaBar" src="https://github.com/user-attachments/assets/ac9a0177-4a86-4ac7-ba63-9a1bfc49dc49" />

3. **ContainerRelativeShape:** The shape of the Toast is now using [`ContainerRelativeShape`](https://developer.apple.com/documentation/SwiftUI/ContainerRelativeShape) instead of hardcoded, fixed corner radius values. This ensures [concentricity](https://developer.apple.com/videos/play/wwdc2025/356?time=183) between the view and the window corners. Given that this API has been available since macOS 11, this improvement benefits PlayCover across all supported OS versions.

<img width="100%" alt="concentric" src="https://github.com/user-attachments/assets/62bb0da6-eec7-4b30-865f-a163871491d4" />
