### PR TITLE
Replace global `npm` install with `npx` runtime

### DIFF
--- a/.github/workflows/1.build_release.yml
+++ b/.github/workflows/1.build_release.yml
@@ -10,12 +10,12 @@ env:
   CI: true
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-26
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get the version
         id: tag_version
@@ -24,11 +24,11 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          brew install graphicsmagick imagemagick swiftlint
+          brew install swiftlint
           gem install fastlane
           bundle install
           pip install setuptools
-          npm install --global https://github.com/PlayCover/create-dmg
+          npm install https://github.com/PlayCover/create-dmg
 
       - name: Fastlane Release
         shell: bash
@@ -47,7 +47,7 @@ jobs:
       - name: Create DMG
         shell: bash
         run: |
-          create-dmg ./output/PlayCover.app ./output
+          npx create-dmg ./output/PlayCover.app ./output
           mv ./output/*.dmg ./output/PlayCover_${{ env.TAG_NAME }}.dmg
 
       - name: Notarize DMG

--- a/.github/workflows/1.build_release.yml
+++ b/.github/workflows/1.build_release.yml
@@ -62,7 +62,7 @@ jobs:
         run: rm apikey.json
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: PlayCover_${{ env.TAG_NAME }}.dmg
           path: output/PlayCover_${{ env.TAG_NAME }}.dmg

--- a/.github/workflows/2.nightly_release.yml
+++ b/.github/workflows/2.nightly_release.yml
@@ -59,7 +59,7 @@ jobs:
         run: rm apikey.json
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: PlayCover_nightly_${{ github.run_number }}.dmg
           path: output/PlayCover_nightly_${{ github.run_number }}.dmg

--- a/.github/workflows/2.nightly_release.yml
+++ b/.github/workflows/2.nightly_release.yml
@@ -12,16 +12,16 @@ jobs:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         shell: bash
         run: |
-          brew install graphicsmagick imagemagick swiftlint
+          brew install swiftlint
           gem install fastlane
           bundle install
           pip install setuptools
-          npm install --global https://github.com/PlayCover/create-dmg
+          npm install https://github.com/PlayCover/create-dmg
 
       - name: Set build number
         shell: bash
@@ -45,7 +45,7 @@ jobs:
       - name: Create DMG
         shell: bash
         run: |
-          create-dmg ./output/PlayCover.app ./output
+          npx create-dmg ./output/PlayCover.app ./output
           mv ./output/*.dmg ./output/PlayCover_nightly_${{ github.run_number }}.dmg
 
       - name: Notarize DMG

--- a/.github/workflows/SwiftLint.yml
+++ b/.github/workflows/SwiftLint.yml
@@ -12,7 +12,7 @@ jobs:
   SwiftLint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v6
       - name: SwiftLint
         uses: norio-nomura/action-swiftlint@3.2.1
         with:


### PR DESCRIPTION
Note that `graphicsmagick` and `imagemagick` dependencies for `create-dmg` was removed in a new release. Updates for `checkout` and `upload-artifact` versions across actions was also committed.