### PR TITLE
fix: read Mach-O load command string until null terminator

### DIFF
--- a/PlayCover/Utils/Extensions/DataExtensions.swift
+++ b/PlayCover/Utils/Extensions/DataExtensions.swift
@@ -11,8 +11,9 @@ extension String {
         let loadCommandStringOffset = Int(loadCommandString.offset)
         let stringOffset = offset + loadCommandStringOffset
         let length = commandSize - loadCommandStringOffset
-        self = String(data: data[stringOffset..<(stringOffset + length)],
-                      encoding: .utf8)!.trimmingCharacters(in: .controlCharacters)
+        let rawData = data[stringOffset..<(stringOffset + length)]
+        let endIndex = rawData.firstIndex(of: 0x00) ?? rawData.endIndex
+        self = String(data: data[stringOffset..<endIndex], encoding: .utf8)!
     }
 }
 


### PR DESCRIPTION
Fixes #2106

## Summary

Fix `String.init(data:offset:commandSize:loadCommandString:)` in `DataExtensions.swift` to stop reading at the first null byte (`0x00`) instead of consuming the entire load command region.

## Problem

When PlayCover parses Mach-O binaries during IPA installation (dylib injection / code signature removal), load command strings are read up to `commandSize`. The padding bytes after the null terminator can contain arbitrary non-UTF-8 data (e.g. `0xC5 0x0F`), causing `String(data:encoding:.utf8)` to return `nil` and crash via force-unwrap. This has been observed to cause installation failures for certain apps.

The same bug also exists in the upstream `inject` dependency — a corresponding fix has been submitted: [paradiseduo/inject#9](https://github.com/paradiseduo/inject/pull/9).

> **Note:** This PR depends on paradiseduo/inject#9 being merged first, so that PlayCover can update its `inject` dependency to include the fix on both sides.

## Fix

Read up to `commandSize` bytes, but stop at the first `0x00` null terminator before attempting UTF-8 decoding.

```diff
-        self = String(data: data[stringOffset..<(stringOffset + length)],
-                      encoding: .utf8)!.trimmingCharacters(in: .controlCharacters)
+        let rawData = data[stringOffset..<(stringOffset + length)]
+        let endIndex = rawData.firstIndex(of: 0x00) ?? rawData.endIndex
+        self = String(data: data[stringOffset..<endIndex], encoding: .utf8)!
```