### PR TITLE
perf: move app icon extraction off the main actor

### DIFF
--- a/PlayCover/Utils/Cacher.swift
+++ b/PlayCover/Utils/Cacher.swift
@@ -39,26 +39,58 @@ class Cacher {
     }
 
     func resolveLocalIcon(_ app: PlayApp) -> NSImage? {
-        var bestResImage: NSImage?
-        let compareStr = app.info.bundleIdentifier + app.info.bundleVersion
+        resolveLocalIcon(
+            at: app.url,
+            bundleIdentifier: app.info.bundleIdentifier,
+            bundleVersion: app.info.bundleVersion,
+            primaryIconName: app.info.primaryIconName
+        )
+    }
 
-        app.url.enumerateContents(blocking: false) { file, _ in
-            if file.lastPathComponent.contains(app.info.primaryIconName), let icon = NSImage(contentsOf: file),
-               self.checkImageDimensions(icon, bestResImage) {
-                bestResImage = icon
-            }
+    func resolveLocalIcon(
+        at url: URL,
+        bundleIdentifier: String,
+        bundleVersion: String,
+        primaryIconName: String
+    ) -> NSImage? {
+        let compareStr = bundleIdentifier + bundleVersion
+        if cache.readString(forKey: compareStr) != nil,
+           let cachedImage = cache.readImage(forKey: bundleIdentifier) {
+            return cachedImage
         }
 
-        if let assetsExtractor = try? AssetsExtractor(appUrl: app.url) {
-            for icon in assetsExtractor.extractIcons() where checkImageDimensions(icon, bestResImage) {
-                bestResImage = icon
+        let lock = NSLock()
+        var candidates: [NSImage] = []
+        url.enumerateContents(blocking: true) { file, _ in
+            guard file.lastPathComponent.contains(primaryIconName), let icon = NSImage(contentsOf: file) else {
+                return
             }
+            lock.lock()
+            candidates.append(icon)
+            lock.unlock()
         }
+
+        if let assetsExtractor = try? AssetsExtractor(appUrl: url) {
+            candidates.append(contentsOf: assetsExtractor.extractIcons())
+        }
+        let bestResImage = candidates.max { $0.size.height < $1.size.height }
         cache.write(string: compareStr, forKey: compareStr)
-        if let image = bestResImage {
-            cache.write(image: image, forKey: app.info.bundleIdentifier)
-        }
-        return cache.readImage(forKey: app.info.bundleIdentifier)
+        if let image = bestResImage { cache.write(image: image, forKey: bundleIdentifier) }
+        return cache.readImage(forKey: bundleIdentifier)
+    }
+
+    func resolveLocalIconData(
+        at url: URL,
+        bundleIdentifier: String,
+        bundleVersion: String,
+        primaryIconName: String
+    ) -> Data? {
+        resolveLocalIcon(
+            at: url,
+            bundleIdentifier: bundleIdentifier,
+            bundleVersion: bundleVersion,
+            primaryIconName: primaryIconName
+        )?.tiffRepresentation
     }
 
     func getLocalIcon(bundleId: String) -> NSImage? {
@@ -69,9 +101,6 @@ class Cacher {
         }
     }
 
-    private func checkImageDimensions(_ new: NSImage, _ currentBest: NSImage?) -> Bool {
-        return new.size.height > currentBest?.size.height ?? -1
-    }
 }
 
 extension URLCache {

--- a/PlayCover/Views/App Views/PlayAppView.swift
+++ b/PlayCover/Views/App Views/PlayAppView.swift
@@ -4,7 +4,6 @@
 //
 
 import SwiftUI
-import DataCache
 
 struct PlayAppView: View {
 
@@ -125,8 +124,6 @@ struct PlayAppConditionalView: View {
     @State var isList: Bool
     @State var hasPlayTools: Bool?
 
-    @State private var cache = DataCache.instance
-
     var body: some View {
         Group {
             if isList {
@@ -228,13 +225,19 @@ struct PlayAppConditionalView: View {
             }
         }
         .task(priority: .userInitiated) {
-            let compareStr = app.info.bundleIdentifier + app.info.bundleVersion
-            if cache.readImage(forKey: app.info.bundleIdentifier) != nil
-                && cache.readString(forKey: compareStr) != nil {
-                appIcon = cache.readImage(forKey: app.info.bundleIdentifier)
-            } else {
-                appIcon = Cacher.shared.resolveLocalIcon(app)
-            }
+            let appURL = app.url
+            let bundleIdentifier = app.info.bundleIdentifier
+            let bundleVersion = app.info.bundleVersion
+            let primaryIconName = app.info.primaryIconName
+            let iconData = await Task.detached(priority: .utility) {
+                Cacher.shared.resolveLocalIconData(
+                    at: appURL,
+                    bundleIdentifier: bundleIdentifier,
+                    bundleVersion: bundleVersion,
+                    primaryIconName: primaryIconName
+                )
+            }.value
+            appIcon = iconData.flatMap(NSImage.init(data:))
         }
         .task(priority: .background) {
             hasPlayTools = app.hasPlayTools()


### PR DESCRIPTION
## Summary
- use the icon cache before rescanning application resources
- perform icon extraction on a utility task
- pass TIFF data across the task boundary instead of NSImage

## Testing
- SwiftLint --strict