### PR TITLE
chore: update dependencies

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -983,56 +983,56 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/scinfu/SwiftSoup";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.13.4;
+				kind = exactVersion;
+				version = 2.13.4;
 			};
 		};
 		365AFB0428847B2E008B3542 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.9.1;
+				kind = exactVersion;
+				version = 2.9.1;
 			};
 		};
 		68E48B932957046D00C39879 /* XCRemoteSwiftPackageReference "download-manager" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/shapedbyiris/download-manager.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				kind = exactVersion;
+				version = 0.1.0;
 			};
 		};
 		68E48B98295708C800C39879 /* XCRemoteSwiftPackageReference "inject" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/paradiseduo/inject";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.1;
+				kind = exactVersion;
+				version = 1.2.1;
 			};
 		};
 		68E48B9D29570A0400C39879 /* XCRemoteSwiftPackageReference "DataCache" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/huynguyencong/DataCache";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.7.0;
+				kind = exactVersion;
+				version = 1.7.0;
 			};
 		};
 		68E48BA029570A2B00C39879 /* XCRemoteSwiftPackageReference "CachedAsyncImage" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/bullinnyc/CachedAsyncImage";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.6.0;
+				kind = exactVersion;
+				version = 2.6.0;
 			};
 		};
 		AA818CB3287ABEC3000BEE9D /* XCRemoteSwiftPackageReference "Yams" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/jpsim/Yams.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 6.2.1;
+				kind = exactVersion;
+				version = 6.2.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		342787552E787EBB003A3C2F /* Keymapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342787542E787EB9003A3C2F /* Keymapping.swift */; };
+		343880DB2F8EE847009B93BE /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = 343880DA2F8EE847009B93BE /* SwiftSoup */; };
 		3447B5E52E28B46800FAA22F /* KeymapViewVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3447B5E42E28B46800FAA22F /* KeymapViewVM.swift */; };
 		34775E752D493B59001586C2 /* CachedAsyncImageWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34775E742D493B54001586C2 /* CachedAsyncImageWrapper.swift */; };
 		349915332F8866A3005565D1 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 349915322F8866A3005565D1 /* AppIcon.icon */; };
@@ -84,7 +85,6 @@
 		B17FD04728C7B0D900B1D4CA /* AssetsExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17FD04628C7B0D900B1D4CA /* AssetsExtractor.swift */; };
 		B429B2642DC204FA001FF7D9 /* VersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = B429B2632DC204F1001FF7D9 /* VersionCheck.swift */; };
 		B44B40372C1E315600CE2A3E /* GoogleDrive.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44B40362C1E315600CE2A3E /* GoogleDrive.swift */; };
-		B44E8CD32C31C50200542038 /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = B44E8CD22C31C50200542038 /* SwiftSoup */; };
 		B6603E1128E206A300DEFA3F /* UninstallSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6603E1028E206A300DEFA3F /* UninstallSettings.swift */; };
 		B6603E1328E2257800DEFA3F /* Uninstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6603E1228E2257800DEFA3F /* Uninstaller.swift */; };
 		B67BC7122C39354C00315011 /* UpdateScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67BC7112C39354500315011 /* UpdateScheme.swift */; };
@@ -219,7 +219,7 @@
 				365AFB0628847B2E008B3542 /* Sparkle in Frameworks */,
 				68E48BA229570A2B00C39879 /* CachedAsyncImage in Frameworks */,
 				AA818CB5287ABEC3000BEE9D /* Yams in Frameworks */,
-				B44E8CD32C31C50200542038 /* SwiftSoup in Frameworks */,
+				343880DB2F8EE847009B93BE /* SwiftSoup in Frameworks */,
 				68E48B952957046D00C39879 /* DownloadManager in Frameworks */,
 				B17FD03C28C70C2100B1D4CA /* CoreUI.framework in Frameworks */,
 			);
@@ -473,7 +473,7 @@
 				68E48B9E29570A0400C39879 /* DataCache */,
 				68E48BA129570A2B00C39879 /* CachedAsyncImage */,
 				68E48B99295708C800C39879 /* Injection */,
-				B44E8CD22C31C50200542038 /* SwiftSoup */,
+				343880DA2F8EE847009B93BE /* SwiftSoup */,
 			);
 			productName = PlayCover;
 			productReference = 8783CFF726B8C52D00171041 /* PlayCover.app */;
@@ -529,7 +529,7 @@
 				68E48B9D29570A0400C39879 /* XCRemoteSwiftPackageReference "DataCache" */,
 				68E48BA029570A2B00C39879 /* XCRemoteSwiftPackageReference "CachedAsyncImage" */,
 				68E48B98295708C800C39879 /* XCRemoteSwiftPackageReference "inject" */,
-				B44E8CD12C31C50200542038 /* XCRemoteSwiftPackageReference "SwiftSoup" */,
+				343880D92F8EE847009B93BE /* XCRemoteSwiftPackageReference "SwiftSoup" */,
 			);
 			productRefGroup = 8783CFF826B8C52D00171041 /* Products */;
 			projectDirPath = "";
@@ -979,12 +979,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		343880D92F8EE847009B93BE /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/scinfu/SwiftSoup";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.13.4;
+			};
+		};
 		365AFB0428847B2E008B3542 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				minimumVersion = 2.9.1;
 			};
 		};
 		68E48B932957046D00C39879 /* XCRemoteSwiftPackageReference "download-manager" */ = {
@@ -1000,7 +1008,7 @@
 			repositoryURL = "https://github.com/paradiseduo/inject";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.2.1;
 			};
 		};
 		68E48B9D29570A0400C39879 /* XCRemoteSwiftPackageReference "DataCache" */ = {
@@ -1008,7 +1016,7 @@
 			repositoryURL = "https://github.com/huynguyencong/DataCache";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.7.0;
 			};
 		};
 		68E48BA029570A2B00C39879 /* XCRemoteSwiftPackageReference "CachedAsyncImage" */ = {
@@ -1016,29 +1024,25 @@
 			repositoryURL = "https://github.com/bullinnyc/CachedAsyncImage";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.5.0;
+				minimumVersion = 2.6.0;
 			};
 		};
 		AA818CB3287ABEC3000BEE9D /* XCRemoteSwiftPackageReference "Yams" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/jpsim/Yams.git";
 			requirement = {
-				kind = versionRange;
-				maximumVersion = 6.0.0;
-				minimumVersion = 5.0.0;
-			};
-		};
-		B44E8CD12C31C50200542038 /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/PlayCover/SwiftSoup";
-			requirement = {
-				kind = revision;
-				revision = 6d808c0522471d9f8892c85601164ed5b462f8c0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.2.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		343880DA2F8EE847009B93BE /* SwiftSoup */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 343880D92F8EE847009B93BE /* XCRemoteSwiftPackageReference "SwiftSoup" */;
+			productName = SwiftSoup;
+		};
 		365AFB0528847B2E008B3542 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 365AFB0428847B2E008B3542 /* XCRemoteSwiftPackageReference "Sparkle" */;
@@ -1068,11 +1072,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AA818CB3287ABEC3000BEE9D /* XCRemoteSwiftPackageReference "Yams" */;
 			productName = Yams;
-		};
-		B44E8CD22C31C50200542038 /* SwiftSoup */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B44E8CD12C31C50200542038 /* XCRemoteSwiftPackageReference "SwiftSoup" */;
-			productName = SwiftSoup;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
> [!CAUTION]
> This will increase the app size by ~6MB, due to switching to full SwiftSoup suite.

This pull request will update all of the packages the PlayCover app is dependent on, and pin the version as caution against supply-chain attacks. However, this also increases the size of the executable (and therefore the app) by ~6MB. This does not need to be merged if updating the minimum dependency versions and switching to the entire SwiftSoup suite is unnecessary.

Below are the minimum dependency version updated:
- Swiftsoup: (Note: Switched from custom stripped version to source, which may be the cause of size incresae) 2.6.0 -> 2.13.4
- Sparkle: 2.0.0 -> 2.9.1
- inject: 1.0.0 -> 1.2.1
- DataCache: 1.0.0 -> 1.7.0
- Yams: 5.0.0<6.0.0 -> 6.2.1