### PR TITLE
feat(settings): support mouse scroll wheel mapping with mutual exclusion

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -50,6 +50,18 @@ struct AppSettingsData: Codable {
     var resizableAspectRatioWidth = 0
     var resizableAspectRatioHeight = 0
     var blockSleepSpamming = false
+    var enableScrollWheelZoom = true // Original zoom logic
+    var enableScrollWheelMapping = false // New keymapping logic
+
+    enum CodingKeys: String, CodingKey {
+        case bundleIdentifier, keymapping, sensitivity, disableTimeout, iosDeviceModel
+        case windowWidth, windowHeight, customScaler, resolution, aspectRatio, notch, bypass
+        case discordActivity, version, playChain, playChainDebugging, inverseScreenValues, metalHUD
+        case windowFixMethod, injectIntrospection, rootWorkDir, noKMOnInput, hideTitleBar
+        case floatingWindow, checkMicPermissionSync, limitMotionUpdateFrequency, disableBuiltinMouse
+        case resizableAspectRatioType, resizableAspectRatioWidth, resizableAspectRatioHeight, blockSleepSpamming
+        case enableScrollWheelZoom, enableScrollWheelMapping
+    }
 
     init() {}
 
@@ -79,7 +91,6 @@ struct AppSettingsData: Codable {
         injectIntrospection = try container.decodeIfPresent(Bool.self, forKey: .injectIntrospection) ?? false
         rootWorkDir = try container.decodeIfPresent(Bool.self, forKey: .rootWorkDir) ?? true
         noKMOnInput = try container.decodeIfPresent(Bool.self, forKey: .noKMOnInput) ?? true
-        enableScrollWheel = try container.decodeIfPresent(Bool.self, forKey: .enableScrollWheel) ?? true
         hideTitleBar = try container.decodeIfPresent(Bool.self, forKey: .hideTitleBar) ?? false
         floatingWindow = try container.decodeIfPresent(Bool.self, forKey: .floatingWindow) ?? false
         checkMicPermissionSync = try container.decodeIfPresent(Bool.self, forKey: .checkMicPermissionSync) ?? false
@@ -90,10 +101,13 @@ struct AppSettingsData: Codable {
         resizableAspectRatioWidth = try container.decodeIfPresent(Int.self, forKey: .resizableAspectRatioWidth) ?? 0
         resizableAspectRatioHeight = try container.decodeIfPresent(Int.self, forKey: .resizableAspectRatioHeight) ?? 0
         blockSleepSpamming = try container.decodeIfPresent(Bool.self, forKey: .blockSleepSpamming) ?? false
+        // Decode scroll wheel settings
+        enableScrollWheelZoom = try container.decodeIfPresent(Bool.self, forKey: .enableScrollWheelZoom) ?? true
+        enableScrollWheelMapping = try container.decodeIfPresent(Bool.self, forKey: .enableScrollWheelMapping) ?? false
     }
 }
 
-class AppSettings {
+class AppSettings: ObservableObject {
     static var appSettingsDir: URL {
         let settingsFolder =
             PlayTools.playCoverContainer.appendingPathComponent("App Settings")
@@ -113,7 +127,7 @@ class AppSettings {
     let settingsUrl: URL
     var openWithLLDB: Bool = false
     var openLLDBWithTerminal: Bool = true
-    var settings: AppSettingsData {
+    @Published var settings: AppSettingsData {
         didSet {
             encode()
         }

--- a/PlayCover/Model/KeyCodeNames.swift
+++ b/PlayCover/Model/KeyCodeNames.swift
@@ -20,6 +20,8 @@ class KeyCodeNames {
         -1: "LMB",
         -2: "RMB",
         -3: "MMB",
+        -100: "ScrU",
+        -101: "ScrD",
         41: "Esc",
         44: "Spc",
         225: "Lshft",

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -149,7 +149,9 @@ struct KeymappingView: View {
     @Binding var settings: AppSettings
     @AppStorage("settings.settings.keymapping") private var keymapping = false
     @AppStorage("settings.settings.noKMOnInput") private var noKMOnInput = false
-    @AppStorage("settings.settings.enableScrollWheel") private var enableScrollWheel = false
+    @AppStorage("settings.settings.enableScrollWheelZoom") private var enableScrollWheelZoom = true
+    @AppStorage("settings.settings.enableScrollWheelMapping") private var enableScrollWheelMapping = false
+    @State private var toggleTrigger = false
     var body: some View {
         ScrollView {
             VStack {
@@ -161,19 +163,37 @@ struct KeymappingView: View {
                         .help("settings.toggle.autoKM.help")
                 }
                 HStack {
-                    Toggle("settings.toggle.enableScrollWheel", isOn: $settings.settings.enableScrollWheel)
-                        .help("settings.toggle.enableScrollWheel.help")
+                    Toggle("settings.toggle.enableScrollWheelZoom",
+                           isOn: $settings.settings.enableScrollWheelZoom)
+                        .help("settings.toggle.enableScrollWheelZoom.help")
+                        .onChange(of: settings.settings.enableScrollWheelZoom) { value in
+                            if value {
+                                settings.settings.enableScrollWheelMapping = false
+                                toggleTrigger.toggle()
+                            }
+                        }
                     Spacer()
+                    Toggle("settings.toggle.enableScrollWheelMapping",
+                           isOn: $settings.settings.enableScrollWheelMapping)
+                        .help("settings.toggle.enableScrollWheelMapping.help")
+                        .onChange(of: settings.settings.enableScrollWheelMapping) { value in
+                            if value {
+                                settings.settings.enableScrollWheelZoom = false
+                                toggleTrigger.toggle()
+                            }
+                        }
                 }
                 HStack {
-                    Toggle("settings.toggle.disableBuiltinMouse", isOn: $settings.settings.disableBuiltinMouse)
+                    Toggle("settings.toggle.disableBuiltinMouse",
+                           isOn: $settings.settings.disableBuiltinMouse)
                         .help("settings.toggle.disableBuiltinMouse.help")
                     Spacer()
                 }
                 HStack {
                     Text(String(
-                        format: NSLocalizedString("settings.slider.mouseSensitivity", comment: ""),
-                        settings.settings.sensitivity))
+                        format: NSLocalizedString("settings.slider.mouseSensitivity",
+                                                  comment: ""),
+                        Int(settings.settings.sensitivity)))
                     Spacer()
                     Slider(value: $settings.settings.sensitivity, in: 0...100, label: { EmptyView() })
                         .frame(width: 250)
@@ -181,6 +201,7 @@ struct KeymappingView: View {
                 }
                 Spacer()
             }
+            .id(toggleTrigger)
             .padding()
         }
     }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -154,11 +154,12 @@
 "settings.slider.mouseSensitivity" = "Mouse sensitivity: %.f";
 "settings.toggle.autoKM" = "Smart Keymap";
 "settings.toggle.autoKM.help" = "Automatically disable keymapping when text input is sensed";
-"settings.toggle.enableScrollWheel" = "Enable Scroll Wheel";
-"settings.toggle.enableScrollWheel.help" = "Enable scroll wheel in keymapping";
+"settings.toggle.enableScrollWheelZoom" = "Enable Scroll Wheel Zoom";
+"settings.toggle.enableScrollWheelZoom.help" = "Use the mouse scroll wheel for in-app zooming.";
+"settings.toggle.enableScrollWheelMapping" = "Enable Scroll Wheel Key Mapping";
+"settings.toggle.enableScrollWheelMapping.help" = "Map mouse scroll wheel up/down to ScrU/ScrD keys. Disables zoom when enabled.";
 "settings.toggle.disableBuiltinMouse" = "Disable Built-in Mouse Support";
-"settings.toggle.disableBuiltinMouse.help" = "Disable the app’s built-in mouse support to avoid click conflicts.";
-
+"settings.toggle.disableBuiltinMouse.help" = "Disable the app's built-in mouse support to avoid click conflicts.";
 "settings.tab.graphics" = "Graphics";
 "settings.picker.iosDevice" = "iOS device:";
 "settings.picker.adaptiveRes" = "Resolution:";

--- a/PlayCover/zh-Hans.lproj/Localizable.strings
+++ b/PlayCover/zh-Hans.lproj/Localizable.strings
@@ -371,10 +371,14 @@
 "settings.toggle.autoKM.help" = "当检测到文本输入时自动禁用按键映射";
 "settings.applicationCategoryType" = "应用程序类型";
 "settings.toggle.iosFrameworks" = "强制插入iOS框架";
-"settings.info.alias" = "别名:";
-"settings.toggle.enableScrollWheel.help" = "在按键映射启用滚轮";
 "settings.toggle.iosFrameworks.help" = "将系统 ios 库添加到应用程序中。已知可修复某些应用程序找不到 ios 框架的问题";
-"settings.toggle.enableScrollWheel" = "启用滚轮";
+"settings.info.alias" = "别名:";
+"settings.toggle.enableScrollWheelZoom" = "启用滚轮缩放";
+"settings.toggle.enableScrollWheelZoom.help" = "使用鼠标滚轮进行应用内缩放。";
+"settings.toggle.enableScrollWheelMapping" = "启用滚轮按键模拟";
+"settings.toggle.enableScrollWheelMapping.help" = "将鼠标滚轮向上/向下滚动映射为 ScrU/ScrD 按键。开启后将禁用滚轮缩放。";
+"settings.toggle.disableBuiltinMouse" = "禁用内置鼠标支持";
+"settings.toggle.disableBuiltinMouse.help" = "禁用应用程序内置的鼠标支持，以避免点击冲突。";
 "ipaLibrary.info.notAvailable" = "此应用链接不可用";
 "ipaLibrary.info" = "应用信息";
 "ipaLibrary.info.checksum.none" = "未提供";


### PR DESCRIPTION
## Overview
This PR introduces a dedicated mouse scroll wheel mapping feature, allowing users to map scroll events to virtual keys (`ScrU` / `ScrD`). To improve clarity and prevent functional conflicts, the original scroll wheel zoom setting has been refactored.

## Key Changes
- **[Refactor] Renamed Setting**: Renamed `enableScrollWheel` to `enableScrollWheelZoom` in `AppSettingsData` to explicitly distinguish it from the new mapping mode.
- **[Feature] Mutual Exclusion**: Implemented UI-level mutual exclusion in `AppSettingsView`. Enabling "Scroll Mapping" will automatically disable "Scroll Zoom" and vice versa, ensuring consistent behavior.
- **[Mapping] New Keycodes**: Added `ScrU` (-100) and `ScrD` (-101) to `KeyCodeNames` for use in the mapping editor.
- **[L10n] Localization**: Updated `Localizable.strings` (English and Simplified Chinese) for the new toggle options.

## Screenshots
Here is the updated UI in AppSettings showing the mutually exclusive scroll modes:

![PlayCover UI Scroll [Settings]()](
<img width="1064" height="716" alt="b3498e45-61fa-4b70-9001-d28b3d825d16" src="https://github.com/user-attachments/assets/5532002c-e9b6-4ff0-b228-445a64102743" />
)

> [!IMPORTANT]
> **Dependency Note**: This PR requires the corresponding changes in **PlayTools** to function correctly.
> **PR Link**: [PlayTools PR #218](https://github.com/PlayCover/PlayTools/pull/218)
>
> **Breaking Change Warning**: Due to the renaming of `enableScrollWheel` to `enableScrollWheelZoom`, this update is **not backwards compatible** with older versions of PlayTools. Both repositories MUST be merged simultaneously to avoid setting synchronization issues.