### PR TITLE
fix: guarantee IPA temporary-directory cleanup

### DIFF
--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -62,6 +62,7 @@ class Installer {
 
         Task(priority: .userInitiated) {
             let ipa = IPA(url: ipaUrl)
+            defer { ipa.releaseTempDir() }
 
             do {
                 InstallVM.shared.next(.unzip, 0.0, 0.5)
@@ -69,7 +70,6 @@ class Installer {
 
                 let app = try ipa.unzip()
                 if await ipa.checkOfficialMacOS(app: IPA.Application.base(app)) {
-                    ipa.releaseTempDir()
                     InstallVM.shared.next(.failed, 0.95, 1.0)
                     returnCompletion(nil)
                     return
@@ -122,14 +122,11 @@ class Installer {
                     installedApp.sign()
                 }
 
-                ipa.releaseTempDir()
                 try ipa.removeQuarantine(finalURL)
                 InstallVM.shared.next(.finish, 0.95, 1.0)
                 returnCompletion(finalURL)
             } catch {
                 Log.shared.error(returnErrorString(error: error))
-                ipa.releaseTempDir()
-
                 InstallVM.shared.next(.failed, 0.95, 1.0)
                 returnCompletion(nil)
             }


### PR DESCRIPTION
## Summary
Use `defer` for IPA temporary-directory cleanup so success, early-return, and error paths all release installer scratch data.

## Testing
- SwiftLint --strict