### PR TITLE
feat: add toggle to ignore Unity keyboard initialization error

### DIFF
--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -51,6 +51,7 @@ struct AppSettingsData: Codable {
     var resizableAspectRatioWidth = 0
     var resizableAspectRatioHeight = 0
     var blockSleepSpamming = false
+    var ignoreUnityKeyboardInitializationError = false
 
     init() {}
 
@@ -92,6 +93,8 @@ struct AppSettingsData: Codable {
         resizableAspectRatioWidth = try container.decodeIfPresent(Int.self, forKey: .resizableAspectRatioWidth) ?? 0
         resizableAspectRatioHeight = try container.decodeIfPresent(Int.self, forKey: .resizableAspectRatioHeight) ?? 0
         blockSleepSpamming = try container.decodeIfPresent(Bool.self, forKey: .blockSleepSpamming) ?? false
+        ignoreUnityKeyboardInitializationError = try container.decodeIfPresent(
+            Bool.self, forKey: .ignoreUnityKeyboardInitializationError) ?? false
     }
 }
 

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -795,6 +795,15 @@ struct MiscView: View {
                         .help("settings.toggle.limitMotionUpdateFrequency.help")
                     Spacer()
                 }
+                Spacer()
+                    .frame(height: 20)
+                HStack {
+                    Toggle("settings.toggle.ignoreUnityKeyboardInitializationError",
+                           isOn: $settings.settings.ignoreUnityKeyboardInitializationError)
+                        .disabled(!(hasPlayTools ?? true))
+                        .help("settings.toggle.ignoreUnityKeyboardInitializationError.help")
+                    Spacer()
+                }
             }
             .padding()
         }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -265,6 +265,8 @@
 "settings.toggle.limitMotionUpdateFrequency.help" = "Limit the frequency of motion sensor updates to avoid excessive CPU usage (often occurs in Unity games).";
 "settings.toggle.blockSleepSpamming" = "Prevent usleep call spamming";
 "settings.toggle.blockSleepSpamming.help" = "Prevent the app from spamming the usleep() syscall which may cause resource exhaustion";
+"settings.toggle.ignoreUnityKeyboardInitializationError" = "Ignore Unity keyboard initialization error";
+"settings.toggle.ignoreUnityKeyboardInitializationError.help" = "Prevent a crash caused by the assertion failure \"[KeyboardDelegate Initialize] called after creating keyboard\"";
 
 
 "configSigning.header" = "Configure Package Signing";


### PR DESCRIPTION
<img width="623" height="422" alt="screenshot" src="https://github.com/user-attachments/assets/87b57255-a750-47d2-972e-6092b1c03287" />
<br/><br/>

Issues: https://github.com/PlayCover/PlayCover/issues/1442 https://github.com/PlayCover/PlayCover/issues/1598 https://github.com/PlayCover/PlayCover/issues/1925 https://github.com/PlayCover/PlayCover/issues/2127 https://github.com/PlayCover/PlayCover/issues/2135 https://github.com/PlayCover/PlayCover/issues/2143

**Note: This PR requires the corresponding changes in  https://github.com/PlayCover/PlayTools/pull/224.**

