### PR TITLE
fix: app Settings UI

### DIFF
--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -142,6 +142,7 @@ struct AppSettingsView: View {
             hasAlias = viewModel.app.hasAlias()
         }
         .padding()
+        .frame(width: 500, height: 500)
     }
 }
 
@@ -711,10 +712,19 @@ struct MiscView: View {
                         Spacer()
                         HStack {
                             Text("settings.text.debugger")
-                            VStack {
-                                Toggle("settings.toggle.lldb", isOn: $settings.openWithLLDB)
-                                Toggle("settings.toggle.lldbWithTerminal", isOn: $settings.openLLDBWithTerminal)
-                                    .disabled(!settings.openWithLLDB)
+                            VStack(alignment: .leading) {
+                                HStack {
+                                    Toggle("", isOn: $settings.openWithLLDB)
+                                        .labelsHidden()
+                                    Text("settings.toggle.lldb")
+                                }
+
+                                HStack {
+                                    Toggle("", isOn: $settings.openLLDBWithTerminal)
+                                        .labelsHidden()
+                                        .disabled(!settings.openWithLLDB)
+                                    Text("settings.toggle.lldbWithTerminal")
+                                }
                             }
                         }
                     }

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -142,7 +142,7 @@ struct AppSettingsView: View {
             hasAlias = viewModel.app.hasAlias()
         }
         .padding()
-        .frame(width: 600, height: 500)
+        .frame(width: 600, height: 400)
     }
 }
 

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -142,7 +142,7 @@ struct AppSettingsView: View {
             hasAlias = viewModel.app.hasAlias()
         }
         .padding()
-        .frame(width: 500, height: 500)
+        .frame(width: 600, height: 500)
     }
 }
 

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -839,7 +839,7 @@ struct InfoView: View {
             HStack {
                 Text("settings.info.playTools")
                 Spacer()
-                Text(String(hasPlayTools))
+                Text(hasPlayTools ? "button.Yes" : "button.No")
             }
             HStack {
                 Text("settings.info.url")


### PR DESCRIPTION
- When you open an app settings, when you switch tab the windows resize and you lost the focus. This fix the issue with a static dimension
- Fix alignment issue on toggle
- Fix text on info not localized