### PR TITLE
Update Chinese localizations (zh-Hans & zh-Hant)

### DIFF
--- a/PlayCover/zh-Hans.lproj/Localizable.strings
+++ b/PlayCover/zh-Hans.lproj/Localizable.strings
@@ -1,260 +1,46 @@
-/* (No Comment) */
-"alert.app.delete" = "所有应用数据将被清除；有些软件可能需要重新下载数据。确定继续？";
-
-/* (No Comment) */
-"alert.app.preferences" = "所有应用内设置将被删除。您可能需要重新设定应用设置。您确定要继续吗？";
-
-/* (No Comment) */
-"alert.appCacheCleared" = "应用数据已被清除！";
-
-/* (No Comment) */
-"alert.error" = "遇到了问题!";
-
-/* (No Comment) */
-"alert.errorImportKm" = "导入过程中出现问题！";
-
-/* (No Comment) */
-"alert.kmImported" = "键盘映射布局已导入！";
-
-/* (No Comment) */
-"alert.moveAppToApplications.move" = "移进应用程序文件夹";
-
-/* (No Comment) */
-"alert.restart" = "请重启 PlayCover。";
-
-/* (No Comment) */
-"alert.success" = "成功";
-
-/* (No Comment) */
-"button.Cancel" = "取消";
-
-/* (No Comment) */
-"button.Close" = "关闭";
-
-/* (No Comment) */
-"button.Install" = "安装";
-
-/* (No Comment) */
-"button.OK" = "好";
-
-/* (No Comment) */
-"button.Proceed" = "继续";
-
-/* (No Comment) */
-"error.corruptedIPA" = "此 ipa 文件已损坏，因为找不到 \"Info.plist\" 文件。";
-
-/* (No Comment) */
-"error.waitInstallation" = "请等待安装过程结束！";
-
-/* (No Comment) */
-"menubar.checkForUpdates" = "检查更新...";
-
-/* (No Comment) */
-"menubar.discord" = "Discord（社区交流平台）";
-
-/* (No Comment) */
-"menubar.documentation" = "使用手册";
-
-/* (No Comment) */
-"menubar.exportToSideloady" = "为 Sideloadly 导出";
-
-/* (No Comment) */
-"menubar.github" = "GitHub（源代码发行网站）";
-
-/* (No Comment) */
-"menubar.log.copy" = "拷贝日志";
-
-/* (No Comment) */
-"menubar.website" = "官网";
-
-/* (No Comment) */
-"notification.appInstalled" = "应用安装成功！";
-
-/* (No Comment) */
-"notification.appInstalled.message" = "立即来看一看吧!";
-
-/* (No Comment) */
-"playapp.clearCache" = "清除应用数据";
-
-/* (No Comment) */
-"playapp.clearPreferences" = "清除应用偏好设置";
-
-/* (No Comment) */
-"playapp.delete" = "卸载应用";
-
-/* (No Comment) */
-"playapp.exportKm" = "导出键盘映射布局";
-
-/* (No Comment) */
-"playapp.importKm" = "导入键盘映射布局";
-
-/* (No Comment) */
-"playapp.install.addToLib" = "正在将应用移进软件库...";
-
-/* (No Comment) */
-"playapp.install.copy" = "正在复制应用...";
-
-/* (No Comment) */
-"playapp.install.createWrapper" = "正在包装应用...";
-
-/* (No Comment) */
-"playapp.progress.finished" = "安装完成";
-
-/* (No Comment) */
-"playapp.install.installPlayTools" = "正在安装 PlayTools...";
-
-/* (No Comment) */
-"playapp.install.signing" = "正在为应用签名...";
-
-/* (No Comment) */
-"playapp.install.unzip" = "正在从文件提取应用...";
-
-/* (No Comment) */
-"playapp.openCache" = "显示应用数据";
-
-/* (No Comment) */
+"playapp.add" = "添加应用";
+"playapp.addSource" = "添加来源";
 "playapp.settings" = "设置";
-
-/* (No Comment) */
+"playapp.keymap" = "查看键盘映射";
 "playapp.showInFinder" = "在访达中查看";
-
-/* (No Comment) */
-"preferences.button.checkForUpdates" = "检查更新";
-
-/* (No Comment) */
-"preferences.tab.updates" = "更新";
-
-/* (No Comment) */
-"preferences.toggle.automaticUpdates" = "自动检查更新";
-
-/* (No Comment) */
-"settings.button.discord" = "自定义 Discord 动态";
-
-/* (No Comment) */
-"settings.button.clearActivity" = "清除自定义动态";
-
-/* (No Comment) */
-"settings.picker.iosDevice" = "选择 iOS 机型:";
-
-/* %.f */
-"settings.slider.mouseSensitivity" = "鼠标灵敏度: %.f";
-
-/* (No Comment) */
-"settings.text.applicationID" = "应用 ID";
-
-/* (No Comment) */
-"settings.text.customHeight" = "高度";
-
-/* (No Comment) */
-"settings.text.customWidth" = "宽度";
-
-/* (No Comment) */
-"settings.text.details" = "详细信息";
-
-/* (No Comment) */
-"settings.text.details.help" = "标题下的第一行文字";
-
-/* (No Comment) */
-"settings.text.image" = "图像";
-
-/* (No Comment) */
-"settings.text.image.help" = "链接到图像或开发者网站的资产名称";
-
-/* (No Comment) */
-"settings.text.state" = "状态";
-
-/* (No Comment) */
-"settings.text.state.help" = "标题下的第二行文字";
-
-/* (No Comment) */
-"settings.toggle.disableDisplaySleep" = "禁用显示器息屏";
-
-/* (No Comment) */
-"settings.toggle.discord" = "启用 Discord 动态";
-
-/* (No Comment) */
-"settings.toggle.jbBypass" = "启用绕过越狱检测（试验阶段）";
-
-/* (No Comment) */
-"settings.toggle.km" = "启用键盘映射布局";
-
-/* (No Comment) */
-"soundAlert.failureText" = "现有音频设备设置采样率 48 KHz 失败。 您可以在 ”音频MIDI设置“ 应用里手动设置";
-
-/* (No Comment) */
-"soundAlert.informativeText" = "现有的音频设备没有设置到 48 或 44.1 kHz 采样率！应用可能会崩溃。您希望把现有的音频设备设置成 48 kHz 采样率吗?";
-
-/* (No Comment) */
-"soundAlert.messageText" = "监测到声音设置有问题!";
-
-/* (No Comment) */
-"soundAlert.successText" = "当前音频设备采样率已设为 48 kHz";
-
-/* (No Comment) */
-"button.Quit" = "退出";
-"error.appProhibited" = "通过 PlayCover 使用这个应用程序很可能会导致帐号被封停！";
-"settings.title" = "%@ 设定";
+"playapp.openCache" = "显示应用数据";
+"playapp.clearCache" = "清除应用数据";
+"playapp.clearPlayChain" = "清除 PlayChain 数据";
+"playapp.importIPA" = "导入 IPA";
+"playapp.importKm" = "导入键盘映射布局";
+"playapp.exportKm" = "导出键盘映射布局";
+"playapp.emptyKm" = "新建";
 "playapp.exportKmPanel.fieldLabel" = "PlayMap 名称：";
-"sidebar.appLibrary" = "App 库";
-"sidebar.ipaLibrary" = "IPA 资源库";
-"alert.moveAppToApplications.title" = "是否移动至应用程序文件夹？";
-"alert.moveAppToApplications.subtitle" = "PlayCover必须在应用程序文件夹下才能正常运行。点击下方按钮将会自动移动PlayCover至应用程序文件夹。";
-"error.appEncrypted" = "此应用已被加密！请使用未加密的 ipa 文件。 现已不再支持来自 iMazing 的 ipa！";
-"error.appCorrupted" = "此 ipa 文件是错误的。请尝试使用其他 ipa 文件。";
-"settings.tab.info" = "详细信息";
-"settings.tab.km" = "键盘映射";
-"settings.toggle.km.help" = "为仅支持触摸游戏添加键盘支持，使用 Command + K 打开编辑菜单。";
-"settings.tab.graphics" = "图像设置";
-"settings.picker.adaptiveRes" = "分辨率：";
-"settings.picker.adaptiveRes.help" = "修改应用程序的窗口分辨率";
-"settings.picker.adaptiveRes.0" = "默认分辨率";
-"settings.picker.adaptiveRes.1" = "自动（基于显示器分辨率）";
-"settings.picker.adaptiveRes.5" = "自定义";
-"settings.picker.aspectRatio" = "长宽比：";
-"settings.toggle.disableDisplaySleep.help" = "在该应用运行时防止显示屏关闭";
-"settings.toggle.jbBypass.help" = "尝试绕过某些游戏的越狱检测 （无法保证能够一直正常工作）";
-"settings.info.displayName" = "显示名称:";
-"settings.info.bundleName" = "Bundle 名称:";
-"settings.info.bundleIdentifier" = "Bundle ID：";
-"settings.info.executableName" = "可执行文件名称:";
-"settings.info.minimumOSVersion" = "最低OS版本:";
-"settings.info.url" = "链接：";
-"settings.resetSettings" = "重置设定";
-"settings.resetKm" = "重置键盘映射";
-"settings.resetSettingsCompleted" = "设定已被重置为默认值！";
-"settings.resetKmCompleted" = "键盘映射已重置！";
-"settings.tab.misc" = "杂项";
-"settings.toggle.hud" = "启用 Metal 性能面板";
-"settings.info.bundleVersion" = "Bundle 版本号：";
+"playapp.delete" = "卸载应用";
 "playapp.deleteConfirm" = "确认卸载";
 "playapp.deleteMessage" = "确认卸载 %@ 吗?";
-"alert.legacyImport.title" = "发现缺省应用程序偏好设置！";
-"alert.legacyImport.subtitle" = "检测到老版本的设置和按键映射文件。你需要把这些文件转换为新的格式吗？";
-"button.Convert" = "转换";
-"settings.text.detectedResolution" = "已检测到的分辨率：";
-"playapp.add" = "添加应用";
-"alert.wrongFileType.title" = "错误的文件类型!";
-"alert.wrongFileType.subtitle" = "PlayCover 只可以安装有效的 .ipa 文件。";
-"playapp.addSource" = "添加来源";
+"playapp.clearPreferences" = "清除应用偏好设置";
+"playapp.refreshSources" = "刷新来源";
+"playapp.noSources.title" = "没有已安装的 IPA";
+"playapp.noSources.subtitle" = "当前你没有安装任何 IPA。点击下面的按钮来导入一个。";
+
+"ipaLibrary.info" = "应用信息";
+"ipaLibrary.info.title" = "%@ 信息";
+"ipaLibrary.info.notAvailable" = "此应用链接不可用";
+"ipaLibrary.info.itunes" = "查找 ITunes:";
+"ipaLibrary.info.checksum" = "核对和:";
+"ipaLibrary.info.checksum.none" = "未提供";
 "ipaLibrary.noSources.title" = "尚未添加 IPA 来源";
 "ipaLibrary.noSources.subtitle" = "您目前没有添加 IPA 来源。点击下面的按钮来添加一个。";
 "ipaLibrary.noSources.button" = "添加来源";
 "ipaLibrary.noNetworkConnection.toast" = "没有网络连接!";
-"preferences.tab.ipasource" = "IPA 来源";
-"preferences.button.addSource" = "添加来源";
-"preferences.button.deleteSource" = "删除来源";
-"preferences.button.moveSourceUp" = "上移来源";
-"preferences.button.moveSourceDown" = "下移来源";
-"preferences.popover.valid" = "链接有效";
-"preferences.popover.badurl" = "链接无效!";
-"preferences.popover.badjson" = "JSON 无效或未找到!";
-"preferences.textfield.url" = "来源 URL 链接...";
-"playapp.download.downloading" = "下载中";
-"error.waitDownload" = "请等待下载完成!";
-"preferences.button.pruneFiles" = "删除未使用的文件";
-"playapp.progress.failed" = "安装失败";
-"alert.supression" = "你可以在 PlayCover 偏好设置中更改";
-"menubar.clearCache" = "清除缓存";
+"ipaLibrary.noNetworkConnection.required" = "连接网络以查看 IPA Library";
+"ipaLibrary.version.older" = "此版本比您已安装的应用更旧";
+"ipaLibrary.version.same" = "应用已安装";
+"ipaLibrary.version.newer" = "这个版本比你已安装的版本更高";
+"ipaLibrary.unavailable" = "链接不可用";
+"ipaLibrary.alert.download" = "您确定您要下载这个版本的 %@ 吗?";
+"ipaLibrary.download" = "下载";
+"ipaLibrary.AlphabeticalSort" = "按字母顺序排列应用来源";
+
+"preferences.button.checkForUpdates" = "检查更新";
+"preferences.tab.updates" = "更新";
+"preferences.toggle.automaticUpdates" = "自动检查更新";
 "preferences.tab.uninstall" = "卸载";
 "preferences.whenUninstalling" = "在卸载同时:";
 "preferences.toggle.showUninstall" = "显示警告弹窗";
@@ -262,34 +48,228 @@
 "preferences.toggle.removeKeymap" = "移除键盘映射";
 "preferences.toggle.removeSetting" = "清除设置";
 "preferences.toggle.removeEntitlements" = "移除授权";
+"preferences.toggle.removePlayChain" = "移除 PlayChain";
+"preferences.button.pruneFiles" = "删除未使用的文件";
 "preferences.prune.alert" = "您确定要删除所有未使用的文件吗？";
 "preferences.prune.message" = "这将删除所有未使用的文件，包括设置、按键映射、授权和应用程序数据";
+"preferences.tab.ipasource" = "IPA 来源";
+"preferences.button.addSource" = "添加来源";
+"preferences.button.deleteSource" = "删除来源";
+"preferences.button.moveSourceUp" = "上移来源";
+"preferences.button.moveSourceDown" = "下移来源";
+"preferences.popover.valid" = "链接有效";
+"preferences.popover.valid.keymap" = "名称有效";
+"preferences.popover.badurl" = "链接无效!";
+"preferences.popover.malformed.keymap" = "名称格式错误";
+"preferences.popover.badjson" = "JSON 无效或未找到!";
+"preferences.popover.duplicate" = "复制链接";
+"preferences.popover.duplicate.keymap" = "名称重复";
+"preferences.popover.checking" = "检查 URL";
+"preferences.textfield.url" = "来源 URL 链接...";
 "preferences.tab.install" = "安装";
 "preferences.toggle.showInstallPopup" = "显示安装 PlayTools 弹窗";
 "preferences.toggle.alwaysInstallPlayTools" = "总是安装 PlayTools";
+"preferences.toggle.showAppStorePopup" = "当应用有官方 App Store 版本时显示提醒";
+
+"sidebar.appLibrary" = "App 库";
+"sidebar.ipaLibrary" = "IPA 资源库";
+"playapp.download.downloading" = "下载中";
+"playapp.download.integrityCheck" = "正在验证文件完整性:";
+"playapp.download.differentChecksum" = "校验不一致！你是否想要继续安装？";
+"playapp.download.differentChecksumDesc" = "预期为 \"%@\", 当前为 \"%@\"";
+"playapp.install.unzip" = "正在从文件提取应用...";
+"playapp.install.createWrapper" = "正在包装应用...";
+"playapp.install.installPlayTools" = "正在安装 PlayTools...";
+"playapp.install.signing" = "正在为应用签名...";
+"playapp.install.addToLib" = "正在将应用移进软件库...";
+"playapp.install.copy" = "正在复制应用...";
+"playapp.progress.finished" = "安装完成";
+"playapp.progress.failed" = "安装失败";
+"playapp.progress.canceled" = "已取消";
+
+"alert.appCacheCleared" = "应用数据已被清除！";
+"alert.errorImportKm" = "导入过程中出现问题！";
+"alert.errorRenameKm" = "重命名键盘映射时出错！";
+"alert.errorKmCreated" = "创建键盘映射时出错！";
+"alert.app.delete" = "所有应用数据将被清除；有些软件可能需要重新下载数据。确定继续？";
+"alert.app.preferences" = "所有应用内设置将被删除。您可能需要重新设定应用设置。您确定要继续吗？";
+"alert.app.clearPlayChain" = "所有 PlayChain 数据将被清除。您可能需要重新登录 APP。您想要继续吗?";
+"alert.restart" = "请重启 PlayCover。";
+"alert.error" = "遇到了问题!";
+"alert.success" = "成功";
+"alert.moveAppToApplications.title" = "是否移动至应用程序文件夹？";
+"alert.moveAppToApplications.subtitle" = "PlayCover必须在应用程序文件夹下才能正常运行。点击下方按钮将会自动移动PlayCover至应用程序文件夹。";
+"alert.moveAppToApplications.move" = "移进应用程序文件夹";
+"alert.legacyImport.title" = "发现缺省应用程序偏好设置！";
+"alert.legacyImport.subtitle" = "检测到老版本的设置和按键映射文件。你需要把这些文件转换为新的格式吗？";
+"alert.wrongFileType.title" = "错误的文件类型!";
+"alert.wrongFileType.subtitle" = "PlayCover 只可以安装有效的 .ipa 文件。";
 "alert.install.injectPlayTools" = "注入 PlayTools";
-"button.Yes" = "是";
-"button.No" = "否";
-"settings.noPlayTools" = "此应用中并无安装 PlayTools";
-"settings.removePlayTools" = "移除 PlayTools";
-"settings.info.playTools" = "已安装 PlayTools：";
-"playapp.refreshSources" = "刷新来源";
-"error.appMaliciousProhibited" = "此应用程序在Mac上有恶意行为，使用它会使您的设备处于无法启动的状态，因此它被PlayCover阻止。（正在卸载...)";
 "alert.install.injectPlayToolsQuestion" = "您希望在此应用中注入 PlayTools 吗？";
 "alert.install.playToolsInformative" = "PlayTools 是一个能帮您将键盘按键映射为触屏控制，自定义显示分辨率以及更多的工具，但它有可能使某些应用无法使用";
-"configSigning.info.SIPHeader" = "系统完整性保护";
-"configSigning.alert.copied" = "命令已复制！";
-"configSigning.alert.info" = "请在 终端 中粘贴并运行该命令。您的 Mac 之后将重新启动";
+"alert.supression" = "你可以在 PlayCover 偏好设置中更改";
+"alert.differentBundleIdKeymap.message" = "此键盘映射文件有可能是为其他应用创建的。";
+"alert.differentBundleIdKeymap.text" = "您确定您要导入此键盘映射文件吗？";
+"alert.power.title" = "低电量模式已开启！";
+"alert.power.subtitle" = "部分应用程序在启用低电量模式后将无法工作。建议将其关闭。";
+
+"button.OK" = "好";
+"button.Proceed" = "继续";
+"button.Cancel" = "取消";
+"button.Close" = "关闭";
+"button.Install" = "安装";
+"button.Quit" = "退出";
+"button.Convert" = "转换";
+"button.Yes" = "是";
+"button.No" = "否";
 "button.Help" = "帮助";
 "button.Dismiss" = "隐藏";
+"button.Reload" = "刷新";
+"button.Enable" = "启用";
+"button.Reset" = "重置";
+"button.Unlock" = "解锁";
+
 "state.enabled" = "启用";
 "state.disabled" = "禁用";
 "state.pendingReboot" = "等待重新启动";
+
+"error.corruptedIPA" = "此 ipa 文件已损坏，因为找不到 \"Info.plist\" 文件。";
+"error.waitInstallation" = "请等待安装过程结束！";
+"error.waitDownload" = "请等待下载完成!";
+"error.appEncrypted" = "此应用已被加密！请使用未加密的 ipa 文件。 现已不再支持来自 iMazing 的 ipa！";
+"error.appCorrupted" = "此 ipa 文件是错误的。请尝试使用其他 ipa 文件。";
+"error.appProhibited" = "通过 PlayCover 使用这个应用程序很可能会导致帐号被封停！";
+"error.appMaliciousProhibited" = "此应用程序在Mac上有恶意行为，使用它会使您的设备处于无法启动的状态，因此它被PlayCover阻止。（正在卸载...)";
+"error.failedToStripBinary" = "无法在通用二进制文件中检索到 ARM64 架构！";
+
+"menubar.exportToSideloady" = "为 Sideloadly 导出";
+
+"settings.title" = "%@ 设定";
+"settings.tab.info" = "详细信息";
+
+"settings.tab.km" = "键盘映射";
+"settings.toggle.km" = "启用键盘映射布局";
+"settings.toggle.km.help" = "为仅支持触摸游戏添加键盘支持，使用 Command + K 打开编辑菜单。";
+"settings.slider.mouseSensitivity" = "鼠标灵敏度: %.f";
+"settings.toggle.autoKM" = "智能按键映射";
+"settings.toggle.autoKM.help" = "当检测到文本输入时自动禁用按键映射";
+"settings.toggle.enableScrollWheel" = "启用滚轮";
+"settings.toggle.enableScrollWheel.help" = "在按键映射启用滚轮";
+"settings.toggle.disableBuiltinMouse" = "禁用内置鼠标支持";
+"settings.toggle.disableBuiltinMouse.help" = "禁用应用内置鼠标支持以避免点击冲突。";
+
+"settings.tab.graphics" = "图像设置";
+"settings.picker.iosDevice" = "选择 iOS 机型:";
+"settings.picker.adaptiveRes" = "分辨率：";
+"settings.picker.adaptiveRes.help" = "修改应用程序的窗口分辨率";
+"settings.picker.adaptiveRes.0" = "默认分辨率";
+"settings.picker.adaptiveRes.1" = "自动（基于显示器分辨率）";
+"settings.picker.adaptiveRes.5" = "自定义";
+"settings.picker.adaptiveRes.6" = "可调整大小";
+"settings.text.customHeight" = "高度";
+"settings.text.customWidth" = "宽度";
+"settings.text.detectedResolution" = "已检测到的分辨率：";
+"settings.picker.aspectRatio" = "长宽比：";
+"settings.picker.aspectRatio.free" = "自由";
+"settings.picker.aspectRatio.custom" = "自定义";
+"settings.picker.windowFix" = "修复窗口化显示问题";
+"settings.picker.windowFix.help" = "启用窗口化修复也许可以让你的程序正常显示";
+"settings.picker.windowFixMethod.0" = "正常";
+"settings.picker.windowFixMethod.1" = "备用";
+"settings.toggle.disableDisplaySleep" = "禁用显示器息屏";
+"settings.settings.displayRotation" = "设备方向";
+"settings.settings.displayRotation.default" = "默认";
+"settings.settings.displayRotation.portrait" = "竖屏";
+"settings.settings.displayRotation.landscapeRight" = "横屏向右";
+"settings.settings.displayRotation.portraitUpsideDown" = "竖屏倒置";
+"settings.settings.displayRotation.flipFix" = "翻转修复";
+"settings.toggle.disableDisplaySleep.help" = "在该应用运行时防止显示屏关闭";
+"settings.toggle.hideTitleBar" = "隐藏标题栏";
+"settings.toggle.floatingWindow" = "浮动窗口";
+"settings.noPlayTools" = "此应用中并无安装 PlayTools";
+"settings.highResolution" = "高画质可能会导致闪退";
+"settings.picker.scaler" = "分辨率缩放";
+
+"settings.tab.bypasses" = "绕过";
+"settings.toggle.jbBypass" = "启用绕过越狱检测（试验阶段）";
+"settings.toggle.jbBypass.help" = "尝试绕过某些游戏的越狱检测 （无法保证能够一直正常工作）";
+"settings.playChain.enable" = "启用 PlayChain (试验阶段)";
+"settings.playChain.help" = "在此应用启用 PlayChain 将使应用（部分）使用 Apple Keychain 服务";
+"settings.playChain.debugging" = "PlayChain 调试";
+"settings.toggle.introspection" = "插入内省库";
+"settings.toggle.introspection.help" = "添加系统内省库到 app。已知可修复某些应用程序无法正确启动的问题";
+"settings.toggle.iosFrameworks" = "强制插入iOS框架";
+"settings.toggle.iosFrameworks.help" = "将系统 ios 库添加到应用程序中。已知可修复某些应用程序找不到 ios 框架的问题";
+"settings.toggle.checkMicPermissionSync" = "同步检查麦克风权限";
+"settings.toggle.checkMicPermissionSync.help" = "强制同步检查麦克风权限。已知可修复某些应用提示未授予麦克风权限的问题";
+
+"settings.applicationCategoryType" = "应用程序类型";
+"settings.removePlayTools" = "移除 PlayTools";
+
+"settings.info.displayName" = "显示名称:";
+"settings.info.bundleName" = "Bundle 名称:";
+"settings.info.bundleIdentifier" = "Bundle ID：";
+"settings.info.bundleVersion" = "Bundle 版本号：";
+"settings.info.executableName" = "可执行文件名称:";
+"settings.info.minimumOSVersion" = "最低OS版本:";
+"settings.info.playTools" = "已安装 PlayTools：";
+"settings.info.url" = "链接：";
+"settings.info.alias" = "别名:";
+
+"settings.resetSettings" = "重置设定";
+"settings.resetKm" = "重置键盘映射";
+"settings.deleteKm" = "删除键盘映射";
+"settings.renameKm" = "重命名键盘映射";
+"settings.defaultKm" = "设为默认";
+"settings.resetSettingsCompleted" = "设定已被重置为默认值！";
+"settings.deleteKmFailed" = "键盘映射 %@ 删除失败";
+
+"notification.appInstalled" = "应用安装成功！";
+"notification.appInstalled.message" = "立即来看一看吧!";
+
+"menubar.log.copy" = "拷贝日志";
+"menubar.documentation" = "使用手册";
+"menubar.website" = "官网";
+"menubar.github" = "GitHub（源代码发行网站）";
+"menubar.discord" = "Discord（社区交流平台）";
+"menubar.checkForUpdates" = "检查更新...";
+"menubar.clearCache" = "清除缓存";
 "menubar.configSigning" = "配置签名";
-"configSigning.info.SIP" = "SIP 需要完整禁用才可以关闭 AMFI 。";
-"configSigning.info.AMFI" = "需要关闭 AMFI，以允许对应用程序进行虚假签名，使其以正确的团队ID运行";
+
+"soundAlert.messageText" = "监测到声音设置有问题!";
+"soundAlert.informativeText" = "现有的音频设备没有设置到 48 或 44.1 kHz 采样率！应用可能会崩溃。您希望把现有的音频设备设置成 48 kHz 采样率吗?";
+"soundAlert.successText" = "当前音频设备采样率已设为 48 kHz";
+"soundAlert.failureText" = "现有音频设备设置采样率 48 KHz 失败。 您可以在 ”音频MIDI设置“ 应用里手动设置";
+
+"settings.tab.misc" = "杂项";
+"settings.button.discord" = "自定义 Discord 动态";
+"settings.button.clearActivity" = "清除自定义动态";
+"settings.text.applicationID" = "应用 ID";
+"settings.text.details" = "详细信息";
+"settings.text.details.help" = "标题下的第一行文字";
+"settings.text.image" = "图像";
+"settings.text.image.help" = "链接到图像或开发者网站的资产名称";
+"settings.text.state" = "状态";
+"settings.text.state.help" = "标题下的第二行文字";
+"settings.toggle.discord" = "启用 Discord 动态";
+"settings.toggle.hud" = "启用 Metal 性能面板";
+"settings.unavailable.hud" = "Metal HUD 不可用";
+"settings.text.debugger" = "调试器：";
+"settings.toggle.lldb" = "用 LLDB 高性能调试器打开";
+"settings.toggle.lldbWithTerminal" = "在终端里打开";
+"settings.toggle.rootWorkDir" = "在 root 目录启动应用程序";
+"settings.toggle.rootWorkDir.help" = "将应用程序的工作目录改为/，就像在iOS上一样。如果应用程序运行不正常，请关闭此功能";
+"settings.toggle.limitMotionUpdateFrequency" = "限制运动传感器更新频率";
+"settings.toggle.limitMotionUpdateFrequency.help" = "限制运动传感器更新频率以避免 CPU 使用率过高（常见于 Unity 游戏）。";
+"settings.toggle.blockSleepSpamming" = "阻止频繁调用 usleep";
+"settings.toggle.blockSleepSpamming.help" = "阻止应用频繁调用 usleep() 系统调用，以免耗尽资源";
+
 "configSigning.header" = "配置软件包签名";
 "configSigning.subtext" = "软件包签名有助于解决应用程序的问题，这些应用程序在授权等操作上依赖 \n正确的 团队ID 进行授权等操作。\n启用这一功能可能会有安全风险。\n\n因此，我们建议在不需要时禁用它";
+
+"configSigning.info.SIP" = "SIP 需要完整禁用才可以关闭 AMFI 。";
+"configSigning.info.SIPHeader" = "系统完整性保护";
+"configSigning.info.AMFI" = "需要关闭 AMFI，以允许对应用程序进行虚假签名，使其以正确的团队ID运行";
 "configSigning.info.AMFIHeader" = "苹果移动文件完整性";
 "configSigning.action.shutdown" = "将我的 Mac 关机";
 "configSigning.action.copyCommand" = "复制命令至剪贴板";
@@ -298,57 +278,18 @@
 "configSigning.step.disableAMFI" = "请禁用 AMFI";
 "configSigning.step.AMFIreboot" = "AMFI 已禁用。请重新启动";
 "configSigning.step.complete" = "软件包签名已成功配置";
-"alert.power.title" = "低电量模式已开启！";
-"alert.power.subtitle" = "部分应用程序在启用低电量模式后将无法工作。建议将其关闭。";
-"ipaLibrary.version.older" = "此版本比您已安装的应用更旧";
-"ipaLibrary.version.same" = "应用已安装";
-"ipaLibrary.version.newer" = "这个版本比你已安装的版本更高";
-"alert.differentBundleIdKeymap.message" = "此键盘映射文件有可能是为其他应用创建的。";
-"alert.differentBundleIdKeymap.text" = "您确定您要导入此键盘映射文件吗？";
-"settings.text.debugger" = "调试器：";
-"settings.toggle.lldb" = "用 LLDB 高性能调试器打开";
-"ipaLibrary.alert.download" = "您确定您要下载这个版本的 %@ 吗?";
-"ipaLibrary.download" = "下载";
-"settings.toggle.lldbWithTerminal" = "在终端里打开";
-"settings.unavailable.hud" = "Metal HUD 不可用";
-"error.failedToStripBinary" = "无法在通用二进制文件中检索到 ARM64 架构！";
-"settings.playChain.enable" = "启用 PlayChain (试验阶段)";
-"settings.playChain.help" = "在此应用启用 PlayChain 将使应用（部分）使用 Apple Keychain 服务";
-"settings.playChain.debugging" = "PlayChain 调试";
-"playapp.noSources.title" = "没有已安装的 IPA";
-"playapp.noSources.subtitle" = "当前你没有安装任何 IPA。点击下面的按钮来导入一个。";
-"settings.tab.bypasses" = "绕过";
-"playapp.download.integrityCheck" = "正在验证文件完整性:";
-"playapp.download.differentChecksum" = "校验不一致！你是否想要继续安装？";
-"playapp.download.differentChecksumDesc" = "预期为 \"%@\", 当前为 \"%@\"";
-"playapp.progress.canceled" = "已取消";
-"preferences.toggle.removePlayChain" = "移除 PlayChain";
-"button.Reload" = "刷新";
-"playapp.clearPlayChain" = "清除 PlayChain 数据";
-"playapp.importIPA" = "导入 IPA";
-"ipaLibrary.noNetworkConnection.required" = "连接网络以查看 IPA Library";
-"preferences.popover.duplicate" = "复制链接";
-"alert.app.clearPlayChain" = "所有 PlayChain 数据将被清除。您可能需要重新登录 APP。您想要继续吗?";
-"settings.highResolution" = "高画质可能会导致闪退";
-"settings.picker.windowFix" = "修复窗口化显示问题";
-"settings.picker.windowFix.help" = "启用窗口化修复也许可以让你的程序正常显示";
-"settings.picker.windowFixMethod.0" = "正常";
-"settings.picker.windowFixMethod.1" = "备用";
-"preferences.popover.checking" = "检查 URL";
-"settings.toggle.introspection" = "插入内省库";
-"settings.toggle.introspection.help" = "添加系统内省库到 app。已知可修复某些应用程序无法正确启动的问题";
-"settings.picker.scaler" = "分辨率缩放";
+
+"configSigning.alert.copied" = "命令已复制！";
+"configSigning.alert.info" = "请在 终端 中粘贴并运行该命令。您的 Mac 之后将重新启动";
+
 "keycover.masterPassword" = "主密码";
-"button.Enable" = "启用";
-"button.Reset" = "重置";
-"button.Unlock" = "解锁";
-"settings.toggle.rootWorkDir" = "在 root 目录启动应用程序";
-"settings.toggle.rootWorkDir.help" = "将应用程序的工作目录改为/，就像在iOS上一样。如果应用程序运行不正常，请关闭此功能";
 "keycover.confirmMasterPassword" = "确认主密码";
 "keycover.oldMasterPassword" = "当前主密码";
+
 "keycover.error.blankPassword" = "密码不能为空";
 "keycover.error.notMatch" = "密码不匹配";
 "keycover.error.incorrectPassword" = "密码不正确";
+
 "keycover.status.title" = "KeyCover 状态:";
 "keycover.status.managedPassword" = "使用管理密码启用";
 "keycover.status.userPassword" = "启用用户密码";
@@ -358,31 +299,38 @@
 "keycover.button.changePassword" = "更改主密码";
 "keycover.toggle.startupPrompt" = "启动时提示KeyCover";
 "keycover.toggle.startupPrompt.help" = "当您启动应用程序时，KeyCover将提示您输入主密码。如果禁用此选项，则当您启动使用PlayChain的应用程序时，系统会提示您。";
+
 "keycover.setup.useGeneratedKey" = "自动管理";
 "keycover.setup.useUserKey" = "使用我自己的密钥";
 "keycover.setup.encryptionKey" = "加密密钥: ";
 "keycover.setupPrompt.title" = "输入用于 KeyCover 的主密码";
+
 "keycover.changePasswordPrompt.title" = "输入您的旧主密码和一个新主密码以更新您的 KeyCover 加密密钥";
 "keycover.removePrompt.title" = "输入您的主密码以删除 KeyCover 加密";
+
 "keycover.unlockPrompt.title" = "输入您的主密码以解锁 KeyCover";
+
 "keycover.alert.title" = "钥匙串未解锁";
 "keycover.alert.content" = "当前会话已禁用钥匙串访问";
-"settings.toggle.autoKM" = "智能按键映射";
-"settings.toggle.autoKM.help" = "当检测到文本输入时自动禁用按键映射";
-"settings.applicationCategoryType" = "应用程序类型";
-"settings.toggle.iosFrameworks" = "强制插入iOS框架";
-"settings.info.alias" = "别名:";
-"settings.toggle.enableScrollWheel.help" = "在按键映射启用滚轮";
-"settings.toggle.iosFrameworks.help" = "将系统 ios 库添加到应用程序中。已知可修复某些应用程序找不到 ios 框架的问题";
-"settings.toggle.enableScrollWheel" = "启用滚轮";
-"ipaLibrary.info.notAvailable" = "此应用链接不可用";
-"ipaLibrary.info" = "应用信息";
-"ipaLibrary.info.checksum.none" = "未提供";
-"ipaLibrary.info.title" = "%@ 信息";
-"ipaLibrary.unavailable" = "链接不可用";
-"ipaLibrary.info.itunes" = "查找 ITunes:";
-"ipaLibrary.info.checksum" = "核对和:";
+
+"keymap.title" = "%@ 键盘映射";
+"keymap.title.import" = "导入键盘映射名称";
+"keymap.title.rename" = "重命名键盘映射名称";
+"keymap.title.empty" = "新建键盘映射";
+"keymap.sheet.name" = "键盘映射名称";
+"keymap.default" = "默认";
+
 "macos.version" = "本应用可以在 Mac App Store 中安装";
-"ipaLibrary.AlphabeticalSort" = "按字母顺序排列应用来源";
+
 "alert.install.anyway" = "仍然安装";
 "alert.open.appstore" = "打开 Mac App Store";
+"alert.appstore" = "MacOS 版本可用";
+"alert.quota.limit" = "已达到配额限制。可能需要等待最多 24 小时后才能再次下载此文件";
+"alert.notSpace" = "磁盘空间不足";
+"alert.corrupted" = "文件可能已损坏。请尝试重新下载";
+"alert.start.anyway" = "仍然启动";
+"alert.version.title" = "有新版本可用";
+"alert.version.text" = "%@ 有新版本可用。是否要下载？";
+"alert.kmImported" = "键盘映射布局已导入！";
+
+"settings.resetKmCompleted" = "键盘映射已重置！";

--- a/PlayCover/zh-Hant.lproj/Localizable.strings
+++ b/PlayCover/zh-Hant.lproj/Localizable.strings
@@ -1,198 +1,246 @@
-/* (No Comment) */
-"alert.app.delete" = "所有應用程式數據將被清除； 有些軟體可能需要重新下載數據。確定繼續？";
-
-/* (No Comment) */
-"alert.app.preferences" = "所有應用程式的偏好設定將被刪除，確定要繼續嗎？";
-
-/* (No Comment) */
-"alert.appCacheCleared" = "應用程式數據應用已被清除！";
-
-/* (No Comment) */
-"alert.error" = "遇到了問題！";
-
-/* (No Comment) */
-"alert.errorImportKm" = "導入過程中出現問題！";
-
-/* (No Comment) */
-"alert.kmImported" = "鍵盤映射佈局已導入！";
-
-/* (No Comment) */
-"alert.moveAppToApplications.move" = "移至應用程式資料夾";
-
-/* (No Comment) */
-"alert.restart" = "請重啟 PlayCover。";
-
-/* (No Comment) */
-"alert.success" = "成功";
-
-/* (No Comment) */
-"button.Cancel" = "取消";
-
-/* (No Comment) */
-"button.Close" = "關閉";
-
-/* (No Comment) */
-"button.Install" = "安裝";
-
-/* (No Comment) */
-"button.OK" = "完成";
-
-/* (No Comment) */
-"button.Proceed" = "繼續";
-
-/* (No Comment) */
-"error.corruptedIPA" = "此 .ipa 檔案已損毀，因為其中沒有包含 \"Info.plist\" 檔案。";
-
-/* (No Comment) */
-"error.waitInstallation" = "請等待安裝過程結束！";
-
-/* (No Comment) */
-"menubar.checkForUpdates" = "檢查更新...";
-
-/* (No Comment) */
-"menubar.discord" = "Discord（社區交流平台）";
-
-/* (No Comment) */
-"menubar.documentation" = "使用手冊";
-
-/* (No Comment) */
-"menubar.exportToSideloady" = "為 Sideloadly 導出";
-
-/* (No Comment) */
-"menubar.github" = "GitHub（源代碼發行網站）";
-
-/* (No Comment) */
-"menubar.log.copy" = "複製日誌";
-
-/* (No Comment) */
-"menubar.website" = "官網";
-
-/* (No Comment) */
-"notification.appInstalled" = "應用程式安裝成功！";
-
-/* (No Comment) */
-"notification.appInstalled.message" = "馬上來看一看吧!";
-
-/* (No Comment) */
-"playapp.clearCache" = "清除應用程式資料";
-
-/* (No Comment) */
-"playapp.clearPreferences" = "清除應用程式偏好設定";
-
-/* (No Comment) */
-"playapp.delete" = "解除安裝應用程式";
-
-/* (No Comment) */
-"playapp.exportKm" = "導出鍵盤映射佈局";
-
-/* (No Comment) */
-"playapp.importKm" = "導入鍵盤映射佈局";
-
-/* (No Comment) */
-"playapp.install.addToLib" = "正在將應用程式移至軟體庫...";
-
-/* (No Comment) */
-"playapp.install.copy" = "正在複製應用程式...";
-
-/* (No Comment) */
-"playapp.install.createWrapper" = "正在包裝應用程式...";
-
-/* (No Comment) */
-"playapp.progress.finished" = "完成";
-
-/* (No Comment) */
-"playapp.install.installPlayTools" = "正在安裝 PlayTools...";
-
-/* (No Comment) */
-"playapp.install.signing" = "正在為應用程式簽名...";
-
-/* (No Comment) */
-"playapp.install.unzip" = "正在從文件中提取應用程式...";
-
-/* (No Comment) */
-"playapp.openCache" = "顯示應用程式資料";
-
-/* (No Comment) */
+"playapp.add" = "新增應用程式";
+"playapp.addSource" = "新增來源";
 "playapp.settings" = "偏好設定";
-
-/* (No Comment) */
+"playapp.keymap" = "檢視鍵盤映射";
 "playapp.showInFinder" = "在 Finder 中查看";
-
-/* (No Comment) */
-"preferences.button.checkForUpdates" = "檢查更新";
-
-/* (No Comment) */
-"preferences.tab.updates" = "更新";
-
-/* (No Comment) */
-"preferences.toggle.automaticUpdates" = "自動檢查更新";
-
-/* (No Comment) */
-"settings.picker.iosDevice" = "選擇 iOS 裝置:";
-
-/* %.f */
-"settings.slider.mouseSensitivity" = "滑鼠靈敏度: %.f";
-
-/* (No Comment) */
-"settings.text.customHeight" = "高度";
-
-/* (No Comment) */
-"settings.text.customWidth" = "寬度";
-
-/* (No Comment) */
-"settings.toggle.disableDisplaySleep" = "停用螢幕休眠";
-
-/* (No Comment) */
-"settings.toggle.jbBypass" = "啟用繞過越獄檢測（預覽）";
-
-/* (No Comment) */
-"settings.toggle.km" = "啟用鍵盤映射佈局";
-
-/* (No Comment) */
-"soundAlert.failureText" = "未能成功更改現有音訊輸出設備取樣率為 48 KHz。您可以在 “音訊 MIDI 設定” 應用程式中自行手動設定";
-
-/* (No Comment) */
-"soundAlert.informativeText" = "現有的音訊設備並無 48 或 44.1 KHz 取樣率! 程式可能會崩潰。你希望把現有的音響設備設定成 48 KHz 取樣率嗎?";
-
-/* (No Comment) */
-"soundAlert.messageText" = "檢測到聲音設定有問題!";
-
-/* (No Comment) */
-"soundAlert.successText" = "現有音訊設備取樣率已設為 48 KHz";
-
-/* (No Comment) */
-"button.Quit" = "離開";
-"settings.info.bundleName" = "Bundle 名稱:";
+"playapp.openCache" = "顯示應用程式資料";
+"playapp.clearCache" = "清除應用程式資料";
+"playapp.clearPlayChain" = "清除 PlayChain 資料";
+"playapp.importIPA" = "導入 IPA";
+"playapp.importKm" = "導入鍵盤映射佈局";
+"playapp.exportKm" = "導出鍵盤映射佈局";
+"playapp.emptyKm" = "新增";
 "playapp.exportKmPanel.fieldLabel" = "PlayMap 名稱:";
+"playapp.delete" = "解除安裝應用程式";
+"playapp.deleteConfirm" = "解除安裝";
+"playapp.deleteMessage" = "你是否確定要解除安裝 %@？";
+"playapp.clearPreferences" = "清除應用程式偏好設定";
+"playapp.refreshSources" = "重新整理來源";
+"playapp.noSources.title" = "尚未安裝任何 IPA";
+"playapp.noSources.subtitle" = "暫時沒有安裝任何 IPA 文件。點擊下方的按鈕來導入一個。";
+
+"ipaLibrary.info" = "App Info";
+"ipaLibrary.info.title" = "%@ Info";
+"ipaLibrary.info.notAvailable" = "Link not valid for this app";
+"ipaLibrary.info.itunes" = "ITunes Lookup:";
+"ipaLibrary.info.checksum" = "Checksum:";
+"ipaLibrary.info.checksum.none" = "None provided";
+"ipaLibrary.noSources.title" = "尚未新增 IPA 來源";
+"ipaLibrary.noSources.subtitle" = "您目前沒有新增 IPA 來源。點擊下方的按鈕來新增一個。";
+"ipaLibrary.noSources.button" = "新增來源";
+"ipaLibrary.noNetworkConnection.toast" = "沒有網路連線！";
+"ipaLibrary.noNetworkConnection.required" = "連接實際網路以查看 IPA Library";
+"ipaLibrary.version.older" = "此版本比你已經安裝的版本更舊";
+"ipaLibrary.version.same" = "應用程式已經安裝了";
+"ipaLibrary.version.newer" = "此版本比你已經安裝的更新";
+"ipaLibrary.unavailable" = "The link is unavailable";
+"ipaLibrary.alert.download" = "你確定要下載這個版本的 %@ 嗎？";
+"ipaLibrary.download" = "下載";
+"ipaLibrary.AlphabeticalSort" = "Sort source apps alphabetically";
+
+"preferences.button.checkForUpdates" = "檢查更新";
+"preferences.tab.updates" = "更新";
+"preferences.toggle.automaticUpdates" = "自動檢查更新";
+"preferences.tab.uninstall" = "解除安裝";
+"preferences.whenUninstalling" = "解除安裝同時：";
+"preferences.toggle.showUninstall" = "顯示警告提示";
+"preferences.toggle.clearAppData" = "清理APP資料";
+"preferences.toggle.removeKeymap" = "刪除鍵盤映射";
+"preferences.toggle.removeSetting" = "移除設定";
+"preferences.toggle.removeEntitlements" = "移除授權";
+"preferences.toggle.removePlayChain" = "移除 PlayChain";
+"preferences.button.pruneFiles" = "未使用的檔案";
+"preferences.prune.alert" = "您確定要刪除所有未被使用的檔案嗎？";
+"preferences.prune.message" = "這將刪除所有未使用的檔案，包括設定、鍵盤映射、授權和應用程式數據";
+"preferences.tab.ipasource" = "IPA 來源";
+"preferences.button.addSource" = "新增來源";
+"preferences.button.deleteSource" = "刪除來源";
+"preferences.button.moveSourceUp" = "上移來源";
+"preferences.button.moveSourceDown" = "下移來源";
+"preferences.popover.valid" = "鏈結有效";
+"preferences.popover.valid.keymap" = "名稱有效";
+"preferences.popover.badurl" = "無效的鏈結!";
+"preferences.popover.malformed.keymap" = "名稱格式錯誤";
+"preferences.popover.badjson" = "JSON 無效或不存在！";
+"preferences.popover.duplicate" = "複製連結";
+"preferences.popover.duplicate.keymap" = "名稱重複";
+"preferences.popover.checking" = "檢查 URL";
+"preferences.textfield.url" = "來源URL鏈結...";
+"preferences.tab.install" = "安裝";
+"preferences.toggle.showInstallPopup" = "顯示安裝 PlayTools 彈窗";
+"preferences.toggle.alwaysInstallPlayTools" = "總是安裝 PlayTools";
+"preferences.toggle.showAppStorePopup" = "當應用程式有官方 App Store 版本時顯示提醒";
+
 "sidebar.appLibrary" = "App資料庫";
 "sidebar.ipaLibrary" = "IPA資料庫";
+"playapp.download.downloading" = "下載中";
+"playapp.download.integrityCheck" = "驗證檔案的完整性：";
+"playapp.download.differentChecksum" = "checksum 不相符！是否繼續安裝？";
+"playapp.download.differentChecksumDesc" = "預期「%@」，得到「%@」";
+"playapp.install.unzip" = "正在從文件中提取應用程式...";
+"playapp.install.createWrapper" = "正在包裝應用程式...";
+"playapp.install.installPlayTools" = "正在安裝 PlayTools...";
+"playapp.install.signing" = "正在為應用程式簽名...";
+"playapp.install.addToLib" = "正在將應用程式移至軟體庫...";
+"playapp.install.copy" = "正在複製應用程式...";
+"playapp.progress.finished" = "完成";
+"playapp.progress.failed" = "失敗";
+"playapp.progress.canceled" = "已取消";
+
+"alert.appCacheCleared" = "應用程式數據應用已被清除！";
+"alert.errorImportKm" = "導入過程中出現問題！";
+"alert.errorRenameKm" = "重新命名鍵盤映射時發生錯誤！";
+"alert.errorKmCreated" = "建立鍵盤映射時發生錯誤！";
+"alert.app.delete" = "所有應用程式數據將被清除； 有些軟體可能需要重新下載數據。確定繼續？";
+"alert.app.preferences" = "所有應用程式的偏好設定將被刪除，確定要繼續嗎？";
+"alert.app.clearPlayChain" = "所有 PlayChain 數據將被清除。您可能需要重新登錄應用程式。 您還希望繼續嗎?";
+"alert.restart" = "請重啟 PlayCover。";
+"alert.error" = "遇到了問題！";
+"alert.success" = "成功";
 "alert.moveAppToApplications.title" = "是否移動到應用程式資料夾？";
 "alert.moveAppToApplications.subtitle" = "PlayCover必須在應用程式資料夾中才能正常運作。點擊下方按鈕會使PlayCover自動移至應用程式資料夾。";
+"alert.moveAppToApplications.move" = "移至應用程式資料夾";
+"alert.legacyImport.title" = "檢測到舊版應用程式設置！";
+"alert.legacyImport.subtitle" = "檢測到舊版應用程式設置及鍵盤映射佈局。是否要把這些檔案轉換為新版格式？";
+"alert.wrongFileType.title" = "錯誤的檔案類型！";
+"alert.wrongFileType.subtitle" = "PlayCover 只可以安裝有效的 .ipa 檔案。";
+"alert.install.injectPlayTools" = "注入 PlayTools";
+"alert.install.injectPlayToolsQuestion" = "你要在這個應用程序裡面植入 PlayTools 嗎？";
+"alert.install.playToolsInformative" = "PlayTools是一個讓您將按鍵綁定到螢幕觸控，自定義顯示分辨率，和更多的工具，但它有可能會讓某些應用程序崩潰";
+"alert.supression" = "你可以在 PlayCover 偏好設定中更改";
+"alert.differentBundleIdKeymap.message" = "這個鍵盤映射文件可能是為其他應用程序創建的。";
+"alert.differentBundleIdKeymap.text" = "你確定你要導入這個鍵盤映射文件嗎？";
+"alert.power.title" = "低電量模式已啟用！";
+"alert.power.subtitle" = "有些應用程序在低電量模式開啟的情況下不能使用。建議把它禁用。";
+
+"button.OK" = "完成";
+"button.Proceed" = "繼續";
+"button.Cancel" = "取消";
+"button.Close" = "關閉";
+"button.Install" = "安裝";
+"button.Quit" = "離開";
+"button.Convert" = "轉換";
+"button.Yes" = "是";
+"button.No" = "否";
+"button.Help" = "幫助";
+"button.Dismiss" = "關閉";
+"button.Reload" = "刷新";
+"button.Enable" = "啟用";
+"button.Reset" = "重設";
+"button.Unlock" = "解鎖";
+
+"state.enabled" = "啟用";
+"state.disabled" = "禁用";
+"state.pendingReboot" = "等待重啟";
+
+"error.corruptedIPA" = "此 .ipa 檔案已損毀，因為其中沒有包含 \"Info.plist\" 檔案。";
+"error.waitInstallation" = "請等待安裝過程結束！";
+"error.waitDownload" = "請等待下載完成！";
 "error.appEncrypted" = "此應用程式已被加密！請使用未加密的IPA文件。現已不再支援使用iMazing輸出的IPA檔案！";
 "error.appCorrupted" = "此IPA檔案中包含一些錯誤。請嘗試使用其他IPA檔案。";
 "error.appProhibited" = "在PlayCover中使用這個應用程式可能會遭到封禁！";
+"error.appMaliciousProhibited" = "此應用程式在 Mac 上存在惡意行為，使用它可能會使您的設備處於無法啟動的狀態，因此它會被 PlayCover 封鎖。 （正在解除安裝...）";
+"error.failedToStripBinary" = "無法在通用二進制文件中檢索到 ARM64 架構！";
+
+"menubar.exportToSideloady" = "為 Sideloadly 導出";
+
 "settings.title" = "%@ 設定";
 "settings.tab.info" = "詳細資料";
+
 "settings.tab.km" = "鍵盤映射佈局";
+"settings.toggle.km" = "啟用鍵盤映射佈局";
 "settings.toggle.km.help" = "為僅可透過觸控螢幕操控的遊戲添加鍵盤支援。使用 Command + K 開啟編輯器選單。";
+"settings.slider.mouseSensitivity" = "滑鼠靈敏度: %.f";
+"settings.toggle.autoKM" = "智能按鍵映射";
+"settings.toggle.autoKM.help" = "當感應到文本輸入時，自動停用按鍵映射";
+"settings.toggle.enableScrollWheel" = "啟用滾輪";
+"settings.toggle.enableScrollWheel.help" = "在鍵盤映射中啟用滾輪";
+"settings.toggle.disableBuiltinMouse" = "停用內建滑鼠支援";
+"settings.toggle.disableBuiltinMouse.help" = "停用應用程式內建滑鼠支援，以避免點擊衝突。";
+
 "settings.tab.graphics" = "影像設置";
+"settings.picker.iosDevice" = "選擇 iOS 裝置:";
 "settings.picker.adaptiveRes" = "解析度:";
 "settings.picker.adaptiveRes.help" = "修改應用程式的視窗解析度";
 "settings.picker.adaptiveRes.0" = "預設解析度";
 "settings.picker.adaptiveRes.1" = "自動（根據螢幕解析度）";
 "settings.picker.adaptiveRes.5" = "自定義";
+"settings.picker.adaptiveRes.6" = "可調整大小";
+"settings.text.customHeight" = "高度";
+"settings.text.customWidth" = "寬度";
+"settings.text.detectedResolution" = "檢測到的解析度:";
 "settings.picker.aspectRatio" = "長寬比:";
+"settings.picker.aspectRatio.free" = "自由";
+"settings.picker.aspectRatio.custom" = "自訂";
+"settings.picker.windowFix" = "修復視窗模式顯示問題";
+"settings.picker.windowFix.help" = "啟用視窗修復也許可以讓你的程序正常顯示";
+"settings.picker.windowFixMethod.0" = "正常";
+"settings.picker.windowFixMethod.1" = "備用";
+"settings.toggle.disableDisplaySleep" = "停用螢幕休眠";
+"settings.settings.displayRotation" = "裝置方向";
+"settings.settings.displayRotation.default" = "預設";
+"settings.settings.displayRotation.portrait" = "直向";
+"settings.settings.displayRotation.landscapeRight" = "橫向向右";
+"settings.settings.displayRotation.portraitUpsideDown" = "直向倒置";
+"settings.settings.displayRotation.flipFix" = "翻轉修復";
 "settings.toggle.disableDisplaySleep.help" = "防止螢幕在應用程式運行期間關閉";
-"settings.info.executableName" = "可執行檔名稱:";
+"settings.toggle.hideTitleBar" = "隱藏標題列";
+"settings.toggle.floatingWindow" = "浮動視窗";
+"settings.noPlayTools" = "該應用程式沒有安裝PlayTools";
+"settings.highResolution" = "高畫質可能會導致閃退";
+"settings.picker.scaler" = "解像度縮放器";
+
+"settings.tab.bypasses" = "繞道";
+"settings.toggle.jbBypass" = "啟用繞過越獄檢測（預覽）";
 "settings.toggle.jbBypass.help" = "在部分遊戲中嘗試繞過越獄檢測（無法保證任何時候都正確運作）";
+"settings.playChain.enable" = "啟用 PlayChain (試驗階段)";
+"settings.playChain.help" = "在此應用程序啟用 PlayChain 將使應用程式（部分）使用 Apple Keychain 服務";
+"settings.playChain.debugging" = "PlayChain 調試";
+"settings.toggle.introspection" = "插入內檢庫";
+"settings.toggle.introspection.help" = "將系統自檢庫增加到應用程式中。修復了應用程式不能正確啓動的一些已知問題";
+"settings.toggle.iosFrameworks" = "強制插入 iOS 框架";
+"settings.toggle.iosFrameworks.help" = "將系統 ios 庫新增至應用程式。 已知修復某些應用程式找不到 ios 框架的問題";
+"settings.toggle.checkMicPermissionSync" = "同步檢查麥克風權限";
+"settings.toggle.checkMicPermissionSync.help" = "強制同步檢查麥克風權限。已知可修復某些應用程式提示未授予麥克風權限的問題";
+
+"settings.applicationCategoryType" = "應用程式類型";
+"settings.removePlayTools" = "移除 PlayTools";
+
 "settings.info.displayName" = "顯示名稱:";
+"settings.info.bundleName" = "Bundle 名稱:";
 "settings.info.bundleIdentifier" = "Bundle ID:";
+"settings.info.bundleVersion" = "Bundle 版本:";
+"settings.info.executableName" = "可執行檔名稱:";
 "settings.info.minimumOSVersion" = "最低作業系統版本:";
+"settings.info.playTools" = "已安裝PlayTools:";
 "settings.info.url" = "位置:";
+"settings.info.alias" = "別名：";
+
 "settings.resetSettings" = "重置偏好設定";
 "settings.resetKm" = "重置鍵盤映射佈局";
+"settings.deleteKm" = "刪除鍵盤映射";
+"settings.renameKm" = "重新命名鍵盤映射";
+"settings.defaultKm" = "設為預設";
 "settings.resetSettingsCompleted" = "偏好設定已被重置為預設值！";
-"settings.resetKmCompleted" = "鍵盤映射佈局已被重置！";
+"settings.deleteKmFailed" = "鍵盤映射 %@ 刪除失敗";
+
+"notification.appInstalled" = "應用程式安裝成功！";
+"notification.appInstalled.message" = "馬上來看一看吧!";
+
+"menubar.log.copy" = "複製日誌";
+"menubar.documentation" = "使用手冊";
+"menubar.website" = "官網";
+"menubar.github" = "GitHub（源代碼發行網站）";
+"menubar.discord" = "Discord（社區交流平台）";
+"menubar.checkForUpdates" = "檢查更新...";
+"menubar.clearCache" = "清理快取";
+"menubar.configSigning" = "配置簽署";
+
+"soundAlert.messageText" = "檢測到聲音設定有問題!";
+"soundAlert.informativeText" = "現有的音訊設備並無 48 或 44.1 KHz 取樣率! 程式可能會崩潰。你希望把現有的音響設備設定成 48 KHz 取樣率嗎?";
+"soundAlert.successText" = "現有音訊設備取樣率已設為 48 KHz";
+"soundAlert.failureText" = "未能成功更改現有音訊輸出設備取樣率為 48 KHz。您可以在 “音訊 MIDI 設定” 應用程式中自行手動設定";
+
 "settings.tab.misc" = "雜項";
 "settings.button.discord" = "自訂 Discord 動態";
 "settings.button.clearActivity" = "清除自定義動態";
@@ -205,66 +253,20 @@
 "settings.text.state.help" = "標題下方第二列";
 "settings.toggle.discord" = "啟用Discord動態";
 "settings.toggle.hud" = "啟用Metal HUD";
-"settings.info.bundleVersion" = "Bundle 版本:";
-"playapp.deleteConfirm" = "解除安裝";
-"playapp.deleteMessage" = "你是否確定要解除安裝 %@？";
-"alert.legacyImport.title" = "檢測到舊版應用程式設置！";
-"alert.legacyImport.subtitle" = "檢測到舊版應用程式設置及鍵盤映射佈局。是否要把這些檔案轉換為新版格式？";
-"button.Convert" = "轉換";
-"settings.text.detectedResolution" = "檢測到的解析度:";
-"playapp.add" = "新增應用程式";
-"alert.wrongFileType.title" = "錯誤的檔案類型！";
-"alert.wrongFileType.subtitle" = "PlayCover 只可以安裝有效的 .ipa 檔案。";
-"playapp.addSource" = "新增來源";
-"ipaLibrary.noSources.title" = "尚未新增 IPA 來源";
-"ipaLibrary.noSources.subtitle" = "您目前沒有新增 IPA 來源。點擊下方的按鈕來新增一個。";
-"ipaLibrary.noSources.button" = "新增來源";
-"ipaLibrary.noNetworkConnection.toast" = "沒有網路連線！";
-"preferences.tab.ipasource" = "IPA 來源";
-"preferences.button.addSource" = "新增來源";
-"preferences.button.deleteSource" = "刪除來源";
-"preferences.button.moveSourceUp" = "上移來源";
-"preferences.button.moveSourceDown" = "下移來源";
-"preferences.popover.valid" = "鏈結有效";
-"preferences.popover.badurl" = "無效的鏈結!";
-"preferences.popover.badjson" = "JSON 無效或不存在！";
-"preferences.textfield.url" = "來源URL鏈結...";
-"playapp.download.downloading" = "下載中";
-"error.waitDownload" = "請等待下載完成！";
-"preferences.tab.uninstall" = "解除安裝";
-"preferences.whenUninstalling" = "解除安裝同時：";
-"preferences.toggle.showUninstall" = "顯示警告提示";
-"preferences.toggle.clearAppData" = "清理APP資料";
-"preferences.toggle.removeKeymap" = "刪除鍵盤映射";
-"preferences.toggle.removeSetting" = "移除設定";
-"preferences.toggle.removeEntitlements" = "移除授權";
-"preferences.button.pruneFiles" = "未使用的檔案";
-"preferences.prune.alert" = "您確定要刪除所有未被使用的檔案嗎？";
-"preferences.prune.message" = "這將刪除所有未使用的檔案，包括設定、鍵盤映射、授權和應用程式數據";
-"playapp.progress.failed" = "失敗";
-"alert.supression" = "你可以在 PlayCover 偏好設定中更改";
-"menubar.clearCache" = "清理快取";
-"preferences.tab.install" = "安裝";
-"preferences.toggle.showInstallPopup" = "顯示安裝 PlayTools 彈窗";
-"preferences.toggle.alwaysInstallPlayTools" = "總是安裝 PlayTools";
-"settings.removePlayTools" = "移除 PlayTools";
-"settings.info.playTools" = "已安裝PlayTools:";
-"alert.install.injectPlayTools" = "注入 PlayTools";
-"button.Yes" = "是";
-"button.No" = "否";
-"settings.noPlayTools" = "該應用程式沒有安裝PlayTools";
-"playapp.refreshSources" = "重新整理來源";
-"error.appMaliciousProhibited" = "此應用程式在 Mac 上存在惡意行為，使用它可能會使您的設備處於無法啟動的狀態，因此它會被 PlayCover 封鎖。 （正在解除安裝...）";
-"alert.install.injectPlayToolsQuestion" = "你要在這個應用程序裡面植入 PlayTools 嗎？";
-"alert.install.playToolsInformative" = "PlayTools是一個讓您將按鍵綁定到螢幕觸控，自定義顯示分辨率，和更多的工具，但它有可能會讓某些應用程序崩潰";
-"button.Help" = "幫助";
-"button.Dismiss" = "關閉";
-"state.enabled" = "啟用";
-"state.disabled" = "禁用";
-"state.pendingReboot" = "等待重啟";
-"menubar.configSigning" = "配置簽署";
+"settings.unavailable.hud" = "Metal HUD 不可用";
+"settings.text.debugger" = "調試器：";
+"settings.toggle.lldb" = "用 LLDB 高性能調試器打開";
+"settings.toggle.lldbWithTerminal" = "用終端機打開";
+"settings.toggle.rootWorkDir" = "在根目錄下啓動應用程式";
+"settings.toggle.rootWorkDir.help" = "將應用程式的工作目錄改為/，就像在 iOS 上一樣。如果應用程式表現不正常，請將其關閉";
+"settings.toggle.limitMotionUpdateFrequency" = "限制動作感測器更新頻率";
+"settings.toggle.limitMotionUpdateFrequency.help" = "限制動作感測器更新頻率以避免 CPU 使用率過高（常見於 Unity 遊戲）。";
+"settings.toggle.blockSleepSpamming" = "阻止頻繁呼叫 usleep";
+"settings.toggle.blockSleepSpamming.help" = "阻止應用程式頻繁呼叫 usleep() 系統呼叫，以免耗盡資源";
+
 "configSigning.header" = "配置應用程式包簽名";
 "configSigning.subtext" = "應用程式包簽名幫助修復需要依靠正確 團隊 ID\n來處理身分驗證等操作的應用程序。\n這個功能有可能會帶來風險。\n\n因此，我們建議在不必要的情況下禁用它";
+
 "configSigning.info.SIP" = "部分的 系統完整性保護（SIP）需要禁用，以便關閉 蘋果移動文件完整性（AMFI）.";
 "configSigning.info.SIPHeader" = "系統完整性保護";
 "configSigning.info.AMFI" = "蘋果移動文件完整性（AMFI）需要關閉以允許應用程序假簽名，以便它們使用正確的 團隊ID 運行";
@@ -276,93 +278,59 @@
 "configSigning.step.disableAMFI" = "請禁用AMFI";
 "configSigning.step.AMFIreboot" = "蘋果移動文件完整性 已禁用。請重啟電腦";
 "configSigning.step.complete" = "應用程式包簽名已成功配置";
+
 "configSigning.alert.copied" = "命令已複製！";
 "configSigning.alert.info" = "請在終端機內貼上並執行此命令。稍後你的 Mac 將重啟";
-"alert.power.title" = "低電量模式已啟用！";
-"alert.power.subtitle" = "有些應用程序在低電量模式開啟的情況下不能使用。建議把它禁用。";
-"ipaLibrary.version.older" = "此版本比你已經安裝的版本更舊";
-"ipaLibrary.version.same" = "應用程式已經安裝了";
-"ipaLibrary.version.newer" = "此版本比你已經安裝的更新";
-"ipaLibrary.alert.download" = "你確定要下載這個版本的 %@ 嗎？";
-"ipaLibrary.download" = "下載";
-"alert.differentBundleIdKeymap.message" = "這個鍵盤映射文件可能是為其他應用程序創建的。";
-"alert.differentBundleIdKeymap.text" = "你確定你要導入這個鍵盤映射文件嗎？";
-"settings.text.debugger" = "調試器：";
-"settings.toggle.lldb" = "用 LLDB 高性能調試器打開";
-"settings.toggle.lldbWithTerminal" = "用終端機打開";
-"settings.unavailable.hud" = "Metal HUD 不可用";
-"settings.playChain.debugging" = "PlayChain 調試";
-"error.failedToStripBinary" = "無法在通用二進制文件中檢索到 ARM64 架構！";
-"settings.playChain.enable" = "啟用 PlayChain (試驗階段)";
-"settings.playChain.help" = "在此應用程序啟用 PlayChain 將使應用程式（部分）使用 Apple Keychain 服務";
-"playapp.noSources.title" = "尚未安裝任何 IPA";
-"playapp.noSources.subtitle" = "暫時沒有安裝任何 IPA 文件。點擊下方的按鈕來導入一個。";
-"settings.tab.bypasses" = "繞道";
-"playapp.download.integrityCheck" = "驗證檔案的完整性：";
-"playapp.download.differentChecksum" = "checksum 不相符！是否繼續安裝？";
-"playapp.download.differentChecksumDesc" = "預期「%@」，得到「%@」";
-"playapp.progress.canceled" = "已取消";
-"playapp.importIPA" = "導入 IPA";
-"preferences.popover.duplicate" = "複製連結";
-"button.Reload" = "刷新";
-"playapp.clearPlayChain" = "清除 PlayChain 資料";
-"ipaLibrary.noNetworkConnection.required" = "連接實際網路以查看 IPA Library";
-"preferences.toggle.removePlayChain" = "移除 PlayChain";
-"alert.app.clearPlayChain" = "所有 PlayChain 數據將被清除。您可能需要重新登錄應用程式。 您還希望繼續嗎?";
-"settings.highResolution" = "高畫質可能會導致閃退";
-"settings.picker.windowFix" = "修復視窗模式顯示問題";
-"settings.picker.windowFix.help" = "啟用視窗修復也許可以讓你的程序正常顯示";
-"settings.picker.windowFixMethod.0" = "正常";
-"settings.picker.windowFixMethod.1" = "備用";
-"preferences.popover.checking" = "檢查 URL";
-"settings.toggle.introspection" = "插入內檢庫";
-"settings.toggle.introspection.help" = "將系統自檢庫增加到應用程式中。修復了應用程式不能正確啓動的一些已知問題";
-"settings.picker.scaler" = "解像度縮放器";
-"settings.toggle.rootWorkDir" = "在根目錄下啓動應用程式";
+
 "keycover.masterPassword" = "主密碼";
-"keycover.button.changePassword" = "更改主密碼";
-"button.Enable" = "啟用";
-"button.Reset" = "重設";
-"button.Unlock" = "解鎖";
-"settings.toggle.rootWorkDir.help" = "將應用程式的工作目錄改為/，就像在 iOS 上一樣。如果應用程式表現不正常，請將其關閉";
 "keycover.confirmMasterPassword" = "確認主密碼";
 "keycover.oldMasterPassword" = "目前主密碼";
+
 "keycover.error.blankPassword" = "密碼不能留空";
 "keycover.error.notMatch" = "密碼不符合";
 "keycover.error.incorrectPassword" = "密碼不正確";
+
 "keycover.status.title" = "KeyCover 狀態：";
 "keycover.status.managedPassword" = "已通過受管理密碼啓用";
 "keycover.status.userPassword" = "已通過使用者密碼啓用";
 "keycover.status.chainCount" = "KeyCover Chain 狀態： ";
 "keycover.status.unlockedCount %@ %@" = "%@ 個已解鎖鏈（共 %@ 個）";
 "keycover.button.lockAll" = "鎖定所有鏈";
+"keycover.button.changePassword" = "更改主密碼";
 "keycover.toggle.startupPrompt" = "啓動時提示使用 KeyCover";
 "keycover.toggle.startupPrompt.help" = "當你啓動應用程式時，KeyCover 會彈出視窗要求主密碼。如果停用這個功能，則當你啓動使用 PlayChain 的應用程式時才會彈出視窗。";
+
 "keycover.setup.useGeneratedKey" = "已自動管理";
 "keycover.setup.useUserKey" = "使用我自己的鑰匙";
 "keycover.setup.encryptionKey" = "加密密鑰： ";
 "keycover.setupPrompt.title" = "輸入一個用於 KeyCover 的主密碼";
+
 "keycover.changePasswordPrompt.title" = "輸入你的舊主密碼和新密碼，以更新你的 KeyCover 加密密鑰";
 "keycover.removePrompt.title" = "輸入主密碼以刪除 KeyCover 加密";
+
 "keycover.unlockPrompt.title" = "輸入你的主密碼以解鎖 KeyCover";
+
 "keycover.alert.title" = "鑰匙圈未解鎖";
 "keycover.alert.content" = "已停用目前工作階段的密鑰圈存取";
-"settings.toggle.autoKM" = "智能按鍵映射";
-"settings.toggle.autoKM.help" = "當感應到文本輸入時，自動停用按鍵映射";
-"settings.applicationCategoryType" = "應用程式類型";
-"settings.toggle.iosFrameworks" = "強制插入 iOS 框架";
-"settings.info.alias" = "別名：";
-"settings.toggle.enableScrollWheel.help" = "在鍵盤映射中啟用滾輪";
-"settings.toggle.iosFrameworks.help" = "將系統 ios 庫新增至應用程式。 已知修復某些應用程式找不到 ios 框架的問題";
-"settings.toggle.enableScrollWheel" = "啟用滾輪";
-"ipaLibrary.info.notAvailable" = "Link not valid for this app";
-"ipaLibrary.info" = "App Info";
-"ipaLibrary.info.checksum.none" = "None provided";
-"ipaLibrary.info.title" = "%@ Info";
-"ipaLibrary.unavailable" = "The link is unavailable";
-"ipaLibrary.info.itunes" = "ITunes Lookup:";
-"ipaLibrary.info.checksum" = "Checksum:";
-"alert.open.appstore" = "Open Mac App Store";
+
+"keymap.title" = "%@ 鍵盤映射";
+"keymap.title.import" = "匯入鍵盤映射名稱";
+"keymap.title.rename" = "重新命名鍵盤映射名稱";
+"keymap.title.empty" = "新增鍵盤映射";
+"keymap.sheet.name" = "鍵盤映射名稱";
+"keymap.default" = "預設";
+
 "macos.version" = "This app can be installed from Mac App Store";
-"ipaLibrary.AlphabeticalSort" = "Sort source apps alphabetically";
+
 "alert.install.anyway" = "Install Anyway";
+"alert.open.appstore" = "Open Mac App Store";
+"alert.appstore" = "MacOS 版本可用";
+"alert.quota.limit" = "已達到配額限制。可能需要等待最多 24 小時後才能再次下載此檔案";
+"alert.notSpace" = "磁碟空間不足";
+"alert.corrupted" = "檔案可能已損毀。請嘗試重新下載";
+"alert.start.anyway" = "仍然啟動";
+"alert.version.title" = "有新版本可用";
+"alert.version.text" = "%@ 有新版本可用。是否要下載？";
+"alert.kmImported" = "鍵盤映射佈局已導入！";
+
+"settings.resetKmCompleted" = "鍵盤映射佈局已被重置！";


### PR DESCRIPTION
Refresh Simplified and Traditional Chinese Localizable.strings: add and reorganize many new keys and translations for PlayCover UI (playapp, ipaLibrary, preferences, settings, keymap, menus, menubar, sound alerts, config signing, keycover, etc.). Includes new settings-related strings (display rotation options, graphics/keyboard/mouse settings, PlayTools, PlayChain, bypasses), fixes duplicated/obsolete entries, and provides missing translations to match recent UI/feature changes.