### PR TITLE
fix: write a real Info.plist into the launch alias (macOS 27 -54 permErr)

### DIFF
--- a/PlayCover/Utils/Extensions/PlayAppExtensions.swift
+++ b/PlayCover/Utils/Extensions/PlayAppExtensions.swift
@@ -57,9 +57,18 @@ extension PlayApp {
                                                     withIntermediateDirectories: true,
                                                     attributes: nil)
             url.enumerateContents(options: [.skipsSubdirectoryDescendants]) { ctxUrl, _ in
-                try FileManager.default.createSymbolicLink(
-                    at: self.aliasURL.appendingPathComponent(ctxUrl.lastPathComponent),
-                    withDestinationURL: ctxUrl)
+                let aliasItem = self.aliasURL.appendingPathComponent(ctxUrl.lastPathComponent)
+
+                // LaunchServices on macOS 27 will not open the alias while Info.plist is a
+                // symlink: it fails with -54 (permErr) and the user sees "does not have
+                // permission to open (null)". A real copy is enough, and it stays current
+                // because the alias is rebuilt on every PlayApp init.
+                if ctxUrl.lastPathComponent == "Info.plist" {
+                    try FileManager.default.copyItem(at: ctxUrl, to: aliasItem)
+                } else {
+                    try FileManager.default.createSymbolicLink(at: aliasItem,
+                                                               withDestinationURL: ctxUrl)
+                }
             }
         } catch {
             Log.shared.log(error.localizedDescription)


### PR DESCRIPTION
Fixes #2184.

### Problem

On macOS 27, clicking the launch button shows *"The application 'PlayCover' does not have permission to open '(null)'"* and the app never starts. Double-clicking the alias in `~/Applications/PlayCover/` from Finder fails the same way.

`runAppExec()` opens `aliasURL` — `~/Applications/PlayCover/<Name>.app` — which `createAlias()` builds as a directory populated with one symlink per top-level item of the real bundle. LaunchServices on macOS 27 refuses to open that: `"(null)"` is it failing to resolve an app identity for the path.

The symlinked `Info.plist` is what it rejects.

### Change

Copy `Info.plist` into the alias as a real file and leave every other item a symlink.

This keeps the alias directory itself as the launched bundle, which matters: it is what makes the Dock, the app switcher and Force Quit show the app's PlayCover name. Replacing the whole alias with a single symlink to the bundle also fixes the launch, but the name then degrades to the bundle identifier (`com.example.game` instead of the display name), so this patch keeps the existing alias shape.

The copy cannot go stale — `PlayApp.init` calls `removeAlias()` then `createAlias()`, so the alias is rebuilt from the current bundle on every launch.

### Evidence

macOS 27.0 (26A5406e), same app, three alias shapes in `~/Applications/`:

```
# every item symlinked — current behaviour
$ open ~/Applications/PlayCover/<Name>.app
_LSOpenURLsWithCompletionHandler() failed with error -54

# Info.plist copied, everything else symlinked — this patch
$ open ~/Applications/Test/<Name>.app
$ echo $?
0                       # LaunchServices reports the app as "<Name>"

# one symlink to the whole bundle
$ open ~/Applications/Test2/<Name>.app
$ echo $?
0                       # but LaunchServices reports it as "com.example.game"
```

`-54` is what surfaces as the alert. From the GUI launch button on nightly 1571:

```
CoreServicesUIAgent  [com.apple.launchservices:default] LAUNCH: Launch failed in CSUI with error
Error Domain=NSOSStatusErrorDomain Code=-54 "permErr: permissions error (on file open)"
UserInfo={_LSLine=4288, _LSFunction=_LSOpenStuffCallLocal, _LSFile=LSOpenCore.mm, _LSErrorMessage=permErr}
```

### Verification

Built this branch (`xcodebuild -scheme PlayCover -configuration Release`, Xcode 27.0/27A5228h) and ran it on macOS 27.0:

- the four existing aliases were rebuilt on first launch, each with a real `Info.plist`;
- the launch button starts apps again — no `permErr` in the log;
- `lsappinfo` reports each launched app under its PlayCover name.
