### PR TITLE
perf: stabilize app library refresh

### DIFF
--- a/PlayCover/ViewModel/AppsVM.swift
+++ b/PlayCover/ViewModel/AppsVM.swift
@@ -5,10 +5,80 @@
 
 import Foundation
 
-class AppsVM: ObservableObject {
+private struct AppLibraryEntry: Sendable {
+    let url: URL
+    let bundleIdentifier: String
+    let displayName: String
+    let searchText: String
+    let signature: String
 
+    var identityKey: String {
+        bundleIdentifier + "\0" + url.standardizedFileURL.path
+    }
+}
+
+private enum AppLibraryScanner {
+    static func scan(at directory: URL) throws -> [AppLibraryEntry] {
+        let urls = try FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+
+        return urls.compactMap(makeEntry(from:)).sorted { lhs, rhs in
+            let order = lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
+            return order == .orderedSame ? lhs.url.path < rhs.url.path : order == .orderedAscending
+        }
+    }
+
+    private static func makeEntry(from url: URL) -> AppLibraryEntry? {
+        guard url.pathExtension.lowercased() == "app",
+              (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else {
+            return nil
+        }
+        let infoURL = url.appendingPathComponent("Info.plist")
+        guard let data = try? Data(contentsOf: infoURL),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+              let values = plist as? [String: Any],
+              let bundleIdentifier = values["CFBundleIdentifier"] as? String,
+              !bundleIdentifier.isEmpty else {
+            return nil
+        }
+        let bundleName = values["CFBundleName"] as? String ?? ""
+        let rawDisplayName = values["CFBundleDisplayName"] as? String ?? bundleName
+        let displayName = rawDisplayName.isEmpty ? bundleIdentifier : rawDisplayName
+        let resourceValues = try? infoURL.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+        let modified = resourceValues?.contentModificationDate?.timeIntervalSince1970 ?? 0
+        let fileSize = resourceValues?.fileSize ?? data.count
+        let signature = "\(bundleIdentifier)|\(fileSize)|\(modified)"
+        return AppLibraryEntry(
+            url: url,
+            bundleIdentifier: bundleIdentifier,
+            displayName: displayName,
+            searchText: "\(displayName) \(bundleName) \(bundleIdentifier)".lowercased(),
+            signature: signature
+        )
+    }
+}
+
+private enum BundleIDCacheStore {
+    static func reconcile(at url: URL, discovered: [String]) {
+        let existing = (try? String(contentsOf: url, encoding: .utf8))?
+            .split(whereSeparator: \.isNewline)
+            .map(String.init) ?? []
+        var seen = Set<String>()
+        let merged = (existing + discovered).filter { !$0.isEmpty && seen.insert($0).inserted }
+        let serialized = merged.map { $0 + "\n" }.joined()
+        do {
+            try serialized.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            Log.shared.error(error)
+        }
+    }
+}
+
+final class AppsVM: ObservableObject {
     public static let appDirectory = PlayTools.playCoverContainer.appendingPathComponent("Applications")
-
     static let shared = AppsVM()
 
     private init() {
@@ -18,71 +88,68 @@ class AppsVM: ObservableObject {
     }
 
     static func ensureBaseDirectoriesExist() throws {
-        try FileManager.default.createDirectory(
-            at: appDirectory,
-            withIntermediateDirectories: true
-        )
+        try FileManager.default.createDirectory(at: appDirectory, withIntermediateDirectories: true)
     }
 
     @Published var filteredApps: [PlayApp] = []
     @Published var apps: [PlayApp] = []
     @Published var searchText: String = ""
     @Published var updatingApps = true
+    private var fetchTask: Task<Void, Never>?
+    private var appEntrySignatures: [String: String] = [:]
 
     func fetchApps() {
-        Task { @MainActor in
-            updatingApps = true
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.fetchTask?.cancel()
+            self.updatingApps = true
 
-            filteredApps.removeAll()
-            apps.removeAll()
+            self.fetchTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                let entries: [AppLibraryEntry]
+                do {
+                    entries = try await Task.detached(priority: .userInitiated) {
+                        try AppLibraryScanner.scan(at: AppsVM.appDirectory)
+                    }.value
+                } catch {
+                    if !Task.isCancelled { Log.shared.error(error) }
+                    if !Task.isCancelled { self.updatingApps = false }
+                    return
+                }
+                guard !Task.isCancelled else { return }
 
-            do {
-                let directoryContents = try FileManager.default
-                    .contentsOfDirectory(at: AppsVM.appDirectory, includingPropertiesForKeys: nil, options: [])
-
-                let subdirs = directoryContents.filter { $0.hasDirectoryPath }
-
-                for sub in subdirs {
-                    if sub.pathExtension.contains("app") &&
-                        FileManager.default.fileExists(atPath: sub.appendingPathComponent("Info")
-                                                                  .appendingPathExtension("plist")
-                                                                  .path) {
-                        let app = PlayApp(appUrl: sub)
-                        print("Application installed under:", sub.path)
-
-                        apps.append(app)
-                        if searchText.isEmpty || app.searchText.contains(searchText.lowercased()) {
-                            filteredApps.append(app)
-                        }
+                // Preserve PlayApp identity when the installed bundle has not changed. Rebuilding every
+                // PlayApp on fetch leaves open settings sheets holding stale AppSettings objects while
+                // hotkey/runtime code consults the new instances. That can make a setting look unsaved
+                // even though the plist write succeeded. Recreate only when the bundle metadata changes.
+                var existingByKey: [String: PlayApp] = [:]
+                for app in self.apps {
+                    let key = app.info.bundleIdentifier + "\0" + app.url.standardizedFileURL.path
+                    existingByKey[key] = app
+                }
+                var nextSignatures: [String: String] = [:]
+                let loadedApps = entries.map { entry -> PlayApp in
+                    nextSignatures[entry.identityKey] = entry.signature
+                    if let existing = existingByKey[entry.identityKey],
+                       self.appEntrySignatures[entry.identityKey] == entry.signature {
+                        return existing
                     }
+                    return PlayApp(appUrl: entry.url)
                 }
-            } catch {
-                print(error)
+                self.appEntrySignatures = nextSignatures
+                self.apps = loadedApps
+                let query = self.searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                self.filteredApps = query.isEmpty ? loadedApps : loadedApps.filter { $0.searchText.contains(query) }
+                self.filteredApps.sort {
+                    $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+                }
+                self.updatingApps = false
+
+                let discoveredIDs = entries.map(\.bundleIdentifier)
+                Task.detached(priority: .utility) {
+                    BundleIDCacheStore.reconcile(at: PlayApp.bundleIDCacheURL, discovered: discoveredIDs)
+                }
             }
-
-            filteredApps.sort(by: { $0.name.lowercased() < $1.name.lowercased() })
-
-            do {
-                if !FileManager.default.fileExists(atPath: PlayApp.bundleIDCacheURL.path),
-                   let firstBundleID = apps.first?.info.bundleIdentifier {
-                    try "\(firstBundleID)\n"
-                        .write(to: PlayApp.bundleIDCacheURL, atomically: false, encoding: .utf8)
-                }
-
-                for bundleId in apps.map({ $0.info.bundleIdentifier })
-                    where !(try PlayApp.bundleIDCache).contains(bundleId) {
-                    if let bundleID = "\(bundleId)\n".data(using: .utf8) {
-                        let cacheFile = try FileHandle(forUpdating: PlayApp.bundleIDCacheURL)
-                        try cacheFile.seekToEnd()
-                        try cacheFile.write(contentsOf: bundleID)
-                        try cacheFile.close()
-                    }
-                }
-            } catch {
-                Log.shared.error(error)
-            }
-
-            updatingApps = false
         }
     }
 }


### PR DESCRIPTION
## Summary
- move directory and Info.plist scanning off the main actor
- cancel stale refresh work
- reconcile the bundle-ID cache atomically
- preserve existing PlayApp instances when the installed bundle is unchanged

## Testing
- SwiftLint --strict