### PR TITLE
chore: add M5 iPad Pro and iPhone 17 Pro Max

### DIFF
--- a/PlayCover/Views/AppSettingsView.swift
+++ b/PlayCover/Views/AppSettingsView.swift
@@ -226,11 +226,13 @@ struct GraphicsView: View {
                         Text("iPad Pro (12.9-inch) (5th gen) | M1 | 8GB").tag("iPad13,8")
                         Text("iPad Pro (12.9-inch) (6th gen) | M2 | 8GB").tag("iPad14,5")
                         Text("iPad Pro (13-inch) (7th gen) | M4 | 8GB").tag("iPad16,6")
+                        Text("iPad Pro (13-inch) (M5) | M5 | 16GB").tag("iPad17,3")
                         Divider()
                         Text("iPhone 13 Pro Max | A15 | 6GB").tag("iPhone14,3")
                         Text("iPhone 14 Pro Max | A16 | 6GB").tag("iPhone15,3")
                         Text("iPhone 15 Pro Max | A17 Pro | 8GB").tag("iPhone16,2")
                         Text("iPhone 16 Pro Max | A18 Pro | 8GB").tag("iPhone17,2")
+                        Text("iPhone 17 Pro Max | A19 Pro | 12GB").tag("iPhone18,2")
                     }
                     .frame(width: 250)
                 }


### PR DESCRIPTION
Make M5 iPad Pro and iPhone 17 Pro Max available, referenced #2063, co-authored with @yuemingruoan.