### PR TITLE
feat: add network capture through a debugging proxy

### DIFF
--- a/PlayCover.xcodeproj/project.pbxproj
+++ b/PlayCover.xcodeproj/project.pbxproj
@@ -66,6 +66,9 @@
 		92EE06DA274EB009002C907B /* PlayApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE06D9274EB009002C907B /* PlayApp.swift */; };
 		92EE06DE274EC09F002C907B /* Entitlements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE06DD274EC09F002C907B /* Entitlements.swift */; };
 		92F8500A27675124005CE6BE /* AppIntegrity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F8500927675124005CE6BE /* AppIntegrity.swift */; };
+		A1B2C3D002000000000000A1 /* NetworkCaptureSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D001000000000000A1 /* NetworkCaptureSettings.swift */; };
+		A1B2C3D004000000000000A1 /* NetworkCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D003000000000000A1 /* NetworkCaptureService.swift */; };
+		A1B2C3D006000000000000A1 /* SystemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D005000000000000A1 /* SystemProxy.swift */; };
 		A25930F42C49E2BC0006C91C /* PlayAppVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25930F32C49E2BC0006C91C /* PlayAppVM.swift */; };
 		AA719649287A0E2500623C15 /* default.yaml in Resources */ = {isa = PBXBuildFile; fileRef = AA719647287A0E2500623C15 /* default.yaml */; };
 		AA71964B287A0EA800623C15 /* PlayRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA71964A287A0EA800623C15 /* PlayRules.swift */; };
@@ -176,6 +179,9 @@
 		92EE06D9274EB009002C907B /* PlayApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayApp.swift; sourceTree = "<group>"; };
 		92EE06DD274EC09F002C907B /* Entitlements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entitlements.swift; sourceTree = "<group>"; };
 		92F8500927675124005CE6BE /* AppIntegrity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntegrity.swift; sourceTree = "<group>"; };
+		A1B2C3D001000000000000A1 /* NetworkCaptureSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkCaptureSettings.swift; sourceTree = "<group>"; };
+		A1B2C3D003000000000000A1 /* NetworkCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkCaptureService.swift; sourceTree = "<group>"; };
+		A1B2C3D005000000000000A1 /* SystemProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemProxy.swift; sourceTree = "<group>"; };
 		A25930F32C49E2BC0006C91C /* PlayAppVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayAppVM.swift; sourceTree = "<group>"; };
 		AA719647287A0E2500623C15 /* default.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = default.yaml; sourceTree = "<group>"; };
 		AA71964A287A0EA800623C15 /* PlayRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayRules.swift; sourceTree = "<group>"; };
@@ -282,6 +288,8 @@
 			children = (
 				53F3802726EB6F6B00D6B525 /* NotifyService.swift */,
 				9280871A2824A8D20034C510 /* SoundDeviceService.swift */,
+				A1B2C3D003000000000000A1 /* NetworkCaptureService.swift */,
+				A1B2C3D005000000000000A1 /* SystemProxy.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -299,6 +307,7 @@
 				6E7CA16428B4D02900216CD8 /* ITunesResponse.swift */,
 				6E7CA16628B4EEAE00216CD8 /* KeymapData.swift */,
 				B6AB53C829232B4F00039B2E /* KeyCodeNames.swift */,
+				A1B2C3D001000000000000A1 /* NetworkCaptureSettings.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -397,6 +406,7 @@
 				53841CC826D9D7920021D27C /* Frameworks */,
 			);
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		8783CFF826B8C52D00171041 /* Products */ = {
 			isa = PBXGroup;
@@ -487,7 +497,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1410;
+				LastUpgradeCheck = 2660;
 				TargetAttributes = {
 					8783CFF626B8C52D00171041 = {
 						CreatedOnToolsVersion = 12.5.1;
@@ -672,6 +682,9 @@
 				53F50C4926E3CA42007AD2D3 /* AppLibraryView.swift in Sources */,
 				6E66B0D1289F57B00099B907 /* Documentation.docc in Sources */,
 				53F3802826EB6F6B00D6B525 /* NotifyService.swift in Sources */,
+				A1B2C3D002000000000000A1 /* NetworkCaptureSettings.swift in Sources */,
+				A1B2C3D004000000000000A1 /* NetworkCaptureService.swift in Sources */,
+				A1B2C3D006000000000000A1 /* SystemProxy.swift in Sources */,
 				6E5C68BA289865C8008EC11B /* MainView.swift in Sources */,
 				3447B5E52E28B46800FAA22F /* KeymapViewVM.swift in Sources */,
 				B1419FB628BA82EE000CB69F /* DiscordActivity.swift in Sources */,
@@ -753,7 +766,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = arm64;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -787,8 +799,10 @@
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = Z4BW6Q86VY;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				EXCLUDED_ARCHS = x86_64;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -804,6 +818,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				RUN_DOCUMENTATION_COMPILER = NO;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_ENFORCE_EXCLUSIVE_ACCESS = off;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -813,22 +828,27 @@
 		8783D00926B8C52E00171041 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon${BUNDLE_ID_SUFFIX}";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				AUTOMATION_APPLE_EVENTS = YES;
 				BUNDLE_ID_SUFFIX = "";
 				CODE_SIGN_ENTITLEMENTS = PlayCover/PlayCoverRelease.entitlements;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 856;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "PlayCover/Preview\\ Content";
-				DEVELOPMENT_TEAM = 792V9HMJW3;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
 				EXCLUDED_ARCHS = x86_64;
 				INFOPLIST_FILE = PlayCover/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -842,7 +862,13 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = io.playcover.PlayCover;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match Direct io.playcover.PlayCover macos";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = YES;
+				RUNTIME_EXCEPTION_ALLOW_JIT = YES;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = YES;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = YES;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = YES;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = YES;
 				RUN_DOCUMENTATION_COMPILER = NO;
 				SWIFT_ENFORCE_EXCLUSIVE_ACCESS = off;
 				SWIFT_OBJC_BRIDGING_HEADER = "./PlayCover/PlayCover-Bridging-Header.h";
@@ -856,7 +882,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = arm64;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -890,8 +915,10 @@
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = Z4BW6Q86VY;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				EXCLUDED_ARCHS = x86_64;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -907,6 +934,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				RUN_DOCUMENTATION_COMPILER = NO;
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_ENFORCE_EXCLUSIVE_ACCESS = off;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -916,22 +944,27 @@
 		9BFBDA6828C95BA500252EB7 /* Nightly */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon${BUNDLE_ID_SUFFIX}";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				AUTOMATION_APPLE_EVENTS = YES;
 				BUNDLE_ID_SUFFIX = .dev;
 				CODE_SIGN_ENTITLEMENTS = PlayCover/PlayCoverRelease.entitlements;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 856;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "PlayCover/Preview\\ Content";
-				DEVELOPMENT_TEAM = 792V9HMJW3;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
 				EXCLUDED_ARCHS = x86_64;
 				INFOPLIST_FILE = PlayCover/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -945,7 +978,13 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = io.playcover.PlayCover;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match Direct io.playcover.PlayCover macos";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = YES;
+				RUNTIME_EXCEPTION_ALLOW_JIT = YES;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = YES;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = YES;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = YES;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = YES;
 				RUN_DOCUMENTATION_COMPILER = NO;
 				SWIFT_ENFORCE_EXCLUSIVE_ACCESS = off;
 				SWIFT_OBJC_BRIDGING_HEADER = "./PlayCover/PlayCover-Bridging-Header.h";

--- a/PlayCover/Model/AppSettings.swift
+++ b/PlayCover/Model/AppSettings.swift
@@ -52,6 +52,7 @@ struct AppSettingsData: Codable {
     var resizableAspectRatioHeight = 0
     var blockSleepSpamming = false
     var ignoreUnityKeyboardInitializationError = false
+    var networkCapture = NetworkCaptureSettings()
 
     init() {}
 
@@ -95,7 +96,24 @@ struct AppSettingsData: Codable {
         blockSleepSpamming = try container.decodeIfPresent(Bool.self, forKey: .blockSleepSpamming) ?? false
         ignoreUnityKeyboardInitializationError = try container.decodeIfPresent(
             Bool.self, forKey: .ignoreUnityKeyboardInitializationError) ?? false
+        if let capture = try container.decodeIfPresent(NetworkCaptureSettings.self, forKey: .networkCapture) {
+            networkCapture = capture
+        } else {
+            // Carry over settings written under the previous "reqable" key
+            let raw = try decoder.container(keyedBy: RawCodingKey.self)
+            networkCapture = (try? raw.decodeIfPresent(NetworkCaptureSettings.self,
+                                                       forKey: RawCodingKey("reqable"))) ?? NetworkCaptureSettings()
+        }
     }
+}
+
+/// A coding key built from an arbitrary string, for reading legacy keys by name.
+private struct RawCodingKey: CodingKey {
+    let stringValue: String
+    var intValue: Int? { nil }
+    init(_ stringValue: String) { self.stringValue = stringValue }
+    init?(stringValue: String) { self.stringValue = stringValue }
+    init?(intValue: Int) { nil }
 }
 
 class AppSettings {

--- a/PlayCover/Model/NetworkCaptureSettings.swift
+++ b/PlayCover/Model/NetworkCaptureSettings.swift
@@ -1,0 +1,65 @@
+//
+//  NetworkCaptureSettings.swift
+//  PlayCover
+//
+
+import Foundation
+
+/// Per app configuration for capturing network traffic through a debugging proxy.
+///
+/// PlayCover apps use CFNetwork, which reads its proxy configuration from the system
+/// network settings, so capturing works the same way as pointing a phone at a debugging
+/// proxy: route the traffic through the proxy and trust its root certificate. The proxy
+/// can run on this Mac or on another machine, which also covers remote debugging.
+struct NetworkCaptureSettings: Codable, Equatable {
+    static let defaultHost = "127.0.0.1"
+    static let defaultPort = 8080
+
+    /// Route this app's traffic through the proxy when it is launched.
+    var enable = false
+
+    /// Address the proxy is listening on. Loopback for a proxy on this Mac, or the LAN /
+    /// remote address of the machine running it.
+    var host = NetworkCaptureSettings.defaultHost
+
+    /// Port of the proxy server.
+    var port = NetworkCaptureSettings.defaultPort
+
+    /// Point the macOS network proxy at the address above while the app is running, and
+    /// put the previous settings back when it quits. This is what CFNetwork based apps
+    /// follow.
+    var setSystemProxy = true
+
+    /// Also pass `http_proxy` style variables to the app. CFNetwork ignores these, but
+    /// engines bundling their own networking stack (Unity, cURL, gRPC) tend to read them.
+    var setEnvironmentVariables = true
+
+    /// Comma separated hosts that should not be captured, e.g. `*.apple.com, localhost`.
+    var bypassDomains = ""
+
+    init() {}
+
+    /// Decoded leniently so that settings written by an older PlayCover keep working.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        enable = try container.decodeIfPresent(Bool.self, forKey: .enable) ?? false
+        host = try container.decodeIfPresent(String.self, forKey: .host) ?? NetworkCaptureSettings.defaultHost
+        port = try container.decodeIfPresent(Int.self, forKey: .port) ?? NetworkCaptureSettings.defaultPort
+        setSystemProxy = try container.decodeIfPresent(Bool.self, forKey: .setSystemProxy) ?? true
+        setEnvironmentVariables = try container.decodeIfPresent(Bool.self, forKey: .setEnvironmentVariables) ?? true
+        bypassDomains = try container.decodeIfPresent(String.self, forKey: .bypassDomains) ?? ""
+    }
+
+    /// Hosts to exclude from capture, as separate entries.
+    var bypassList: [String] {
+        bypassDomains
+            .split(whereSeparator: { $0 == "," || $0 == ";" || $0.isNewline })
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// `true` when the address the user typed can actually be dialled.
+    var isValid: Bool {
+        !host.trimmingCharacters(in: .whitespaces).isEmpty && (1...65535).contains(port)
+    }
+}

--- a/PlayCover/Model/PlayApp.swift
+++ b/PlayCover/Model/PlayApp.swift
@@ -162,11 +162,24 @@ extension PlayApp {
             unsetenv(key)
         }
 
+        // Route the app's traffic through the capture proxy, for as long as it is running
+        let isCaptured = NetworkCaptureService.shared.beginCapture(for: self)
+        if isCaptured && settings.settings.networkCapture.setEnvironmentVariables {
+            config.environment = ProcessInfo.processInfo.environment
+                .merging(NetworkCaptureService.shared
+                    .proxyEnvironment(settings.settings.networkCapture)) { _, proxy in proxy }
+        }
+
         NSWorkspace.shared.openApplication(
             at: aliasURL,
             configuration: config,
             completionHandler: { runningApp, error in
-                guard error == nil else { return }
+                guard error == nil else {
+                    if isCaptured {
+                        NetworkCaptureService.shared.endCapture(for: self)
+                    }
+                    return
+                }
                 // Run a thread loop in the background to handle background tasks
                 Task(priority: .background) {
                     if let runningApp = runningApp {
@@ -181,6 +194,9 @@ extension PlayApp {
                         sleep(1)
                     }
                     // Things that are run after the app is closed
+                    if isCaptured {
+                        NetworkCaptureService.shared.endCapture(for: self)
+                    }
                     self.lockKeyCover()
                 }
             }

--- a/PlayCover/Services/NetworkCaptureService.swift
+++ b/PlayCover/Services/NetworkCaptureService.swift
@@ -1,0 +1,231 @@
+//
+//  NetworkCaptureService.swift
+//  PlayCover
+//
+
+import AppKit
+import Foundation
+
+/// Routes a PlayCover app's traffic through a debugging proxy, the same way a phone is
+/// pointed at one.
+///
+/// Apps launched by PlayCover are iOS apps running on macOS, so their networking goes
+/// through CFNetwork, which takes its proxy configuration from the macOS network
+/// settings rather than from the process environment. Capturing an app therefore means
+/// pointing the system proxy at the chosen address for as long as the app runs. The
+/// address may be on this Mac or on another machine, which also covers remote debugging.
+final class NetworkCaptureService {
+    static let shared = NetworkCaptureService()
+
+    /// Where a previously applied proxy configuration is parked, so it can be put back
+    /// even if PlayCover is killed while an app is being captured.
+    static var backupURL: URL {
+        PlayTools.playCoverContainer.appendingPathComponent("NetworkCaptureProxyBackup.plist")
+    }
+
+    private let lock = NSLock()
+
+    /// Bundle identifiers of the apps currently being captured.
+    private var capturingApps = Set<String>()
+
+    private init() {}
+
+    /// Opens a TCP connection to check that something is actually listening for us.
+    /// The Network framework is unavailable here, as this target searches the private
+    /// frameworks directory, where a different Network.framework shadows the public one.
+    func isProxyReachable(host: String, port: Int, timeout: TimeInterval = 2) -> Bool {
+        var hints = addrinfo()
+        hints.ai_family = AF_UNSPEC
+        hints.ai_socktype = SOCK_STREAM
+
+        var resolved: UnsafeMutablePointer<addrinfo>?
+        guard getaddrinfo(host, String(port), &hints, &resolved) == 0 else { return false }
+        defer { freeaddrinfo(resolved) }
+
+        var candidate = resolved
+        while let address = candidate {
+            if canConnect(to: address.pointee, timeout: timeout) { return true }
+            candidate = address.pointee.ai_next
+        }
+
+        return false
+    }
+
+    private func canConnect(to address: addrinfo, timeout: TimeInterval) -> Bool {
+        let descriptor = socket(address.ai_family, address.ai_socktype, address.ai_protocol)
+        guard descriptor >= 0 else { return false }
+        defer { close(descriptor) }
+
+        // Connect without blocking, so a proxy that is not there cannot hold up a launch
+        let flags = fcntl(descriptor, F_GETFL, 0)
+        guard flags >= 0, fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) >= 0 else { return false }
+
+        if connect(descriptor, address.ai_addr, address.ai_addrlen) == 0 { return true }
+        guard errno == EINPROGRESS else { return false }
+
+        var pending = pollfd(fd: descriptor, events: Int16(POLLOUT), revents: 0)
+        guard poll(&pending, 1, Int32(timeout * 1000)) == 1 else { return false }
+
+        // A refused connection also wakes up poll, so ask the socket how it went
+        var failure: Int32 = 0
+        var length = socklen_t(MemoryLayout<Int32>.size)
+        guard getsockopt(descriptor, SOL_SOCKET, SO_ERROR, &failure, &length) == 0 else { return false }
+
+        return failure == 0
+    }
+}
+
+// MARK: - Capture sessions
+
+extension NetworkCaptureService {
+    /// Starts routing traffic through the proxy for `app`. Returns whether a session was
+    /// started, so the caller knows if it has to be ended later.
+    @discardableResult
+    func beginCapture(for app: PlayApp) -> Bool {
+        let settings = app.settings.settings.networkCapture
+
+        guard settings.enable, settings.isValid else { return false }
+
+        if !isProxyReachable(host: settings.host, port: settings.port) {
+            Log.shared.log("No proxy is listening on \(settings.host):\(settings.port), "
+                           + "traffic of \(app.info.bundleIdentifier) will not be captured", isError: true)
+            return false
+        }
+
+        lock.lock()
+        capturingApps.insert(app.info.bundleIdentifier)
+        lock.unlock()
+
+        guard settings.setSystemProxy else { return true }
+
+        // The first app to ask for the system proxy is the one that owns the backup,
+        // which is not necessarily the first app being captured
+        let hasBackup = FileManager.default.fileExists(atPath: NetworkCaptureService.backupURL.path)
+
+        do {
+            if !hasBackup {
+                try backupSystemProxy()
+            }
+            try applySystemProxy(host: settings.host, port: settings.port, bypass: settings.bypassList)
+        } catch {
+            lock.lock()
+            capturingApps.remove(app.info.bundleIdentifier)
+            let isEmpty = capturingApps.isEmpty
+            lock.unlock()
+
+            // Only throw away a backup this call is responsible for, and only when
+            // there is no other app left that would need it
+            if !hasBackup && isEmpty {
+                try? FileManager.default.removeItem(at: NetworkCaptureService.backupURL)
+            }
+
+            Log.shared.error(error)
+            return false
+        }
+
+        return true
+    }
+
+    /// Ends `app`'s session, restoring the previous proxy configuration once the last
+    /// captured app has quit.
+    func endCapture(for app: PlayApp) {
+        lock.lock()
+        capturingApps.remove(app.info.bundleIdentifier)
+        let isLastSession = capturingApps.isEmpty
+        lock.unlock()
+
+        guard isLastSession else { return }
+
+        do {
+            try restoreSystemProxy()
+        } catch {
+            Log.shared.error(error)
+        }
+    }
+
+    /// Drops every session, e.g. when PlayCover itself is quitting.
+    func endAllCaptures() {
+        lock.lock()
+        let wasCapturing = !capturingApps.isEmpty
+        capturingApps.removeAll()
+        lock.unlock()
+
+        guard wasCapturing else { return }
+
+        do {
+            try restoreSystemProxy()
+        } catch {
+            Log.shared.error(error)
+        }
+    }
+
+    /// Puts back a configuration left behind by a PlayCover that did not exit cleanly.
+    /// Called on startup, before any app can have a session of its own.
+    func restoreStaleSystemProxy() {
+        guard FileManager.default.fileExists(atPath: NetworkCaptureService.backupURL.path) else { return }
+
+        do {
+            try restoreSystemProxy()
+            Log.shared.log("Restored the network proxy settings left behind by a previous session")
+        } catch {
+            Log.shared.error(error)
+        }
+    }
+
+    /// Adds a proxy tool's root certificate to the System keychain and marks it as a
+    /// trusted root, so HTTPS decrypted by that proxy is accepted. Works with any tool's
+    /// CA (Reqable, Proxyman, Charles, mitmproxy, …). Needs an administrator, so macOS
+    /// puts up a password prompt. Must be called from the main thread.
+    func trustCertificate(at certificate: URL) throws {
+        try Shell.runAsAdmin("/usr/bin/security add-trusted-cert -d -r trustRoot "
+                             + "-k /Library/Keychains/System.keychain \(certificate.esc)")
+    }
+
+    /// Variables for stacks that do their own networking instead of using CFNetwork.
+    func proxyEnvironment(_ settings: NetworkCaptureSettings) -> [String: String] {
+        let proxy = "http://\(settings.host):\(settings.port)"
+        var environment = [
+            "http_proxy": proxy,
+            "HTTP_PROXY": proxy,
+            "https_proxy": proxy,
+            "HTTPS_PROXY": proxy,
+            "all_proxy": proxy,
+            "ALL_PROXY": proxy
+        ]
+
+        if !settings.bypassList.isEmpty {
+            let bypass = settings.bypassList.joined(separator: ",")
+            environment["no_proxy"] = bypass
+            environment["NO_PROXY"] = bypass
+        }
+
+        return environment
+    }
+}
+
+// MARK: - macOS proxy configuration
+
+extension NetworkCaptureService {
+    /// Stores the current configuration so it can be put back later.
+    private func backupSystemProxy() throws {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+        try encoder.encode(try SystemProxy.read()).write(to: NetworkCaptureService.backupURL, options: .atomic)
+    }
+
+    private func applySystemProxy(host: String, port: Int, bypass: [String]) throws {
+        try SystemProxy.apply(host: host, port: port, bypass: bypass)
+    }
+
+    /// Puts the stored configuration back and forgets it. Does nothing when there is
+    /// none, so it is safe to call more often than it is needed.
+    private func restoreSystemProxy() throws {
+        let backupURL = NetworkCaptureService.backupURL
+        guard let data = try? Data(contentsOf: backupURL) else { return }
+
+        let backup = try PropertyListDecoder().decode([SystemProxy.ServiceState].self, from: data)
+
+        defer { try? FileManager.default.removeItem(at: backupURL) }
+        try SystemProxy.restore(backup)
+    }
+}

--- a/PlayCover/Services/SystemProxy.swift
+++ b/PlayCover/Services/SystemProxy.swift
@@ -1,0 +1,154 @@
+//
+//  SystemProxy.swift
+//  PlayCover
+//
+
+import Foundation
+
+/// Reads and writes the macOS network proxy configuration through `networksetup`.
+///
+/// This is the configuration CFNetwork follows, so it is what decides where the traffic
+/// of an app launched by PlayCover ends up.
+enum SystemProxy {
+    private static let networksetup = "/usr/sbin/networksetup"
+
+    /// One of the two proxies (HTTP or HTTPS) of a network service.
+    private struct ProxyState {
+        var enabled = false
+        var server = ""
+        var port = 0
+    }
+
+    /// The proxy configuration of a single network service.
+    struct ServiceState: Codable {
+        let service: String
+        let webEnabled: Bool
+        let webServer: String
+        let webPort: Int
+        let secureEnabled: Bool
+        let secureServer: String
+        let securePort: Int
+        let bypassDomains: [String]
+    }
+
+    /// Every enabled network service. Disabled ones are prefixed with an asterisk and
+    /// cannot carry a proxy configuration.
+    static func networkServices() throws -> [String] {
+        try Shell.run(print: false, networksetup, arguments: ["-listallnetworkservices"])
+            .split(whereSeparator: \.isNewline)
+            .dropFirst() // an explanatory line about the asterisk
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !$0.hasPrefix("*") }
+    }
+
+    /// The current configuration of every network service.
+    static func read() throws -> [ServiceState] {
+        try networkServices().map { service in
+            let web = try read(service: service, secure: false)
+            let secure = try read(service: service, secure: true)
+
+            return ServiceState(service: service,
+                                webEnabled: web.enabled,
+                                webServer: web.server,
+                                webPort: web.port,
+                                secureEnabled: secure.enabled,
+                                secureServer: secure.server,
+                                securePort: secure.port,
+                                bypassDomains: try readBypassDomains(service: service))
+        }
+    }
+
+    /// Points every network service at the given proxy, for HTTP as well as HTTPS.
+    static func apply(host: String, port: Int, bypass: [String]) throws {
+        for service in try networkServices() {
+            try Shell.run(print: false, networksetup,
+                          arguments: ["-setwebproxy", service, host, String(port)])
+            try Shell.run(print: false, networksetup,
+                          arguments: ["-setsecurewebproxy", service, host, String(port)])
+            try Shell.run(print: false, networksetup,
+                          arguments: ["-setwebproxystate", service, "on"])
+            try Shell.run(print: false, networksetup,
+                          arguments: ["-setsecurewebproxystate", service, "on"])
+
+            if !bypass.isEmpty {
+                try Shell.run(print: false, networksetup,
+                              arguments: ["-setproxybypassdomains", service] + bypass)
+            }
+        }
+    }
+
+    /// Writes previously read state back. Every service is attempted, so one that has
+    /// gone away in the meantime cannot leave the others pointed at the proxy.
+    static func restore(_ states: [ServiceState]) throws {
+        var failure: Error?
+
+        for state in states {
+            do {
+                try restore(state)
+            } catch {
+                failure = error
+            }
+        }
+
+        if let failure = failure {
+            throw failure
+        }
+    }
+
+    private static func restore(_ state: ServiceState) throws {
+        // Setting a server also switches the proxy on, so the state is set afterwards
+        if !state.webServer.isEmpty {
+            try Shell.run(print: false, networksetup,
+                          arguments: ["-setwebproxy", state.service, state.webServer, String(state.webPort)])
+        }
+        try Shell.run(print: false, networksetup,
+                      arguments: ["-setwebproxystate", state.service, state.webEnabled ? "on" : "off"])
+
+        if !state.secureServer.isEmpty {
+            try Shell.run(print: false, networksetup,
+                          arguments: ["-setsecurewebproxy", state.service,
+                                      state.secureServer, String(state.securePort)])
+        }
+        try Shell.run(print: false, networksetup,
+                      arguments: ["-setsecurewebproxystate", state.service, state.secureEnabled ? "on" : "off"])
+
+        // "Empty" is how networksetup is told to clear the list. Passing an empty
+        // string instead leaves a blank entry behind
+        try Shell.run(print: false, networksetup,
+                      arguments: ["-setproxybypassdomains", state.service]
+                                 + (state.bypassDomains.isEmpty ? ["Empty"] : state.bypassDomains))
+    }
+
+    /// Parses the `Enabled: / Server: / Port:` block printed by `networksetup`.
+    private static func read(service: String, secure: Bool) throws -> ProxyState {
+        let output = try Shell.run(print: false, networksetup,
+                                   arguments: [secure ? "-getsecurewebproxy" : "-getwebproxy", service])
+
+        var state = ProxyState()
+
+        for line in output.split(whereSeparator: \.isNewline) {
+            let parts = line.split(separator: ":", maxSplits: 1).map {
+                $0.trimmingCharacters(in: .whitespaces)
+            }
+            guard parts.count == 2 else { continue }
+
+            switch parts[0] {
+            case "Enabled": state.enabled = parts[1].caseInsensitiveCompare("Yes") == .orderedSame
+            case "Server": state.server = parts[1]
+            case "Port": state.port = Int(parts[1]) ?? 0
+            default: break
+            }
+        }
+
+        return state
+    }
+
+    private static func readBypassDomains(service: String) throws -> [String] {
+        try Shell.run(print: false, networksetup, arguments: ["-getproxybypassdomains", service])
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            // With nothing set, networksetup prints a localized sentence rather than an
+            // empty list. Hostnames never contain spaces, so that is enough to tell apart
+            .filter { !$0.isEmpty && !$0.contains(" ") }
+    }
+}

--- a/PlayCover/Utils/Shell.swift
+++ b/PlayCover/Utils/Shell.swift
@@ -8,11 +8,16 @@ import Foundation
 class Shell: ObservableObject {
     @discardableResult
     static func run(print: Bool = true, _ binary: String, _ args: String...) throws -> String {
+        try run(print: print, binary, arguments: args)
+    }
+
+    @discardableResult
+    static func run(print: Bool = true, _ binary: String, arguments: [String]) throws -> String {
         let process = Process()
         let pipe = Pipe()
 
         process.executableURL = URL(fileURLWithPath: binary)
-        process.arguments = args
+        process.arguments = arguments
         process.standardOutput = pipe
         process.standardError = pipe
 
@@ -70,6 +75,22 @@ class Shell: ObservableObject {
         // Make sure we don't disappear while output is still being produced.
         sudo.waitUntilExit()
         return result
+    }
+
+    /// Runs a command as root, letting macOS ask the user for an administrator password.
+    /// Must be called from the main thread, as it puts up a window.
+    static func runAsAdmin(_ command: String) throws {
+        let escaped = command
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+
+        var possibleError: NSDictionary?
+        NSAppleScript(source: "do shell script \"\(escaped)\" with administrator privileges")?
+            .executeAndReturnError(&possibleError)
+
+        if let error = possibleError {
+            throw error[NSAppleScript.errorMessage] as? String ?? "Shell error occured"
+        }
     }
 
     static func signMacho(_ binary: URL) throws {

--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import DataCache
+import UniformTypeIdentifiers
 
 enum BlockingTask {
     case none, playTools, introspection, iosFrameworks, applicationCategoryType
@@ -94,6 +95,10 @@ struct AppSettingsView: View {
                         Text("settings.tab.bypasses")
                     }
                     .disabled(!(hasPlayTools ?? true))
+                NetworkView(settings: $viewModel.settings)
+                    .tabItem {
+                        Text("settings.tab.network")
+                    }
                 MiscView(settings: $viewModel.settings,
                          closeView: $closeView,
                          hasPlayTools: $hasPlayTools,
@@ -620,6 +625,108 @@ struct BypassesView: View {
                 _ = await app.changeDyldLibraryPath(set: hasIosFrameworks, path: PlayApp.iosFrameworks)
                 task = .none
             }
+        }
+    }
+}
+
+/// Network capture settings: route the app's traffic through a debugging proxy, on this
+/// Mac or a remote machine. Works with any proxy tool (Reqable, Proxyman, Charles,
+/// mitmproxy, …); trusting its certificate is done in that tool, not here.
+struct NetworkView: View {
+    @Binding var settings: AppSettings
+
+    @State private var isTrustingCertificate = false
+
+    static var portFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .none
+        formatter.usesGroupingSeparator = false
+        formatter.minimum = 1
+        formatter.maximum = 65535
+        return formatter
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Toggle("settings.netCapture.enable", isOn: $settings.settings.networkCapture.enable)
+                    .help("settings.netCapture.enable.help")
+
+                HStack {
+                    Text("settings.netCapture.address")
+                    TextField("", text: $settings.settings.networkCapture.host)
+                        .frame(width: 160)
+                    Text(":")
+                    TextField("", value: $settings.settings.networkCapture.port,
+                              formatter: NetworkView.portFormatter)
+                        .frame(width: 70)
+                    Spacer()
+                }
+                .help("settings.netCapture.address.help")
+
+                Toggle("settings.netCapture.systemProxy", isOn: $settings.settings.networkCapture.setSystemProxy)
+                    .help("settings.netCapture.systemProxy.help")
+
+                Toggle("settings.netCapture.environment",
+                       isOn: $settings.settings.networkCapture.setEnvironmentVariables)
+                    .help("settings.netCapture.environment.help")
+
+                HStack {
+                    Text("settings.netCapture.bypass")
+                    TextField("settings.netCapture.bypass.placeholder",
+                              text: $settings.settings.networkCapture.bypassDomains)
+                }
+                .help("settings.netCapture.bypass.help")
+
+                Divider()
+
+                HStack {
+                    Button("settings.netCapture.trustCert") {
+                        chooseAndTrustCertificate()
+                    }
+                    .disabled(isTrustingCertificate)
+                    .overlay {
+                        if isTrustingCertificate {
+                            ProgressView().scaleEffect(0.5)
+                        }
+                    }
+                    Spacer()
+                }
+                .help("settings.netCapture.trustCert.help")
+
+                Text("settings.netCapture.note")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer()
+            }
+            .padding()
+        }
+    }
+
+    /// Lets the user pick their proxy tool's root certificate and trust it on this Mac.
+    private func chooseAndTrustCertificate() {
+        let panel = NSOpenPanel()
+        panel.title = NSLocalizedString("settings.netCapture.trustCert", comment: "")
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.allowedContentTypes = [.x509Certificate, .data]
+        panel.allowsOtherFileTypes = true
+
+        guard panel.runModal() == .OK, let certificate = panel.url else { return }
+
+        isTrustingCertificate = true
+        Task { @MainActor in
+            do {
+                try NetworkCaptureService.shared.trustCertificate(at: certificate)
+                ToastVM.shared.showToast(
+                    toastType: .notice,
+                    toastDetails: NSLocalizedString("settings.netCapture.certTrusted", comment: ""))
+            } catch {
+                Log.shared.error(error)
+            }
+            isTrustingCertificate = false
         }
     }
 }

--- a/PlayCover/Views/PlayCoverApp.swift
+++ b/PlayCover/Views/PlayCoverApp.swift
@@ -17,6 +17,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         UpdateScheme.checkForUpdate()
 
+        // A previous session may have been killed while an app was being captured,
+        // leaving the network proxy pointed at the capture proxy
+        NetworkCaptureService.shared.restoreStaleSystemProxy()
+
         UserDefaults.standard.register(
             defaults: ["NSApplicationCrashOnExceptions": true]
         )
@@ -44,6 +48,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return true
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        // Never leave the network proxy pointed at the capture proxy after PlayCover is gone
+        NetworkCaptureService.shared.endAllCaptures()
     }
 
     @objc func powerStateChanged(_ notification: Notification) {

--- a/PlayCover/Views/ToastView.swift
+++ b/PlayCover/Views/ToastView.swift
@@ -42,8 +42,13 @@ struct ToastView: View {
                     .onAppear {
                         Task { @MainActor in
                             try await Task.sleep(nanoseconds: toast.timeRemaining * 1000000000)
-                            // Next toast to be removed will always be the first in the list
-                            toastVM.toasts.removeFirst()
+                            // Next toast to be removed will always be the first in the list.
+                            // Guard against an empty list: overlapping toasts, or a
+                            // re-run of onAppear, can fire more removals than there are
+                            // toasts, and removeFirst() traps on an empty array.
+                            if !toastVM.toasts.isEmpty {
+                                toastVM.toasts.removeFirst()
+                            }
                         }
                     }
                 }

--- a/PlayCover/en.lproj/Localizable.strings
+++ b/PlayCover/en.lproj/Localizable.strings
@@ -204,6 +204,23 @@
 "settings.toggle.checkMicPermissionSync" = "Check Microphone Permission Synchronously";
 "settings.toggle.checkMicPermissionSync.help" = "Force microphone permission check to be synchronous. Known to fix issues with some apps complaining about microphone permission not being granted";
 
+"settings.tab.network" = "Network";
+"settings.netCapture.enable" = "Capture network traffic through a proxy";
+"settings.netCapture.enable.help" = "Route this app's traffic through a debugging proxy while it runs, the same way a phone is pointed at one, so its requests can be inspected";
+"settings.netCapture.address" = "Proxy address";
+"settings.netCapture.address.help" = "Host and port the proxy is listening on. Use 127.0.0.1 for a proxy on this Mac, or the LAN / remote address of the machine running it (for remote debugging). Works with Reqable, Proxyman, Charles, mitmproxy and others";
+"settings.netCapture.systemProxy" = "Set the macOS network proxy while the app runs";
+"settings.netCapture.systemProxy.help" = "iOS apps read their proxy from the macOS network settings, so this is what actually routes their traffic. The previous settings are put back when the app quits. Other apps on this Mac are proxied too while it is running";
+"settings.netCapture.environment" = "Pass proxy environment variables to the app";
+"settings.netCapture.environment.help" = "Sets http_proxy and friends for the app. Ignored by CFNetwork, but read by engines that bring their own networking stack, such as Unity, cURL and gRPC";
+"settings.netCapture.bypass" = "Do not capture";
+"settings.netCapture.bypass.placeholder" = "*.apple.com, localhost";
+"settings.netCapture.bypass.help" = "Comma separated hosts that stay off the proxy";
+"settings.netCapture.trustCert" = "Trust proxy certificate…";
+"settings.netCapture.trustCert.help" = "Choose your proxy tool's root certificate (Reqable, Proxyman, Charles, mitmproxy, …) to trust it on this Mac, so HTTPS can be decrypted. Requires an administrator password";
+"settings.netCapture.certTrusted" = "Certificate added to the System keychain and trusted";
+"settings.netCapture.note" = "To decrypt HTTPS, trust your proxy tool's root certificate on this Mac. Apps that pin their certificates, and connections that do not go through CFNetwork, are not captured.";
+
 "settings.applicationCategoryType" = "Application Type";
 "settings.removePlayTools" = "Remove PlayTools";
 


### PR DESCRIPTION
Add a "Network" tab in per-app settings that routes a launched app's traffic through a debugging proxy (Reqable, Proxyman, Charles, mitmproxy, or a remote proxy), the same way a phone is pointed at one.

iOS apps run under PlayCover use CFNetwork, which reads its proxy from the macOS network settings rather than the process environment, so capture works by pointing the system proxy at the configured host:port for the lifetime of the app and restoring the previous settings on quit. A backup plist survives an unclean exit and is restored on next launch. Optional proxy environment variables cover engines with their own networking stack (Unity, cURL, gRPC). A host field means the proxy may be local or remote.

A "Trust proxy certificate…" action adds any tool's root CA to the System keychain so HTTPS can be decrypted.

- Model/NetworkCaptureSettings.swift: per-app settings (leniently decoded, migrates the previous key)
- Services/NetworkCaptureService.swift: reachability probe and ref-counted capture sessions
- Services/SystemProxy.swift: read/apply/restore the macOS proxy via networksetup
- Utils/Shell.swift: array-argument run() and runAsAdmin()
- integrate into PlayApp launch and the app lifecycle

Also fix a pre-existing crash in ToastView where removeFirst() could trap on an empty toast list when timers outnumbered visible toasts.